### PR TITLE
Change Validation target from name to nip05

### DIFF
--- a/nostr-java-event/src/main/java/nostr/event/impl/MetadataEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/MetadataEvent.java
@@ -43,7 +43,7 @@ public final class MetadataEvent extends GenericEvent {
     protected void validate() {
         boolean valid = true;
         
-        var strNameArr = this.profile.getName().split("@");
+        var strNameArr = this.profile.getNip05().split("@");
         if (strNameArr.length == 2) {
             var localPart = strNameArr[0];
             valid = localPart.matches(NAME_PATTERN);


### PR DESCRIPTION
***The summary of the changes***
Change Validation target from name to NIP05 (issue https://github.com/tcheeric/nostr-java/issues/45)

***Why are these changes being made***
The part that requires verification is the 'local part' of NIP-05,not name.

***Additional context***
>>NIP-05 assumes the part will be restricted to the characters a-z0-9-_., case-insensitive.
from https://github.com/nostr-protocol/nips/blob/master/05.md