### PR TITLE
issue #39,Store incoming messages in a list instead of an array.

### DIFF
--- a/nostr-ws-response-handler-provider/src/main/java/nostr/ws/response/handler/provider/ResponseHandlerImpl.java
+++ b/nostr-ws-response-handler-provider/src/main/java/nostr/ws/response/handler/provider/ResponseHandlerImpl.java
@@ -5,11 +5,8 @@ package nostr.ws.response.handler.provider;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.logging.Level;

--- a/nostr-ws-response-handler-provider/src/main/java/nostr/ws/response/handler/provider/ResponseHandlerImpl.java
+++ b/nostr-ws-response-handler-provider/src/main/java/nostr/ws/response/handler/provider/ResponseHandlerImpl.java
@@ -4,6 +4,7 @@
 package nostr.ws.response.handler.provider;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -12,6 +13,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
+
 import lombok.Data;
 import lombok.extern.java.Log;
 import nostr.base.Relay;
@@ -49,11 +52,8 @@ public class ResponseHandlerImpl implements IResponseHandler {
         ObjectMapper objectMapper = new ObjectMapper();
         List<String> items;
         try {
-            JsonNode jsonBody = objectMapper.readTree(message);
-            items = new ArrayList<>();
-            for (JsonNode item :jsonBody) {
-                items.add(item.toString());
-            }
+            var listObj = objectMapper.readValue(message, new TypeReference<List<Object>>() {});
+            items = listObj.stream().map(Object::toString).collect(Collectors.toList());
         } catch (JsonProcessingException ex) {
             throw new NostrException(ex);
         }

--- a/nostr-ws-response-handler-provider/src/main/java/nostr/ws/response/handler/provider/ResponseHandlerImpl.java
+++ b/nostr-ws-response-handler-provider/src/main/java/nostr/ws/response/handler/provider/ResponseHandlerImpl.java
@@ -4,7 +4,10 @@
 package nostr.ws.response.handler.provider;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -46,7 +49,11 @@ public class ResponseHandlerImpl implements IResponseHandler {
         ObjectMapper objectMapper = new ObjectMapper();
         List<String> items;
         try {
-            items = Arrays.asList(objectMapper.readValue(message, String[].class));
+            JsonNode jsonBody = objectMapper.readTree(message);
+            items = new ArrayList<>();
+            for (JsonNode item :jsonBody) {
+                items.add(item.toString());
+            }
         } catch (JsonProcessingException ex) {
             throw new NostrException(ex);
         }


### PR DESCRIPTION
##Summary of the changes
issue #39, 
Change to convert the input into a JsonNode instead of directly converting it into a String array in process(). Then, I added each element to a List.

##Why are we making this change
Storing incoming messages directly in a String array leads to exceptions being thrown.

##changes
The received messages are first converted to JsonNode and then each element of that JsonNode is stored as a String in a list.

##what is deemed necessary
*Removal of unnecessary import statements
*Appropriate logging output
*Format validation of received messages

