### PR TITLE
in case "nonce",change nodeDifficulty from node.get(1) to node.get(2)

### DIFF
--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/TagDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/TagDeserializer.java
@@ -61,7 +61,7 @@ public class TagDeserializer<T extends BaseTag> extends JsonDeserializer<T> {
                         tag.setNonce(Integer.valueOf(nodeNonce.asText()));
                     }
 
-                    final JsonNode nodeDifficulty = node.get(1);
+                    final JsonNode nodeDifficulty = node.get(2);
                     if (nodeDifficulty != null) {
                         tag.setDifficulty(Integer.valueOf(nodeDifficulty.asText()));
                     }


### PR DESCRIPTION
***The summary of the changes***
in case "nonce",change nodeDifficulty from node.get(1) to node.get(2)
(issue #69)

***Why are these changes being made***
In TagDeserializer.java, when the code is "nonce", both nodeNonce and nodeDifficulty are set to node.get(1).


