### PR TITLE
Update to Java 17

### DIFF
--- a/nb-configuration.xml
+++ b/nb-configuration.xml
@@ -13,7 +13,7 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
         <netbeans.compile.on.save>none</netbeans.compile.on.save>
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>
         <org-netbeans-modules-javascript2-requirejs.enabled>true</org-netbeans-modules-javascript2-requirejs.enabled>

--- a/nostr-base/nb-configuration.xml
+++ b/nostr-base/nb-configuration.xml
@@ -13,7 +13,7 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
         <netbeans.hint.license>mit</netbeans.hint.license>
     </properties>
 </project-shared-configuration>

--- a/nostr-crypto/nb-configuration.xml
+++ b/nostr-crypto/nb-configuration.xml
@@ -13,7 +13,7 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
         <netbeans.hint.license>mit</netbeans.hint.license>
         <netbeans.compile.on.save>none</netbeans.compile.on.save>
     </properties>

--- a/nostr-crypto/pom.xml
+++ b/nostr-crypto/pom.xml
@@ -8,10 +8,6 @@
     </parent>
     <artifactId>nostr-schnorr</artifactId>
     <packaging>jar</packaging>
-    <properties>
-        <maven.compiler.source>15</maven.compiler.source>
-        <maven.compiler.target>15</maven.compiler.target>
-    </properties>
     <name>nostr-crypto</name>
     <description>A simple Java implementation (no external libs) of Sipa's Python reference implementation test vectors for BIP340 Schnorr signatures for secp256k1. Inspired/Copied from: https://code.samourai.io/samouraidev/BIP340_Schnorr and https://github.com/unclebob/more-speech/tree/bdd2f32b37264f20bf6abb4887489e70d2b0fdf1</description>
     <dependencies>

--- a/nostr-event/nb-configuration.xml
+++ b/nostr-event/nb-configuration.xml
@@ -13,7 +13,7 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
         <netbeans.hint.license>mit</netbeans.hint.license>
         <netbeans.compile.on.save>none</netbeans.compile.on.save>
     </properties>

--- a/nostr-event/pom.xml
+++ b/nostr-event/pom.xml
@@ -8,10 +8,6 @@
     </parent>
     <artifactId>nostr-event</artifactId>
     <packaging>jar</packaging>
-    <properties>
-        <maven.compiler.source>15</maven.compiler.source>
-        <maven.compiler.target>15</maven.compiler.target>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/nostr-examples/nb-configuration.xml
+++ b/nostr-examples/nb-configuration.xml
@@ -13,7 +13,7 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
         <netbeans.hint.license>mit</netbeans.hint.license>
     </properties>
 </project-shared-configuration>

--- a/nostr-examples/pom.xml
+++ b/nostr-examples/pom.xml
@@ -48,7 +48,5 @@
     </dependencies>
     <properties>
         <exec.mainClass>com.tcheeric.nostr.examples.NostrExamples</exec.mainClass>
-        <maven.compiler.source>15</maven.compiler.source>
-        <maven.compiler.target>15</maven.compiler.target>
     </properties>
 </project>

--- a/nostr-examples/pom.xml
+++ b/nostr-examples/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>nostr-controller</artifactId>
+            <artifactId>nostr-ws</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/nostr-id/nb-configuration.xml
+++ b/nostr-id/nb-configuration.xml
@@ -13,7 +13,7 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
         <netbeans.compile.on.save>none</netbeans.compile.on.save>
         <netbeans.hint.license>mit</netbeans.hint.license>
     </properties>

--- a/nostr-id/pom.xml
+++ b/nostr-id/pom.xml
@@ -58,7 +58,5 @@
     </dependencies>
     <properties>
         <exec.mainClass>com.tcheeric.nostr.id.NostrId</exec.mainClass>
-        <maven.compiler.source>15</maven.compiler.source>
-        <maven.compiler.target>15</maven.compiler.target>
     </properties>
 </project>

--- a/nostr-json/nb-configuration.xml
+++ b/nostr-json/nb-configuration.xml
@@ -13,7 +13,7 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
         <netbeans.hint.license>mit</netbeans.hint.license>
     </properties>
 </project-shared-configuration>

--- a/nostr-test/nb-configuration.xml
+++ b/nostr-test/nb-configuration.xml
@@ -13,7 +13,7 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
         <netbeans.compile.on.save>all</netbeans.compile.on.save>
         <netbeans.hint.license>mit</netbeans.hint.license>
     </properties>

--- a/nostr-test/pom.xml
+++ b/nostr-test/pom.xml
@@ -57,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>nostr-controller</artifactId>
+            <artifactId>nostr-ws</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/nostr-types/nb-configuration.xml
+++ b/nostr-types/nb-configuration.xml
@@ -13,6 +13,6 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
     </properties>
 </project-shared-configuration>

--- a/nostr-util/nb-configuration.xml
+++ b/nostr-util/nb-configuration.xml
@@ -13,6 +13,6 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
     </properties>
 </project-shared-configuration>

--- a/nostr-ws/nb-configuration.xml
+++ b/nostr-ws/nb-configuration.xml
@@ -13,7 +13,7 @@ You can copy and paste the single properties, into the pom.xml file and the IDE 
 That way multiple projects can share the same settings (useful for formatting rules for example).
 Any value defined here will override the pom.xml file value but is only applicable to the current project.
 -->
-        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+        <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
         <netbeans.hint.license>mit</netbeans.hint.license>
         <netbeans.compile.on.save>all</netbeans.compile.on.save>
     </properties>

--- a/nostr-ws/pom.xml
+++ b/nostr-ws/pom.xml
@@ -63,8 +63,4 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-    <properties>
-        <maven.compiler.source>15</maven.compiler.source>
-        <maven.compiler.target>15</maven.compiler.target>
-    </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     </modules>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>15</maven.compiler.source>
-        <maven.compiler.target>15</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 </project>


### PR DESCRIPTION
Java 15 is non-LTS and has been superseded, with 17 being the latest LTS.

Without this change, I am unable to import this project via JitPack. JitPack fails to build the project because it attempts to run Java 8 and compile it to 15. I assume JitPack does not support Java 15, so falls back to 8.
Ref: https://jitpack.io/com/github/tcheeric/nostr-java/87f6ac7/build.log.

With this change, it successfully builds in JitPack.
Ref: https://jitpack.io/com/github/devinbileck/nostr-java/update-to-java-17-3cfae0619a-1/build.log