### PR TITLE
Improving keys generation to use secp256k1 corectly

### DIFF
--- a/nostr-java-crypto/pom.xml
+++ b/nostr-java-crypto/pom.xml
@@ -25,6 +25,10 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcprov-jdk15on</artifactId>
+		</dependency>
 
         <!-- Project Dependencies -->
         <dependency>

--- a/nostr-java-crypto/src/main/java/module-info.java
+++ b/nostr-java-crypto/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module nostr.crypto {
     requires java.logging;
     requires nostr.util;
     requires static lombok;
+    requires org.bouncycastle.provider;
     
     exports nostr.crypto.bech32;
     exports nostr.crypto.schnorr;

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>2.14.1</version>
             </dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk15on</artifactId>
+				<version>1.70</version>
+			</dependency>
 
             <!-- Test Dependencies -->
             <dependency>


### PR DESCRIPTION
Actually Nostr-java isn't generating keys according NIP-01 using secp256k1.

This change improve this situation, according NIP-01. Now it will create strongest keys.