### PR TITLE
Cleanup pom files

### DIFF
--- a/nostr-base/pom.xml
+++ b/nostr-base/pom.xml
@@ -13,18 +13,21 @@
     <packaging>jar</packaging>
 
     <dependencies>
+        <!-- Annotation Dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+
+        <!-- Project Dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>nostr-util</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.tcheeric</groupId>
-                    <artifactId>Schnorr</artifactId>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>nostr-schnorr</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/nostr-crypto/pom.xml
+++ b/nostr-crypto/pom.xml
@@ -19,18 +19,21 @@
     </description>
 
     <dependencies>
+        <!-- Annotation Dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+
+        <!-- Project Dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>nostr-util</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.tcheeric</groupId>
-                    <artifactId>Schnorr</artifactId>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>nostr-schnorr</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/nostr-event/pom.xml
+++ b/nostr-event/pom.xml
@@ -13,10 +13,13 @@
     <packaging>jar</packaging>
 
     <dependencies>
+        <!-- Annotation Dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+
+        <!-- Project Dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>nostr-schnorr</artifactId>
@@ -38,8 +41,8 @@
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.tcheeric</groupId>
-                    <artifactId>Schnorr</artifactId>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>nostr-schnorr</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/nostr-examples/pom.xml
+++ b/nostr-examples/pom.xml
@@ -17,13 +17,14 @@
     </properties>
 
     <dependencies>
+        <!-- Project Dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>nostr-event</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.tcheeric</groupId>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>nostr-util</artifactId>
                 </exclusion>
             </exclusions>

--- a/nostr-id/pom.xml
+++ b/nostr-id/pom.xml
@@ -17,14 +17,17 @@
     </properties>
 
     <dependencies>
+        <!-- Annotation Dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+
+        <!-- Project Dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>nostr-schnorr</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -38,11 +41,11 @@
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.tcheeric</groupId>
-                    <artifactId>Schnorr</artifactId>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>nostr-schnorr</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.tcheeric</groupId>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>nostr-util</artifactId>
                 </exclusion>
             </exclusions>

--- a/nostr-json/pom.xml
+++ b/nostr-json/pom.xml
@@ -13,10 +13,13 @@
     <packaging>jar</packaging>
 
     <dependencies>
+        <!-- Annotation Dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+
+        <!-- Project Dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>nostr-base</artifactId>

--- a/nostr-test/pom.xml
+++ b/nostr-test/pom.xml
@@ -16,39 +16,24 @@
         <exec.mainClass>com.tcheeric.nostr.test.NostrTest</exec.mainClass>
     </properties>
 
-    <profiles>
-        <profile>
-            <id>integration-tests</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <dependencies>
+        <!-- Annotation Dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+
+        <!-- Project Dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>nostr-event</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.tcheeric</groupId>
-                    <artifactId>Schnorr</artifactId>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>nostr-schnorr</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -59,16 +44,7 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>nostr-id</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>nostr-json</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>nostr-ws</artifactId>
-            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -76,20 +52,39 @@
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.tcheeric</groupId>
-                    <artifactId>Schnorr</artifactId>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>nostr-schnorr</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Test Dependencies -->
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>nostr-schnorr</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>nostr-types</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>integration-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/nostr-test/src/test/java/nostr/test/id/ClientIT.java
+++ b/nostr-test/src/test/java/nostr/test/id/ClientIT.java
@@ -8,31 +8,33 @@ import nostr.id.Wallet;
 import nostr.test.EntityFactory;
 import java.io.IOException;
 import nostr.util.NostrException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
  * @author squirrel
  */
-public class ClientTest {
+class ClientIT {
 
     private final Client client;
 
-    public ClientTest() throws IOException, NostrException {
+    public ClientIT() throws IOException, NostrException {
         this.client = new Client("TestClient", new Wallet());
     }
 
     @Test
-    public void testSend() {
+    void testSend() {
         try {
             System.out.println("testSend");
             PublicKey publicKey = client.getWallet().getProfile().getPublicKey();
             BaseMessage msg = EventMessage.builder().event(EntityFactory.Events.createTextNoteEvent(publicKey)).build();
             this.client.send(msg);
-            Assertions.assertTrue(true);
+            assertTrue(true);
         } catch (Exception ex) {
-            Assertions.fail(ex);
+            fail(ex);
         }
     }
 
@@ -50,6 +52,6 @@ public class ClientTest {
 //                    this.client.send(msg);
 //                }
 //        );
-//        Assertions.assertNotNull(thrown);
+//        assertNotNull(thrown);
 //    }
 }

--- a/nostr-types/pom.xml
+++ b/nostr-types/pom.xml
@@ -16,16 +16,8 @@
         <exec.mainClass>nostr.types.NostrTypes</exec.mainClass>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
+        <!-- Annotation Dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/nostr-util/pom.xml
+++ b/nostr-util/pom.xml
@@ -12,31 +12,15 @@
     <artifactId>nostr-util</artifactId>
     <packaging>jar</packaging>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
     <properties>
         <exec.mainClass>nostr.util.NostrUtil</exec.mainClass>
     </properties>
 
     <dependencies>
+        <!-- Annotation Dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/nostr-ws/pom.xml
+++ b/nostr-ws/pom.xml
@@ -16,16 +16,8 @@
         <jetty-websocket.version>11.0.13</jetty-websocket.version>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
+        <!-- Jetty Dependencies -->
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jetty-client</artifactId>
@@ -41,13 +33,15 @@
             <artifactId>http2-http-client-transport</artifactId>
             <version>${jetty-websocket.version}</version>
         </dependency>
+
+        <!-- Project Dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>nostr-event</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.tcheeric</groupId>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>nostr-util</artifactId>
                 </exclusion>
             </exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -37,15 +37,19 @@
         <!-- Maven Plugin Versions -->
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- Annotation Dependencies -->
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>
             </dependency>
+
+            <!-- Test Dependencies -->
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
@@ -76,6 +80,19 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Minor cleanup to the pom files, as well as renaming ClientTest to ClientIT to ensure maven-failsafe runs it, since it is an integration test. This will ensure that particular test is only run when using the integration-tests profile
(e.g. ./mvnw verify -Pintegration-tests).