### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,23 @@
-/nostr-util/target/
-/nostr-crypto/target/
-/nostr-examples/target/
-/nostr-types/target/
-/nostr-ws/target/
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/


### PR DESCRIPTION
We may want to also ignore the nb-configuration.xml files, since those are specific to Netbeans. If we want to enforce a consistent code style, there are other options that do not rely on using a specific IDE. For now, I will not ignore them.