### PR TITLE
Modify fields of NIP46.Response to match protocol

### DIFF
--- a/nostr-java-api/src/main/java/nostr/api/NIP46.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP46.java
@@ -96,10 +96,9 @@ public final class NIP46<T extends GenericEvent> extends EventNostr<T> {
     @NoArgsConstructor
     @Log
     public static final class Response implements Serializable {
-        private Long id;
-        private String responseUuid;
+        private String id;
+        private String error;
         private String result;
-        private LocalDateTime createdAt;
 
         public String toString() {
             try {


### PR DESCRIPTION
Without this change, you will fail to deserialize events from NIP46 relays.