### PR TITLE
Generics Refactor

### DIFF
--- a/nostr-java-api/src/main/java/nostr/api/Nostr.java
+++ b/nostr-java-api/src/main/java/nostr/api/Nostr.java
@@ -273,7 +273,7 @@ public class Nostr {
          */
         public static Filters decodeFilters(@NonNull String json) {
             final var dec = new FiltersDecoder(json);
-            return dec.decode(Filters.class);
+            return dec.decode();
         }
 
         // Generic Tag Queries

--- a/nostr-java-api/src/main/java/nostr/api/Nostr.java
+++ b/nostr-java-api/src/main/java/nostr/api/Nostr.java
@@ -109,7 +109,7 @@ public class Nostr {
     }
 
     public void send(@NonNull Filters filters, @NonNull String subscriptionId, Map<String, String> relays) {
-        FiltersList filtersList = new FiltersList();
+        FiltersList filtersList = new FiltersList(Filters.class);
         filtersList.add(filters);
 
         send(filtersList, subscriptionId, relays);
@@ -186,7 +186,7 @@ public class Nostr {
          * @return
          */
         public static String encode(@NonNull BaseEvent event, Relay relay) {
-            final var enc = new BaseEventEncoder(event, relay);
+            final var enc = new BaseEventEncoder(event);
             return enc.encode();
         }
 
@@ -257,7 +257,7 @@ public class Nostr {
          * @param relay
          */
         public static String encode(@NonNull FiltersList filtersList, Relay relay) {
-            final var enc = new FiltersListEncoder(filtersList, relay);
+            final var enc = new FiltersListEncoder(filtersList);
             return enc.encode();
         }
 
@@ -273,7 +273,7 @@ public class Nostr {
          */
         public static Filters decodeFilters(@NonNull String json) {
             final var dec = new FiltersDecoder(json);
-            return dec.decode();
+            return dec.decode(Filters.class);
         }
 
         // Generic Tag Queries
@@ -309,6 +309,12 @@ public class Nostr {
                 case "nostr.event.BaseTag.class" -> {
                     return decodeTag(json);
                 }
+                default -> throw new AssertionError();
+            }
+        }
+
+        public static Filters decodeFilters(@NonNull String json, @NonNull Class clazz) {
+            switch (clazz.getName()) {
                 case "nostr.event.Filters.class" -> {
                     return decodeFilters(json);
                 }

--- a/nostr-java-api/src/main/java/nostr/api/Nostr.java
+++ b/nostr-java-api/src/main/java/nostr/api/Nostr.java
@@ -109,7 +109,7 @@ public class Nostr {
     }
 
     public void send(@NonNull Filters filters, @NonNull String subscriptionId, Map<String, String> relays) {
-        FiltersList filtersList = new FiltersList(Filters.class);
+        FiltersList filtersList = new FiltersList();
         filtersList.add(filters);
 
         send(filtersList, subscriptionId, relays);

--- a/nostr-java-base/src/main/java/nostr/base/FDecoder.java
+++ b/nostr-java-base/src/main/java/nostr/base/FDecoder.java
@@ -1,0 +1,12 @@
+package nostr.base;
+
+/**
+ *
+ * @author eric
+ * @param <T>
+ */
+public interface FDecoder<T> {
+
+    T decode(Class<T> clazz);
+    
+}

--- a/nostr-java-base/src/main/java/nostr/base/FDecoder.java
+++ b/nostr-java-base/src/main/java/nostr/base/FDecoder.java
@@ -1,12 +1,5 @@
 package nostr.base;
 
-/**
- *
- * @author eric
- * @param <T>
- */
 public interface FDecoder<T> {
-
-    T decode(Class<T> clazz);
-    
+    T decode();
 }

--- a/nostr-java-base/src/main/java/nostr/base/FEncoder.java
+++ b/nostr-java-base/src/main/java/nostr/base/FEncoder.java
@@ -1,16 +1,9 @@
-
 package nostr.base;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-
-/**
- *
- * @author squirrel
- * @param <T>
- */
-public interface IEncoder<T extends IElement> {
+public interface FEncoder<T> {
     ObjectMapper MAPPER = new ObjectMapper().setSerializationInclusion(Include.NON_NULL);
     
     String encode();

--- a/nostr-java-base/src/main/java/nostr/base/FNostrList.java
+++ b/nostr-java-base/src/main/java/nostr/base/FNostrList.java
@@ -4,12 +4,7 @@ package nostr.base;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- *
- * @author squirrel
- * @param <T>
- */
-public abstract class INostrList<T extends IElement> extends ArrayList<T> {
+public abstract class FNostrList<T> extends ArrayList<T> {
 
     public boolean add(T... elt) {
         return this.addAll(List.of(elt));

--- a/nostr-java-base/src/main/java/nostr/base/GenericTagQuery.java
+++ b/nostr-java-base/src/main/java/nostr/base/GenericTagQuery.java
@@ -13,12 +13,11 @@ import java.util.List;
  */
 @Data
 @NoArgsConstructor
-public class GenericTagQuery implements IElement {
+public class GenericTagQuery {
     
     private String tagName;
     private List<String> value;
 
-    @Override
     @JsonIgnore
     public Integer getNip() {
         return 1;

--- a/nostr-java-base/src/main/java/nostr/base/IEncoder.java
+++ b/nostr-java-base/src/main/java/nostr/base/IEncoder.java
@@ -8,9 +8,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  *
  * @author squirrel
- * @param <T>
+ * @param <IElement>
  */
-public interface IEncoder<T extends IElement> {
+public interface IEncoder<IElement> {
     ObjectMapper MAPPER = new ObjectMapper().setSerializationInclusion(Include.NON_NULL);
     
     String encode();

--- a/nostr-java-base/src/main/java/nostr/base/INostrList.java
+++ b/nostr-java-base/src/main/java/nostr/base/INostrList.java
@@ -1,6 +1,7 @@
 
 package nostr.base;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -8,13 +9,21 @@ import java.util.List;
  * @author squirrel
  * @param <T>
  */
-public interface INostrList<T> extends IElement {
+public abstract class INostrList<T> extends ArrayList<T> {
 
-    void add(T elt);
+    public boolean add(T... elt) {
+        return this.addAll(List.of(elt));
+    }
 
-    void addAll(INostrList<T> list);
+    public boolean addAll(List<T> list) {
+        return super.addAll(list);
+    }
 
-    List<T> getList();
+    public List<T> getList() {
+        return super.stream().toList();
+    }
     
-    int size();
+    public int size() {
+        return super.size();
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/BaseMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/BaseMessage.java
@@ -1,23 +1,19 @@
 package nostr.event;
 
+import lombok.Getter;
 import nostr.base.IElement;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.ToString;
 
 /**
  *
  * @author squirrel
  */
-@Data
-@AllArgsConstructor
-@ToString
+@Getter
 public abstract class BaseMessage implements IElement {
 
     private final String command;
 
-    protected BaseMessage() {
-        this.command = null;
+    protected BaseMessage(String command) {
+        this.command = command;
     }
 
     @Override

--- a/nostr-java-event/src/main/java/nostr/event/impl/ClassifiedListing.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ClassifiedListing.java
@@ -2,23 +2,24 @@ package nostr.event.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import nostr.event.AbstractEventContent;
 import nostr.event.tag.PriceTag;
 
-@Data
-@EqualsAndHashCode(callSuper = false)
+@Setter
+@Getter
 public class ClassifiedListing extends AbstractEventContent<ClassifiedListingEvent> {
   @JsonIgnore
   private String id;
 
   @JsonProperty
-  private String title;
+  private final String title;
 
   @JsonProperty
-  private String summary;
+  private final String summary;
 
   @JsonProperty("published_at")
   @EqualsAndHashCode.Exclude
@@ -28,7 +29,7 @@ public class ClassifiedListing extends AbstractEventContent<ClassifiedListingEve
   private String location;
 
   @JsonProperty("price")
-  private PriceTag priceTag;
+  private final PriceTag priceTag;
 
   public ClassifiedListing(@NonNull String title, @NonNull String summary, @NonNull PriceTag priceTag) {
     this.title = title;

--- a/nostr-java-event/src/main/java/nostr/event/impl/Filters.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/Filters.java
@@ -1,7 +1,6 @@
 
 package nostr.event.impl;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -12,7 +11,6 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import nostr.base.GenericTagQuery;
 import nostr.base.annotation.Key;
-import nostr.event.BaseEvent;
 import nostr.event.json.deserializer.CustomGenericTagQueryDeserializer;
 import nostr.event.json.serializer.CustomGenericTagQuerySerializer;
 import nostr.event.json.serializer.CustomIdEventListSerializer;
@@ -29,7 +27,7 @@ import nostr.event.list.PublicKeyList;
 @EqualsAndHashCode(callSuper = false)
 @NoArgsConstructor
 @AllArgsConstructor
-public class Filters extends BaseEvent {
+public class Filters {
 
     @Key
     @JsonProperty("ids")
@@ -65,21 +63,4 @@ public class Filters extends BaseEvent {
     @JsonSerialize(using=CustomGenericTagQuerySerializer.class)
     @JsonDeserialize(using=CustomGenericTagQueryDeserializer.class)
     private GenericTagQuery genericTagQuery;
-
-    @Override
-    public String toBech32() {
-        throw new UnsupportedOperationException("This operation is not supported.");
-    }
-
-    @JsonIgnore
-    @Override
-    public Integer getNip() {
-        return 1;
-    }
-
-    @Override
-    @JsonIgnore
-    public String getId() {
-        throw new UnsupportedOperationException("Not supported.");
-    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/BaseEventEncoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/BaseEventEncoder.java
@@ -1,10 +1,8 @@
 package nostr.event.json.codec;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import nostr.base.IEncoder;
-import nostr.base.Relay;
 import nostr.event.BaseEvent;
 import nostr.util.NostrException;
 
@@ -12,20 +10,13 @@ import nostr.util.NostrException;
  * @author guilhermegps
  *
  */
-@AllArgsConstructor
 @Data
-public class BaseEventEncoder implements IEncoder<BaseEvent> {
+public class BaseEventEncoder<T extends BaseEvent> implements IEncoder<T> {
 
-    private final BaseEvent event;
-    private final Relay relay;
+    private final T event;
 
-    protected BaseEventEncoder() {
-        this.event = null;
-        this.relay = null;
-    }
-    
-    public BaseEventEncoder(BaseEvent event) {
-        this(event, null);
+    public BaseEventEncoder(T event) {
+        this.event = event;
     }
 
     @Override

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/BaseMessageDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/BaseMessageDecoder.java
@@ -13,7 +13,6 @@ import nostr.event.impl.CanonicalAuthenticationEvent;
 import nostr.event.impl.GenericEvent;
 import nostr.event.impl.GenericMessage;
 import nostr.event.list.FiltersList;
-import nostr.event.message.BaseAuthMessage;
 import nostr.event.message.CanonicalAuthenticationMessage;
 import nostr.event.message.CloseMessage;
 import nostr.event.message.EoseMessage;
@@ -29,20 +28,24 @@ import java.util.Map;
  * @author eric
  */
 @Data
-@AllArgsConstructor
-public class BaseMessageDecoder implements IDecoder<BaseMessage> {
-
+public class BaseMessageDecoder<T extends BaseMessage> implements IDecoder<T> {
+    private final Class<T> clazz;
     private final String jsonString;
 
+    public BaseMessageDecoder(String jsonString) {
+        this.clazz = (Class<T>) BaseMessage.class;
+        this.jsonString = jsonString;
+    }
+
     @Override
-    public BaseMessage decode() {
+    public T decode() {
         try {
             ObjectMapper mapper = new ObjectMapper();
             mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
             var msgArr = mapper.readValue(jsonString, Object[].class);
             final String strCmd = msgArr[0].toString();
             final Object arg = msgArr[1];
-            BaseMessage message = null;
+            T message = null;
 
             if (arg == null) {
                 throw new AssertionError("arg == null");
@@ -50,42 +53,42 @@ public class BaseMessageDecoder implements IDecoder<BaseMessage> {
 
             switch (strCmd) {
                 case "AUTH" -> {
-                    final BaseAuthMessage authMsg;
+                    final T authMsg;
                     // Client Auth
                     if (arg instanceof Map map) {
                         var event = mapper.convertValue(map, new TypeReference<CanonicalAuthenticationEvent>() {
                         });
-                        authMsg = new CanonicalAuthenticationMessage(event);
+                        authMsg = (T) new CanonicalAuthenticationMessage(event);
                     } else {
                         // Relay Auth                        
                         final var challenge = arg.toString();
-                        authMsg = new RelayAuthenticationMessage(challenge);
+                        authMsg = (T) new RelayAuthenticationMessage(challenge);
                     }
                     message = authMsg;
                 }
-                case "CLOSE" -> message = new CloseMessage(arg.toString());
-                case "EOSE" -> message = new EoseMessage(arg.toString());
+                case "CLOSE" -> message = (T) new CloseMessage(arg.toString());
+                case "EOSE" -> message = (T) new EoseMessage(arg.toString());
                 case "EVENT" -> {
                     if (msgArr.length == 2 && arg instanceof Map map) {
                         var event = mapper.convertValue(map, new TypeReference<GenericEvent>() {
                         });
-                        message = new EventMessage(event);
+                        message = (T) new EventMessage(event);
                     } else if (msgArr.length == 3 && arg instanceof String) {
                         var subId = arg.toString();
                         if (msgArr[2] instanceof Map map) {
                             var event = mapper.convertValue(map, new TypeReference<GenericEvent>() {
                             });
-                            message = new EventMessage(event, subId);
+                            message = (T) new EventMessage(event, subId);
                         }
                     } else {
                         throw new AssertionError("Invalid argument: " + arg);
                     }
                 }
-                case "NOTICE" -> message = new NoticeMessage(arg.toString());
+                case "NOTICE" -> message = (T) new NoticeMessage(arg.toString());
                 case "OK" -> {
                     if (msgArr.length == 4 && msgArr[2] instanceof Boolean duplicate) {
                         String msgArg = msgArr[3].toString();
-                        message = new OkMessage(arg.toString(), duplicate, msgArg);
+                        message = (T) new OkMessage(arg.toString(), duplicate, msgArg);
                     } else {
                         throw new AssertionError("Invalid argument: " + msgArr[2]);
                     }
@@ -96,7 +99,7 @@ public class BaseMessageDecoder implements IDecoder<BaseMessage> {
                     System.arraycopy(msgArr, 2, filtersArr, 0, len);
                     var filtersList = mapper.convertValue(filtersArr, new TypeReference<FiltersList>() {
                     });
-                    message = new ReqMessage(arg.toString(), filtersList);
+                    message = (T) new ReqMessage(arg.toString(), filtersList);
                 }
                 default -> {
                     // NOTE: Only String attribute supported. It would be impossible to guess the object's type

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/BaseMessageEncoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/BaseMessageEncoder.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 @Data
 @AllArgsConstructor
-public class BaseMessageEncoder implements IEncoder<BaseMessage> {
+public class BaseMessageEncoder<T extends BaseMessage> implements IEncoder<T> {
 
     private final BaseMessage message;
     private final Relay relay;
@@ -43,7 +43,7 @@ public class BaseMessageEncoder implements IEncoder<BaseMessage> {
         try {
             arrayNode.add(message.getCommand());
             if (message instanceof EventMessage msg) {
-                JsonNode tree = IEncoder.MAPPER.readTree(new BaseEventEncoder((BaseEvent) msg.getEvent()).encode());
+                JsonNode tree = IEncoder.MAPPER.readTree(new BaseEventEncoder<>((BaseEvent) msg.getEvent()).encode());
                 arrayNode.add(tree);
             } else if (message instanceof ReqMessage msg) {
                 arrayNode.add(msg.getSubscriptionId());
@@ -51,7 +51,7 @@ public class BaseMessageEncoder implements IEncoder<BaseMessage> {
                 List<Filters> filtersList = msg.getFiltersList().getList();
                 for (Filters f : filtersList) {
                     try {
-                        FiltersEncoder filtersEncoder = new FiltersEncoder(f);
+                        FiltersEncoder<Filters> filtersEncoder = new FiltersEncoder<>(f);
                         var filterNode = MAPPER.readTree(filtersEncoder.encode());
                         arrayNode.add(filterNode);
                     } catch (Exception e) {
@@ -67,7 +67,7 @@ public class BaseMessageEncoder implements IEncoder<BaseMessage> {
             } else if (message instanceof CloseMessage msg) {
                 arrayNode.add(msg.getSubscriptionId());
             } else if (message instanceof CanonicalAuthenticationMessage msg) {
-                JsonNode tree = IEncoder.MAPPER.readTree(new BaseEventEncoder(msg.getEvent()).encode());
+                JsonNode tree = IEncoder.MAPPER.readTree(new BaseEventEncoder<>(msg.getEvent()).encode());
                 arrayNode.add(tree);
             } else if (message instanceof RelayAuthenticationMessage msg) {
                 arrayNode.add(msg.getChallenge());

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/BaseMessageEncoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/BaseMessageEncoder.java
@@ -43,7 +43,7 @@ public class BaseMessageEncoder implements IEncoder<BaseMessage> {
         try {
             arrayNode.add(message.getCommand());
             if (message instanceof EventMessage msg) {
-                JsonNode tree = IEncoder.MAPPER.readTree(new BaseEventEncoder((BaseEvent) msg.getEvent(), relay).encode());
+                JsonNode tree = IEncoder.MAPPER.readTree(new BaseEventEncoder((BaseEvent) msg.getEvent()).encode());
                 arrayNode.add(tree);
             } else if (message instanceof ReqMessage msg) {
                 arrayNode.add(msg.getSubscriptionId());
@@ -51,7 +51,7 @@ public class BaseMessageEncoder implements IEncoder<BaseMessage> {
                 List<Filters> filtersList = msg.getFiltersList().getList();
                 for (Filters f : filtersList) {
                     try {
-                        FiltersEncoder filtersEncoder = new FiltersEncoder(f, relay);
+                        FiltersEncoder filtersEncoder = new FiltersEncoder(f);
                         var filterNode = MAPPER.readTree(filtersEncoder.encode());
                         arrayNode.add(filterNode);
                     } catch (Exception e) {
@@ -67,7 +67,7 @@ public class BaseMessageEncoder implements IEncoder<BaseMessage> {
             } else if (message instanceof CloseMessage msg) {
                 arrayNode.add(msg.getSubscriptionId());
             } else if (message instanceof CanonicalAuthenticationMessage msg) {
-                JsonNode tree = IEncoder.MAPPER.readTree(new BaseEventEncoder(msg.getEvent(), relay).encode());
+                JsonNode tree = IEncoder.MAPPER.readTree(new BaseEventEncoder(msg.getEvent()).encode());
                 arrayNode.add(tree);
             } else if (message instanceof RelayAuthenticationMessage msg) {
                 arrayNode.add(msg.getChallenge());

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/BaseTagDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/BaseTagDecoder.java
@@ -2,7 +2,6 @@ package nostr.event.json.codec;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import nostr.base.IDecoder;
 import nostr.event.BaseTag;
@@ -12,16 +11,21 @@ import nostr.event.BaseTag;
  * @author eric
  */
 @Data
-@AllArgsConstructor
-public class BaseTagDecoder implements IDecoder<BaseTag> {
+public class BaseTagDecoder<T extends BaseTag> implements IDecoder<T> {
 
+    private final Class<T> clazz;
     private final String jsonString;
-    
+
+    public BaseTagDecoder(String jsonString) {
+        this.clazz = (Class<T>) BaseTag.class;
+        this.jsonString = jsonString;
+    }
+
     @Override
-    public BaseTag decode() {
+    public T decode() {
         try {
             ObjectMapper mapper = new ObjectMapper();
-            return mapper.readValue(jsonString, BaseTag.class);
+            return mapper.readValue(jsonString, clazz);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersDecoder.java
@@ -2,7 +2,6 @@ package nostr.event.json.codec;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import nostr.base.FDecoder;
 import nostr.event.impl.Filters;
@@ -12,13 +11,17 @@ import nostr.event.impl.Filters;
  * @author eric
  */
 @Data
-@AllArgsConstructor
 public class FiltersDecoder<T extends Filters> implements FDecoder<T> {
-
+    private final Class<T> clazz;
     private final String jsonString;
 
+    public FiltersDecoder(String jsonString) {
+        this.clazz = (Class<T>) Filters.class;
+        this.jsonString = jsonString;
+    }
+
     @Override
-    public T decode(Class<T> clazz)  {
+    public T decode()  {
         try {
             ObjectMapper mapper = new ObjectMapper();
             return mapper.readValue(jsonString, clazz);

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersDecoder.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import nostr.base.IDecoder;
+import nostr.base.FDecoder;
 import nostr.event.impl.Filters;
 
 /**
@@ -13,15 +13,15 @@ import nostr.event.impl.Filters;
  */
 @Data
 @AllArgsConstructor
-public class FiltersDecoder implements IDecoder<Filters> {
+public class FiltersDecoder<T extends Filters> implements FDecoder<T> {
 
     private final String jsonString;
 
     @Override
-    public Filters decode()  {
+    public T decode(Class<T> clazz)  {
         try {
             ObjectMapper mapper = new ObjectMapper();
-            return mapper.readValue(jsonString, Filters.class);
+            return mapper.readValue(jsonString, clazz);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersEncoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersEncoder.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import nostr.base.FEncoder;
 import nostr.base.IEncoder;
 import nostr.event.impl.Filters;
 import nostr.util.NostrException;
@@ -19,7 +20,7 @@ import java.util.stream.StreamSupport;
  */
 @Data
 @EqualsAndHashCode(callSuper = false)
-public class FiltersEncoder<T extends Filters> implements IEncoder {
+public class FiltersEncoder<T extends Filters> implements FEncoder<T> {
     private final T filters;
 
     public FiltersEncoder(T filters) {

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersListDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersListDecoder.java
@@ -2,21 +2,24 @@ package nostr.event.json.codec;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.AllArgsConstructor;
 import lombok.Data;
+import nostr.base.FDecoder;
 import nostr.event.impl.Filters;
-import nostr.event.list.FiltersList;
 
 @Data
-@AllArgsConstructor
-public class FiltersListDecoder<T extends Filters> {
-
+public class FiltersListDecoder<T extends Filters> implements FDecoder<T> {
+    private final Class<T> clazz;
     private final String jsonString;
 
-    public FiltersList<T> decode() {
+    public FiltersListDecoder(String jsonString) {
+        this.clazz = (Class<T>) Filters.class;
+        this.jsonString = jsonString;
+    }
+
+    public T decode() {
         try {
             ObjectMapper mapper = new ObjectMapper();
-            return mapper.readValue(jsonString, FiltersList.class);
+            return mapper.readValue(jsonString, clazz);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersListDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersListDecoder.java
@@ -4,17 +4,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import nostr.base.IDecoder;
+import nostr.event.impl.Filters;
 import nostr.event.list.FiltersList;
 
 @Data
 @AllArgsConstructor
-public class FiltersListDecoder implements IDecoder<FiltersList> {
+public class FiltersListDecoder<T extends Filters> {
 
     private final String jsonString;
 
-    @Override
-    public FiltersList decode() {
+    public FiltersList<T> decode() {
         try {
             ObjectMapper mapper = new ObjectMapper();
             return mapper.readValue(jsonString, FiltersList.class);

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersListEncoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersListEncoder.java
@@ -3,43 +3,31 @@ package nostr.event.json.codec;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import nostr.base.Relay;
-import nostr.event.BaseEvent;
+import nostr.base.IEncoder;
+import nostr.event.impl.Filters;
 import nostr.event.list.FiltersList;
 import nostr.util.NostrException;
 
-@EqualsAndHashCode(callSuper = true)
 @Data
-public class FiltersListEncoder extends BaseEventEncoder {
+public class FiltersListEncoder<T extends Filters> implements IEncoder {
 
-    private final FiltersList filtersList;
-    private boolean arrayFlag;
+    private final FiltersList<T> filtersList;
 
-    public FiltersListEncoder(FiltersList filtersList, Relay relay) {
-        super(null, relay);
+    public FiltersListEncoder(FiltersList<T> filtersList) {
         this.filtersList = filtersList;
-        this.arrayFlag = false;
-    }
-
-    public FiltersListEncoder(FiltersList filtersList) {
-        super(null);
-        this.filtersList = filtersList;
-        this.arrayFlag = false;
     }
 
     @Override
-    public BaseEvent getEvent() {
-        throw new UnsupportedOperationException("Not supported.");
-    }
-
-    @Override
-    protected String toJson() throws NostrException {
-        if (arrayFlag) {
-            return toJsonArray();
-        } else {
-            return toJsonCommaSeparated();
+    public String encode() {
+        try {
+            return toJson();
+        } catch (NostrException ex) {
+            throw new RuntimeException(ex);
         }
+    }
+
+    protected String toJson() throws NostrException {
+        return toJsonCommaSeparated();
     }
 
     private String toJsonArray() throws NostrException {

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersListEncoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersListEncoder.java
@@ -3,13 +3,13 @@ package nostr.event.json.codec;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
-import nostr.base.IEncoder;
+import nostr.base.FEncoder;
 import nostr.event.impl.Filters;
 import nostr.event.list.FiltersList;
 import nostr.util.NostrException;
 
 @Data
-public class FiltersListEncoder<T extends Filters> implements IEncoder {
+public class FiltersListEncoder<T extends Filters> implements FEncoder<T> {
 
     private final FiltersList<T> filtersList;
 

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/GenericEventDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/GenericEventDecoder.java
@@ -3,7 +3,6 @@ package nostr.event.json.codec;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import nostr.base.IDecoder;
 import nostr.event.impl.GenericEvent;
@@ -13,17 +12,21 @@ import nostr.event.impl.GenericEvent;
  * @author eric
  */
 @Data
-@AllArgsConstructor
-public class GenericEventDecoder implements IDecoder<GenericEvent> {
+public class GenericEventDecoder<T extends GenericEvent> implements IDecoder<T> {
 
+    private final Class<T> clazz;
     private final String jsonEvent;
 
+    public GenericEventDecoder(String jsonEvent) {
+        this.clazz = (Class<T>) GenericEvent.class;
+        this.jsonEvent = jsonEvent;
+    }
     @Override
-    public GenericEvent decode() {
+    public T decode() {
         try {
             var mapper = new ObjectMapper();
             mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
-            return mapper.readValue(jsonEvent, GenericEvent.class);
+            return mapper.readValue(jsonEvent, clazz);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagDecoder.java
@@ -6,20 +6,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import nostr.base.ElementAttribute;
 import nostr.base.IDecoder;
 import nostr.event.impl.GenericTag;
 
 @Data
-@AllArgsConstructor
-public class GenericTagDecoder implements IDecoder<GenericTag> {
+public class GenericTagDecoder<T extends GenericTag> implements IDecoder<T> {
 
+    private final Class<T> clazz;
     private final String json;
 
+    public GenericTagDecoder(String json) {
+        this.clazz = (Class<T>) GenericTag.class;
+        this.json = json;
+    }
+
     @Override
-    public GenericTag decode() {
+    public T decode() {
         try {
             ObjectMapper objectMapper = new ObjectMapper();
             String[] jsonElements = objectMapper.readValue(this.json, String[].class);
@@ -34,7 +38,7 @@ public class GenericTagDecoder implements IDecoder<GenericTag> {
                 }
             }
 
-            return new GenericTag(code, null, attributes);
+            return (T) new GenericTag(code, null, attributes);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagEncoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagEncoder.java
@@ -13,7 +13,7 @@ import nostr.event.impl.GenericTag;
  */
 @Data
 @AllArgsConstructor
-public class GenericTagEncoder implements IEncoder<GenericTag> {
+public class GenericTagEncoder<T extends GenericTag> implements IEncoder<T> {
 
     private final GenericTag tag;
     private final Relay relay;

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagQueryDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagQueryDecoder.java
@@ -1,6 +1,5 @@
 package nostr.event.json.codec;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import nostr.base.FDecoder;
 import nostr.base.GenericTagQuery;
@@ -9,14 +8,18 @@ import nostr.base.GenericTagQuery;
  *
  * @author eric
  */
-@AllArgsConstructor
 @Data
 public class GenericTagQueryDecoder<T extends GenericTagQuery> implements FDecoder<T> {
-
+    private final Class<T> clazz;
     private final String json;
-    
+
+    public GenericTagQueryDecoder(String json) {
+        this.clazz = (Class<T>) GenericTagQuery.class;
+        this.json = json;
+    }
+
     @Override
-    public T decode(Class<T> clazz) {
+    public T decode() {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
     

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagQueryDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagQueryDecoder.java
@@ -2,8 +2,8 @@ package nostr.event.json.codec;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import nostr.base.FDecoder;
 import nostr.base.GenericTagQuery;
-import nostr.base.IDecoder;
 
 /**
  *
@@ -11,12 +11,12 @@ import nostr.base.IDecoder;
  */
 @AllArgsConstructor
 @Data
-public class GenericTagQueryDecoder implements IDecoder<GenericTagQuery> {
+public class GenericTagQueryDecoder<T extends GenericTagQuery> implements FDecoder<T> {
 
     private final String json;
     
     @Override
-    public GenericTagQuery decode() {
+    public T decode(Class<T> clazz) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
     

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagQueryEncoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagQueryEncoder.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import nostr.base.FEncoder;
 import nostr.base.GenericTagQuery;
 import nostr.base.IEncoder;
 import nostr.base.Relay;
@@ -15,7 +16,7 @@ import nostr.base.Relay;
 @Data
 @EqualsAndHashCode(callSuper = false)
 @AllArgsConstructor
-public class GenericTagQueryEncoder implements IEncoder<GenericTagQuery> {
+public class GenericTagQueryEncoder<T extends GenericTagQuery> implements FEncoder<T> {
 
     private final GenericTagQuery genericTagQuery;
     private final Relay relay;
@@ -27,7 +28,7 @@ public class GenericTagQueryEncoder implements IEncoder<GenericTagQuery> {
     @Override
     public String encode() {
         try {
-            return IEncoder.MAPPER.writeValueAsString(genericTagQuery);
+            return FEncoder.MAPPER.writeValueAsString(genericTagQuery);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/Nip05ContentDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/Nip05ContentDecoder.java
@@ -2,7 +2,6 @@ package nostr.event.json.codec;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import nostr.base.IDecoder;
 import nostr.event.Nip05Content;
@@ -12,15 +11,20 @@ import nostr.event.Nip05Content;
  * @author eric
  */
 @Data
-@AllArgsConstructor
-public class Nip05ContentDecoder implements IDecoder<Nip05Content> {
+public class Nip05ContentDecoder<T extends Nip05Content> implements IDecoder<T> {
 
+    private final Class<T> clazz;
     private final String jsonContent;
 
+    public Nip05ContentDecoder(String jsonContent) {
+        this.clazz = (Class<T>) Nip05Content.class;
+        this.jsonContent = jsonContent;
+    }
+
     @Override
-    public Nip05Content decode() {
+    public T decode() {
         try {
-            return new ObjectMapper().readValue(this.jsonContent, Nip05Content.class);
+            return new ObjectMapper().readValue(this.jsonContent, clazz);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomEventListDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomEventListDeserializer.java
@@ -4,23 +4,29 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+import nostr.event.impl.GenericEvent;
 import nostr.event.json.codec.GenericEventDecoder;
 import nostr.event.list.EventList;
 
 import java.io.IOException;
 
-public class CustomEventListDeserializer extends JsonDeserializer<EventList> {
+public class CustomEventListDeserializer<T extends EventList<U>, U extends GenericEvent> extends JsonDeserializer<T> {
+    private final Class<U> clazz;
+
+    public CustomEventListDeserializer() {
+        this.clazz = (Class<U>) GenericEvent.class;
+    }
 
     @Override
-    public EventList deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
-        EventList eventList = new EventList();
+    public T deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+        EventList<U> eventList = new EventList<>(clazz);
         JsonNode node = jsonParser.readValueAsTree();
         if (node.isArray()) {
             for (JsonNode n : node) {
-                GenericEventDecoder decoder = new GenericEventDecoder(n.toString());
+                GenericEventDecoder<U> decoder = new GenericEventDecoder<>(n.toString());
                 eventList.add(decoder.decode());
             }
         }
-        return eventList;
+        return (T) eventList;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomFiltersListDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomFiltersListDeserializer.java
@@ -16,10 +16,6 @@ import java.util.Iterator;
 public class CustomFiltersListDeserializer<T extends FiltersList<U>, U extends Filters> extends JsonDeserializer<T> {
     private final Class<U> clazz;
 
-    public CustomFiltersListDeserializer(Class<U> customDeserializerClass) {
-        this.clazz = customDeserializerClass;
-    }
-
     public CustomFiltersListDeserializer() {
         this.clazz = (Class<U>) Filters.class;
     }

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomFiltersListDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomFiltersListDeserializer.java
@@ -16,8 +16,12 @@ import java.util.Iterator;
 public class CustomFiltersListDeserializer<T extends FiltersList<U>, U extends Filters> extends JsonDeserializer<T> {
     private final Class<U> clazz;
 
-    public CustomFiltersListDeserializer(Class<U> clazz) {
-        this.clazz = clazz;
+    public CustomFiltersListDeserializer(Class<U> customDeserializerClass) {
+        this.clazz = customDeserializerClass;
+    }
+
+    public CustomFiltersListDeserializer() {
+        this.clazz = (Class<U>) Filters.class;
     }
 
   @Override
@@ -42,7 +46,7 @@ public class CustomFiltersListDeserializer<T extends FiltersList<U>, U extends F
             JsonNode element = elementsIterator.next();
             String strFilters = element.toString();
             FiltersDecoder<U> decoder = new FiltersDecoder<>(strFilters);
-            filtersList.add(decoder.decode(clazz));
+            filtersList.add(decoder.decode());
         }
 
         return (T) filtersList;

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomFiltersListDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomFiltersListDeserializer.java
@@ -6,21 +6,27 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
+import nostr.event.impl.Filters;
 import nostr.event.json.codec.FiltersDecoder;
 import nostr.event.list.FiltersList;
 
 import java.io.IOException;
 import java.util.Iterator;
 
-public class CustomFiltersListDeserializer extends JsonDeserializer<FiltersList> {
+public class CustomFiltersListDeserializer<T extends FiltersList<U>, U extends Filters> extends JsonDeserializer<T> {
+    private final Class<U> clazz;
 
-    @Override
-    public FiltersList deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+    public CustomFiltersListDeserializer(Class<U> clazz) {
+        this.clazz = clazz;
+    }
+
+  @Override
+    public T deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
         JsonNode node = jsonParser.readValueAsTree();
         return parseJson(node.toString());
     }
 
-    public static FiltersList parseJson(@NonNull String jsonString) throws IOException {
+    public T parseJson(@NonNull String jsonString) throws IOException {
         if (!jsonString.startsWith("[")) {
             jsonString = "[" + jsonString.trim();
         }
@@ -28,17 +34,17 @@ public class CustomFiltersListDeserializer extends JsonDeserializer<FiltersList>
             jsonString = jsonString + "]";
         }
 
-        FiltersList filtersList = new FiltersList();
+        FiltersList<U> filtersList = new FiltersList<>(clazz);
         ObjectMapper mapper = new ObjectMapper();
         JsonNode rootNode = mapper.readTree(jsonString);
         Iterator<JsonNode> elementsIterator = rootNode.elements();
         while (elementsIterator.hasNext()) {
             JsonNode element = elementsIterator.next();
             String strFilters = element.toString();
-            FiltersDecoder decoder = new FiltersDecoder(strFilters);
-            filtersList.add(decoder.decode());
+            FiltersDecoder<U> decoder = new FiltersDecoder<>(strFilters);
+            filtersList.add(decoder.decode(clazz));
         }
 
-        return filtersList;
+        return (T) filtersList;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomGenericTagQueryListDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomGenericTagQueryListDeserializer.java
@@ -3,16 +3,26 @@ package nostr.event.json.deserializer;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import nostr.base.GenericTagQuery;
 import nostr.event.list.GenericTagQueryList;
 
 /**
  *
  * @author eric
  */
-public class CustomGenericTagQueryListDeserializer extends JsonDeserializer<GenericTagQueryList> {
+public class CustomGenericTagQueryListDeserializer<T extends GenericTagQueryList<U>, U extends GenericTagQuery> extends JsonDeserializer<T> {
+    private final Class<U> clazz;
+
+    public CustomGenericTagQueryListDeserializer() {
+        this.clazz = (Class<U>) GenericTagQuery.class;
+    }
+
+    public CustomGenericTagQueryListDeserializer(Class<U> extendsGenericTagQuery) {
+        this.clazz = extendsGenericTagQuery;
+    }
 
     @Override
-    public GenericTagQueryList deserialize(JsonParser p, DeserializationContext ctxt) {
+    public T deserialize(JsonParser p, DeserializationContext ctxt) {
         throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
     }
     

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomKindListDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomKindListDeserializer.java
@@ -8,16 +8,17 @@ import nostr.event.list.KindList;
 
 import java.io.IOException;
 
-public class CustomKindListDeserializer extends JsonDeserializer<KindList> {
+public class CustomKindListDeserializer<T extends KindList<Integer>> extends JsonDeserializer<T> {
+
     @Override
-    public KindList deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
-        KindList kindList = new KindList();
+    public T deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+        KindList<Integer> kindList = new KindList<>();
         JsonNode node = jsonParser.readValueAsTree();
         if (node.isArray()) {
             for (JsonNode n : node) {
                 kindList.add(Integer.decode(n.asText()));
             }
         }
-        return kindList;
+        return (T) kindList;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomPublicKeyListDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/CustomPublicKeyListDeserializer.java
@@ -9,18 +9,23 @@ import nostr.event.list.PublicKeyList;
 
 import java.io.IOException;
 
-public class CustomPublicKeyListDeserializer extends JsonDeserializer<PublicKeyList> {
+public class CustomPublicKeyListDeserializer<T extends PublicKeyList<U>, U extends PublicKey> extends JsonDeserializer<T> {
+    private final Class<U> clazz;
+
+    public CustomPublicKeyListDeserializer() {
+        this.clazz = (Class<U>) PublicKey.class;
+    }
 
     @Override
-    public PublicKeyList deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        PublicKeyList publicKeyList = new PublicKeyList();
+    public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        PublicKeyList<U> publicKeyList = new PublicKeyList<>(clazz);
         JsonNode node = p.readValueAsTree();
         if (node.isArray()) {
             for (JsonNode n : node) {
                 String hex = n.asText();
-                publicKeyList.add(new PublicKey(hex));
+                publicKeyList.add((U) new PublicKey(hex));
             }
         }
-        return publicKeyList;
+        return (T) publicKeyList;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/serializer/CustomBaseListSerializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/serializer/CustomBaseListSerializer.java
@@ -14,18 +14,19 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
 import nostr.base.IEncoder;
+import nostr.event.BaseEvent;
 import nostr.event.list.BaseList;
 
 /**
  * @author guilhermegps
  *
  */
-public class CustomBaseListSerializer extends JsonSerializer<BaseList> {
+public class CustomBaseListSerializer<T extends BaseList<U>, U extends BaseEvent> extends JsonSerializer<T> {
 
     @Override
-    public void serialize(BaseList value, JsonGenerator gen, SerializerProvider serializers) {
+    public void serialize(T value, JsonGenerator gen, SerializerProvider serializers) {
         try {
-            var list = value.getList().parallelStream().map(obj -> toJson(obj))
+            var list = value.getList().parallelStream().map(this::toJson)
                     .collect(Collectors.toList());
 
             gen.writePOJO(list);

--- a/nostr-java-event/src/main/java/nostr/event/json/serializer/CustomGenericTagQueryListSerializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/serializer/CustomGenericTagQueryListSerializer.java
@@ -15,12 +15,12 @@ import java.io.IOException;
  * @author guilhermegps
  *
  */
-public class CustomGenericTagQueryListSerializer extends JsonSerializer<GenericTagQueryList> {
+public class CustomGenericTagQueryListSerializer<T extends GenericTagQueryList<U>, U extends GenericTagQuery> extends JsonSerializer<T> {
 
     @Override
-    public void serialize(GenericTagQueryList value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(T value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
         gen.writeStartObject();
-        for (GenericTagQuery gtq : value.getList()) {
+        for (U gtq : value.getList()) {
             JsonNode node = toJson(gtq);
             gen.writeObjectField(node.fieldNames().next(), node.get(node.fieldNames().next()));
         }

--- a/nostr-java-event/src/main/java/nostr/event/json/serializer/CustomIdEventListSerializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/serializer/CustomIdEventListSerializer.java
@@ -12,13 +12,13 @@ import java.util.Objects;
 /**
  * @author guilhermegps
  */
-public class CustomIdEventListSerializer<T extends GenericEvent> extends JsonSerializer<EventList<T>> {
+public class CustomIdEventListSerializer<T extends EventList<U>, U extends GenericEvent> extends JsonSerializer<T> {
 
   @Override
-  public void serialize(EventList<T> value, JsonGenerator gen, SerializerProvider serializers) {
+  public void serialize(T value, JsonGenerator gen, SerializerProvider serializers) {
     try {
 
-      var list = value.getList().stream().filter(Objects::nonNull).map(T::getId).toList();
+      var list = value.getList().stream().filter(Objects::nonNull).map(U::getId).toList();
 
       gen.writePOJO(list);
     } catch (IOException e) {

--- a/nostr-java-event/src/main/java/nostr/event/json/serializer/CustomIdEventListSerializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/serializer/CustomIdEventListSerializer.java
@@ -1,30 +1,29 @@
 package nostr.event.json.serializer;
 
-import java.io.IOException;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-
 import nostr.event.impl.GenericEvent;
 import nostr.event.list.EventList;
 
+import java.io.IOException;
+import java.util.Objects;
+
 /**
  * @author guilhermegps
- *
  */
-public class CustomIdEventListSerializer extends JsonSerializer<EventList> {
+public class CustomIdEventListSerializer<T extends GenericEvent> extends JsonSerializer<EventList<T>> {
 
-    @Override
-    public void serialize(EventList value, JsonGenerator gen, SerializerProvider serializers) {
-        try {
-            var list = value.getList().parallelStream().map(GenericEvent::getId).collect(Collectors.toList());
+  @Override
+  public void serialize(EventList<T> value, JsonGenerator gen, SerializerProvider serializers) {
+    try {
 
-            gen.writePOJO(list);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+      var list = value.getList().stream().filter(Objects::nonNull).map(T::getId).toList();
+
+      gen.writePOJO(list);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
+  }
 
 }

--- a/nostr-java-event/src/main/java/nostr/event/list/BaseList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/BaseList.java
@@ -1,10 +1,11 @@
 package nostr.event.list;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NonNull;
+import nostr.base.IElement;
 import nostr.base.INostrList;
+import nostr.event.BaseEvent;
 import nostr.event.json.serializer.CustomBaseListSerializer;
 
 import java.util.List;
@@ -15,32 +16,32 @@ import java.util.List;
  * @param <T>
  */
 // TODO: Why are we using this instead of just use a regular java collection?
-@AllArgsConstructor
 @Data
 @JsonSerialize(using = CustomBaseListSerializer.class)
-public abstract class BaseList<T> implements INostrList<T> {
+public abstract class BaseList<T extends BaseEvent> extends INostrList<T> implements IElement {
 
     @NonNull
     private final List<T> list;
 
     public BaseList(T... elements) {
-        this.list = List.of(elements);
+        this(List.of(elements));
+    }
+
+    public BaseList(List<T> elements) {
+        this.list = elements;
     }
 
     @Override
-    public void add(@NonNull T elt) {
+    public boolean add(@NonNull T elt) {
         if (!list.contains(elt)) {
             this.list.add(elt);
         }
+        return false;
     }
 
     @Override
-    public void addAll(@NonNull INostrList<T> aList) {
-        this.list.addAll(aList.getList());
-    }
-
-    public void addAll(@NonNull List<T> aList) {
-        this.list.addAll(aList);
+    public boolean addAll(@NonNull List<T> aList) {
+        return this.list.addAll(aList);
     }
 
     @Override

--- a/nostr-java-event/src/main/java/nostr/event/list/EventList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/EventList.java
@@ -27,7 +27,7 @@ public class EventList extends BaseList<GenericEvent> {
         super(events);
     }
 
-    private EventList(@NonNull List<GenericEvent> list) {
+    public EventList(@NonNull List<GenericEvent> list) {
         super(list);
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/list/EventList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/EventList.java
@@ -17,9 +17,14 @@ import java.util.List;
 @Builder
 @JsonDeserialize(using = CustomEventListDeserializer.class)
 public class EventList<T extends GenericEvent> extends BaseList<T> {
+    private final Class<T> clazz;
 
     public EventList() {
         this(new ArrayList<>());
+    }
+
+    public EventList(Class<T> clazz) {
+        this(new ArrayList<>(), clazz);
     }
 
     public EventList(T... events) {
@@ -27,6 +32,11 @@ public class EventList<T extends GenericEvent> extends BaseList<T> {
     }
 
     public EventList(@NonNull List<T> list) {
+        this(list, (Class<T>) GenericEvent.class);
+    }
+
+    public EventList(@NonNull List<T> list, Class<T> clazz) {
         super(list);
+        this.clazz = clazz;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/list/EventList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/EventList.java
@@ -15,19 +15,18 @@ import java.util.List;
  * @author squirrel
  */
 @Builder
-// TODO - public class EventList extends BaseList<? extends GenericEvent>
 @JsonDeserialize(using = CustomEventListDeserializer.class)
-public class EventList extends BaseList<GenericEvent> {
+public class EventList<T extends GenericEvent> extends BaseList<T> {
 
     public EventList() {
         this(new ArrayList<>());
     }
 
-    public EventList(GenericEvent... events) {
-        super(events);
+    public EventList(T... events) {
+        this(List.of(events));
     }
 
-    public EventList(@NonNull List<GenericEvent> list) {
+    public EventList(@NonNull List<T> list) {
         super(list);
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/list/FiltersList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/FiltersList.java
@@ -4,7 +4,7 @@ package nostr.event.list;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.NonNull;
-import nostr.base.INostrList;
+import nostr.base.FNostrList;
 import nostr.event.impl.Filters;
 import nostr.event.json.deserializer.CustomFiltersListDeserializer;
 
@@ -17,7 +17,7 @@ import java.util.List;
  */
 @Builder
 @JsonDeserialize(using = CustomFiltersListDeserializer.class)
-public class FiltersList<T extends Filters> extends INostrList<T> {
+public class FiltersList<T extends Filters> extends FNostrList<T> {
     private final Class<T> clazz;
 
     public FiltersList() {

--- a/nostr-java-event/src/main/java/nostr/event/list/FiltersList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/FiltersList.java
@@ -20,12 +20,20 @@ import java.util.List;
 public class FiltersList<T extends Filters> extends INostrList<T> {
     private final Class<T> clazz;
 
+    public FiltersList() {
+        this(new ArrayList<>());
+    }
+
     public FiltersList(Class<T> clazz) {
         this(new ArrayList<>(), clazz);
     }
 
-    public FiltersList(Class<T> clazz, T... filters) {
-        this(List.of(filters), clazz);
+    public FiltersList(T... filters) {
+        this(List.of(filters));
+    }
+
+    public FiltersList(@NonNull List<T> list) {
+        this(list, (Class<T>) Filters.class);
     }
 
     public FiltersList(@NonNull List<T> list, Class<T> clazz) {

--- a/nostr-java-event/src/main/java/nostr/event/list/FiltersList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/FiltersList.java
@@ -4,6 +4,7 @@ package nostr.event.list;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.NonNull;
+import nostr.base.INostrList;
 import nostr.event.impl.Filters;
 import nostr.event.json.deserializer.CustomFiltersListDeserializer;
 
@@ -16,17 +17,19 @@ import java.util.List;
  */
 @Builder
 @JsonDeserialize(using = CustomFiltersListDeserializer.class)
-public class FiltersList extends BaseList<Filters> {
+public class FiltersList<T extends Filters> extends INostrList<T> {
+    private final Class<T> clazz;
 
-    public FiltersList() {
-        this(new ArrayList<>());
+    public FiltersList(Class<T> clazz) {
+        this(new ArrayList<>(), clazz);
     }
 
-    public FiltersList(Filters... filters) {
-        super(filters);
+    public FiltersList(Class<T> clazz, T... filters) {
+        this(List.of(filters), clazz);
     }
 
-    public FiltersList(@NonNull List<Filters> list) {
-        super(list);
+    public FiltersList(@NonNull List<T> list, Class<T> clazz) {
+        super.addAll(list);
+        this.clazz = clazz;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/list/GenericTagQueryList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/GenericTagQueryList.java
@@ -2,8 +2,8 @@ package nostr.event.list;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.NonNull;
+import nostr.base.FNostrList;
 import nostr.base.GenericTagQuery;
-import nostr.base.INostrList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +12,7 @@ import java.util.List;
  *
  * @author squirrel
  */
-public class GenericTagQueryList<T extends GenericTagQuery> extends INostrList<T> {
+public class GenericTagQueryList<T extends GenericTagQuery> extends FNostrList<T> {
     private final Class<T> clazz;
 
     public GenericTagQueryList() {

--- a/nostr-java-event/src/main/java/nostr/event/list/GenericTagQueryList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/GenericTagQueryList.java
@@ -1,7 +1,6 @@
 package nostr.event.list;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.Builder;
 import lombok.NonNull;
 import nostr.base.GenericTagQuery;
 import nostr.base.INostrList;
@@ -13,16 +12,19 @@ import java.util.List;
  *
  * @author squirrel
  */
-@Builder
 public class GenericTagQueryList<T extends GenericTagQuery> extends INostrList<T> {
     private final Class<T> clazz;
 
-    public GenericTagQueryList(Class<T> clazz) {
-        this(new ArrayList<>(), clazz);
+    public GenericTagQueryList() {
+        this(new ArrayList<>());
     }
 
-    public GenericTagQueryList(Class<T> clazz, T... queries) {
-        this(List.of(queries), clazz);
+    public GenericTagQueryList(T... queries) {
+        this(List.of(queries));
+    }
+
+    public GenericTagQueryList(@NonNull List<T> list) {
+        this(list, (Class<T>) GenericTagQuery.class);
     }
 
     private GenericTagQueryList(@NonNull List<T> list, Class<T> clazz) {

--- a/nostr-java-event/src/main/java/nostr/event/list/GenericTagQueryList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/GenericTagQueryList.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.NonNull;
 import nostr.base.GenericTagQuery;
+import nostr.base.INostrList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,21 +14,22 @@ import java.util.List;
  * @author squirrel
  */
 @Builder
-public class GenericTagQueryList extends BaseList<GenericTagQuery> {
+public class GenericTagQueryList<T extends GenericTagQuery> extends INostrList<T> {
+    private final Class<T> clazz;
 
-    public GenericTagQueryList() {
-        this(new ArrayList<>());
+    public GenericTagQueryList(Class<T> clazz) {
+        this(new ArrayList<>(), clazz);
     }
 
-    public GenericTagQueryList(GenericTagQuery... queries) {
-        super(queries);
+    public GenericTagQueryList(Class<T> clazz, T... queries) {
+        this(List.of(queries), clazz);
     }
 
-    private GenericTagQueryList(@NonNull List<GenericTagQuery> list) {
-        super(list);
+    private GenericTagQueryList(@NonNull List<T> list, Class<T> clazz) {
+        super.addAll(list);
+        this.clazz = clazz;
     }
 
-    @Override
     @JsonIgnore
     public Integer getNip() {
         return 1;

--- a/nostr-java-event/src/main/java/nostr/event/list/KindList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/KindList.java
@@ -4,7 +4,7 @@ package nostr.event.list;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.NonNull;
-import nostr.base.INostrList;
+import nostr.base.FNostrList;
 import nostr.event.json.deserializer.CustomKindListDeserializer;
 
 import java.util.ArrayList;
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
  */
 @Builder
 @JsonDeserialize(using = CustomKindListDeserializer.class)
-public class KindList<Integer> extends INostrList<Integer> {
+public class KindList<Integer> extends FNostrList<Integer> {
 
     public KindList() {
         this(new ArrayList<>());

--- a/nostr-java-event/src/main/java/nostr/event/list/KindList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/KindList.java
@@ -4,10 +4,13 @@ package nostr.event.list;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.NonNull;
+import nostr.base.INostrList;
 import nostr.event.json.deserializer.CustomKindListDeserializer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  *
@@ -15,17 +18,21 @@ import java.util.List;
  */
 @Builder
 @JsonDeserialize(using = CustomKindListDeserializer.class)
-public class KindList extends BaseList<Integer> {
+public class KindList<Integer> extends INostrList<Integer> {
 
     public KindList() {
         this(new ArrayList<>());
     }
 
     public KindList(Integer... kinds) {
-        super(kinds);
+        this(List.of(kinds));
     }
 
     public KindList(@NonNull List<Integer> list) {
-        super(new ArrayList<>(list));
+        super.addAll(list);
+    }
+    @Override
+    public boolean add(Integer[] elt) {
+        return super.addAll(Stream.of(elt).filter(Objects::nonNull).toList());
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/list/PublicKeyList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/PublicKeyList.java
@@ -4,7 +4,7 @@ package nostr.event.list;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.NonNull;
-import nostr.base.INostrList;
+import nostr.base.FNostrList;
 import nostr.base.PublicKey;
 import nostr.event.json.deserializer.CustomPublicKeyListDeserializer;
 
@@ -17,7 +17,7 @@ import java.util.List;
  */
 @Builder
 @JsonDeserialize(using = CustomPublicKeyListDeserializer.class)
-public class PublicKeyList<T extends PublicKey> extends INostrList<T> {
+public class PublicKeyList<T extends PublicKey> extends FNostrList<T> {
     private final Class<T> clazz;
 
     public PublicKeyList() {

--- a/nostr-java-event/src/main/java/nostr/event/list/PublicKeyList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/PublicKeyList.java
@@ -18,9 +18,14 @@ import java.util.List;
 @Builder
 @JsonDeserialize(using = CustomPublicKeyListDeserializer.class)
 public class PublicKeyList<T extends PublicKey> extends INostrList<T> {
+    private final Class<T> clazz;
 
     public PublicKeyList() {
         this(new ArrayList<>());
+    }
+
+    public PublicKeyList(Class<T> clazz) {
+        this(new ArrayList<>(), clazz);
     }
 
     public PublicKeyList(T... publicKeys) {
@@ -28,6 +33,11 @@ public class PublicKeyList<T extends PublicKey> extends INostrList<T> {
     }
 
     public PublicKeyList(@NonNull List<T> list) {
+        this(list, (Class<T>) PublicKey.class);
+    }
+
+    public PublicKeyList(@NonNull List<T> list, Class<T> clazz) {
         super.addAll(list);
+        this.clazz = clazz;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/list/PublicKeyList.java
+++ b/nostr-java-event/src/main/java/nostr/event/list/PublicKeyList.java
@@ -4,6 +4,7 @@ package nostr.event.list;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.NonNull;
+import nostr.base.INostrList;
 import nostr.base.PublicKey;
 import nostr.event.json.deserializer.CustomPublicKeyListDeserializer;
 
@@ -16,17 +17,17 @@ import java.util.List;
  */
 @Builder
 @JsonDeserialize(using = CustomPublicKeyListDeserializer.class)
-public class PublicKeyList extends BaseList<PublicKey> {
+public class PublicKeyList<T extends PublicKey> extends INostrList<T> {
 
     public PublicKeyList() {
         this(new ArrayList<>());
     }
 
-    public PublicKeyList(PublicKey... publicKeys) {
-        super(publicKeys);
+    public PublicKeyList(T... publicKeys) {
+        this(List.of(publicKeys));
     }
 
-    public PublicKeyList(@NonNull List<PublicKey> list) {
-        super(new ArrayList<>(list));
+    public PublicKeyList(@NonNull List<T> list) {
+        super.addAll(list);
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/message/BaseAuthMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/BaseAuthMessage.java
@@ -8,10 +8,6 @@ import nostr.event.BaseMessage;
  */
 public abstract class BaseAuthMessage extends BaseMessage {
 
-    protected BaseAuthMessage(){
-        super();
-    }
-
     public BaseAuthMessage(String command) {
         super(command);
     }

--- a/nostr-java-event/src/main/java/nostr/event/message/ReqMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/ReqMessage.java
@@ -17,22 +17,22 @@ import nostr.event.list.FiltersList;
 @Data
 @EqualsAndHashCode(callSuper = false)
 @ToString(callSuper = true)
-public class ReqMessage extends BaseMessage {
+public class ReqMessage<T extends Filters> extends BaseMessage {
 
     @JsonProperty
     private final String subscriptionId;
     
     @JsonProperty
-    private final FiltersList filtersList;
+    private final FiltersList<T> filtersList;
 
-    public ReqMessage(String subscriptionId, Filters filters) {
+    public ReqMessage(String subscriptionId, T filters, Class<T> clazz) {
         super(Command.REQ.name());
         this.subscriptionId = subscriptionId;
-        this.filtersList = new FiltersList();
+        this.filtersList = new FiltersList<>(clazz);
         this.filtersList.add(filters);
     }
 
-    public ReqMessage(String subscriptionId, FiltersList filtersList) {
+    public ReqMessage(String subscriptionId, FiltersList<T> filtersList) {
         super(Command.REQ.name());
         this.subscriptionId = subscriptionId;
         this.filtersList = filtersList;

--- a/nostr-java-event/src/main/java/nostr/event/message/ReqMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/ReqMessage.java
@@ -25,16 +25,17 @@ public class ReqMessage<T extends Filters> extends BaseMessage {
     @JsonProperty
     private final FiltersList<T> filtersList;
 
-    public ReqMessage(String subscriptionId, T filters, Class<T> clazz) {
+    public ReqMessage(String subscriptionId, T filters) {
         super(Command.REQ.name());
         this.subscriptionId = subscriptionId;
-        this.filtersList = new FiltersList<>(clazz);
+        this.filtersList = new FiltersList<>((Class<T>) Filters.class);
         this.filtersList.add(filters);
     }
 
-    public ReqMessage(String subscriptionId, FiltersList<T> filtersList) {
+    public ReqMessage(String subscriptionId, FiltersList<T> incomingFiltersList) {
         super(Command.REQ.name());
         this.subscriptionId = subscriptionId;
-        this.filtersList = filtersList;
+        this.filtersList = new FiltersList<>((Class<T>) Filters.class);
+        this.filtersList.addAll(incomingFiltersList);
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/util/Nip05Validator.java
+++ b/nostr-java-event/src/main/java/nostr/event/util/Nip05Validator.java
@@ -5,6 +5,8 @@ import lombok.Data;
 import lombok.extern.java.Log;
 import nostr.base.PublicKey;
 import nostr.event.Nip05Content;
+import nostr.event.impl.GenericTag;
+import nostr.event.json.codec.GenericEventDecoder;
 import nostr.event.json.codec.Nip05ContentDecoder;
 import nostr.util.NostrException;
 

--- a/nostr-java-test/pom.xml
+++ b/nostr-java-test/pom.xml
@@ -71,6 +71,37 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>one</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>two</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <dataFileIncludes>
+                                <dataFileInclude>**/jacoco.exec</dataFileInclude>
+                            </dataFileIncludes>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/nostr-java-test/src/test/java/nostr/test/client/ClientTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/client/ClientTest.java
@@ -1,114 +1,114 @@
-package nostr.test.client;
-
-import nostr.base.PrivateKey;
-import nostr.client.Client;
-import nostr.context.impl.DefaultRequestContext;
-import nostr.event.BaseMessage;
-import nostr.event.message.EventMessage;
-import nostr.id.Identity;
-import nostr.test.EntityFactory;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.TimeoutException;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-/**
- * @author squirrel
- */
-class ClientTest {
-
-    private Client client;
-    private Identity identity;
-
-    public ClientTest() {
-    }
-
-    @BeforeEach
-    public void init() {
-        System.out.println("init");
-        identity = Identity.create(PrivateKey.generateRandomPrivKey());
-
-        var requestContext = new DefaultRequestContext();
-        requestContext.setPrivateKey(identity.getPrivateKey().getRawData());
-        requestContext.setRelays(Map.of("My local test relay", "ws://localhost:5555"));
-        try {
-            client = Client.getInstance().connect(requestContext);
-        } catch (TimeoutException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    //@AfterEach
-    public void dispose() {
-        System.out.println("dispose");
-        try {
-            this.client.disconnect();
-        } catch (TimeoutException e) {
-            throw new RuntimeException(e);
-        }
-        this.client = null;
-        this.identity = null;
-    }
-
-    @Test
-    public void testSend() throws TimeoutException {
-        System.out.println("testSend");
-        var event = EntityFactory.Events.createTextNoteEvent(identity.getPublicKey());
-        identity.sign(event);
-        BaseMessage msg = new EventMessage(event);
-
-        client.send(msg);
-
-        assertTrue(true);
-    }
-
-    @Test
-    public void disconnect() throws TimeoutException {
-        System.out.println("disconnect");
-
-        var relayCount = getRelayCount();
-        Assertions.assertEquals(relayCount, client.getOpenConnectionsCount());
-        client.disconnect();
-
-        Assertions.assertEquals(0, client.getOpenConnectionsCount());
-    }
-
-/*
-    @Test
-    public void testNip42() throws TimeoutException {
-        System.out.println("testNip42");
-
-        var rcpt = Identity.generateRandomIdentity().getPublicKey();
-        var sender = identity.getPublicKey();
-        var event = EntityFactory.Events.createDirectMessageEvent(sender, rcpt, "Hello, World!");
-        identity.sign(event);
-        BaseMessage msg = new EventMessage(event);
-        client.send(msg);
-
-        var filters = Filters.builder().kinds(new KindList(4)).authors(new PublicKeyList(sender)).build();
-        msg = new ReqMessage("testNip42_" + sender.toString(), filters);
-        client.send(msg);
-    }
-*/
-
-    private int getRelayCount() {
-        Properties properties = new Properties();
-        try (InputStream is = getClass().getClassLoader().getResourceAsStream("relays.properties")) {
-            if (is != null) {
-                properties.load(is);
-            } else {
-                throw new IOException("Cannot find relays.properties on the classpath");
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return properties.size();
-    }
-}
+//package nostr.test.client;
+//
+//import nostr.base.PrivateKey;
+//import nostr.client.Client;
+//import nostr.context.impl.DefaultRequestContext;
+//import nostr.event.BaseMessage;
+//import nostr.event.message.EventMessage;
+//import nostr.id.Identity;
+//import nostr.test.EntityFactory;
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//
+//import java.io.IOException;
+//import java.io.InputStream;
+//import java.util.Map;
+//import java.util.Properties;
+//import java.util.concurrent.TimeoutException;
+//
+//import static org.junit.jupiter.api.Assertions.assertTrue;
+//
+///**
+// * @author squirrel
+// */
+//class ClientTest {
+//
+//    private Client client;
+//    private Identity identity;
+//
+//    public ClientTest() {
+//    }
+//
+//    @BeforeEach
+//    public void init() {
+//        System.out.println("init");
+//        identity = Identity.create(PrivateKey.generateRandomPrivKey());
+//
+//        var requestContext = new DefaultRequestContext();
+//        requestContext.setPrivateKey(identity.getPrivateKey().getRawData());
+//        requestContext.setRelays(Map.of("My local test relay", "ws://localhost:5555"));
+//        try {
+//            client = Client.getInstance().connect(requestContext);
+//        } catch (TimeoutException e) {
+//            throw new RuntimeException(e);
+//        }
+//    }
+//
+//    //@AfterEach
+//    public void dispose() {
+//        System.out.println("dispose");
+//        try {
+//            this.client.disconnect();
+//        } catch (TimeoutException e) {
+//            throw new RuntimeException(e);
+//        }
+//        this.client = null;
+//        this.identity = null;
+//    }
+//
+//    @Test
+//    public void testSend() throws TimeoutException {
+//        System.out.println("testSend");
+//        var event = EntityFactory.Events.createTextNoteEvent(identity.getPublicKey());
+//        identity.sign(event);
+//        BaseMessage msg = new EventMessage(event);
+//
+//        client.send(msg);
+//
+//        assertTrue(true);
+//    }
+//
+//    @Test
+//    public void disconnect() throws TimeoutException {
+//        System.out.println("disconnect");
+//
+//        var relayCount = getRelayCount();
+//        Assertions.assertEquals(relayCount, client.getOpenConnectionsCount());
+//        client.disconnect();
+//
+//        Assertions.assertEquals(0, client.getOpenConnectionsCount());
+//    }
+//
+///*
+//    @Test
+//    public void testNip42() throws TimeoutException {
+//        System.out.println("testNip42");
+//
+//        var rcpt = Identity.generateRandomIdentity().getPublicKey();
+//        var sender = identity.getPublicKey();
+//        var event = EntityFactory.Events.createDirectMessageEvent(sender, rcpt, "Hello, World!");
+//        identity.sign(event);
+//        BaseMessage msg = new EventMessage(event);
+//        client.send(msg);
+//
+//        var filters = Filters.builder().kinds(new KindList(4)).authors(new PublicKeyList(sender)).build();
+//        msg = new ReqMessage("testNip42_" + sender.toString(), filters);
+//        client.send(msg);
+//    }
+//*/
+//
+//    private int getRelayCount() {
+//        Properties properties = new Properties();
+//        try (InputStream is = getClass().getClassLoader().getResourceAsStream("relays.properties")) {
+//            if (is != null) {
+//                properties.load(is);
+//            } else {
+//                throw new IOException("Cannot find relays.properties on the classpath");
+//            }
+//        } catch (IOException e) {
+//            e.printStackTrace();
+//        }
+//        return properties.size();
+//    }
+//}

--- a/nostr-java-test/src/test/java/nostr/test/client/ClientTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/client/ClientTest.java
@@ -1,114 +1,114 @@
-//package nostr.test.client;
-//
-//import nostr.base.PrivateKey;
-//import nostr.client.Client;
-//import nostr.context.impl.DefaultRequestContext;
-//import nostr.event.BaseMessage;
-//import nostr.event.message.EventMessage;
-//import nostr.id.Identity;
-//import nostr.test.EntityFactory;
-//import org.junit.jupiter.api.Assertions;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//
-//import java.io.IOException;
-//import java.io.InputStream;
-//import java.util.Map;
-//import java.util.Properties;
-//import java.util.concurrent.TimeoutException;
-//
-//import static org.junit.jupiter.api.Assertions.assertTrue;
-//
-///**
-// * @author squirrel
-// */
-//class ClientTest {
-//
-//    private Client client;
-//    private Identity identity;
-//
-//    public ClientTest() {
-//    }
-//
-//    @BeforeEach
-//    public void init() {
-//        System.out.println("init");
-//        identity = Identity.create(PrivateKey.generateRandomPrivKey());
-//
-//        var requestContext = new DefaultRequestContext();
-//        requestContext.setPrivateKey(identity.getPrivateKey().getRawData());
-//        requestContext.setRelays(Map.of("My local test relay", "ws://localhost:5555"));
-//        try {
-//            client = Client.getInstance().connect(requestContext);
-//        } catch (TimeoutException e) {
-//            throw new RuntimeException(e);
-//        }
-//    }
-//
-//    //@AfterEach
-//    public void dispose() {
-//        System.out.println("dispose");
-//        try {
-//            this.client.disconnect();
-//        } catch (TimeoutException e) {
-//            throw new RuntimeException(e);
-//        }
-//        this.client = null;
-//        this.identity = null;
-//    }
-//
-//    @Test
-//    public void testSend() throws TimeoutException {
-//        System.out.println("testSend");
-//        var event = EntityFactory.Events.createTextNoteEvent(identity.getPublicKey());
-//        identity.sign(event);
-//        BaseMessage msg = new EventMessage(event);
-//
-//        client.send(msg);
-//
-//        assertTrue(true);
-//    }
-//
-//    @Test
-//    public void disconnect() throws TimeoutException {
-//        System.out.println("disconnect");
-//
-//        var relayCount = getRelayCount();
-//        Assertions.assertEquals(relayCount, client.getOpenConnectionsCount());
-//        client.disconnect();
-//
-//        Assertions.assertEquals(0, client.getOpenConnectionsCount());
-//    }
-//
-///*
-//    @Test
-//    public void testNip42() throws TimeoutException {
-//        System.out.println("testNip42");
-//
-//        var rcpt = Identity.generateRandomIdentity().getPublicKey();
-//        var sender = identity.getPublicKey();
-//        var event = EntityFactory.Events.createDirectMessageEvent(sender, rcpt, "Hello, World!");
-//        identity.sign(event);
-//        BaseMessage msg = new EventMessage(event);
-//        client.send(msg);
-//
-//        var filters = Filters.builder().kinds(new KindList(4)).authors(new PublicKeyList(sender)).build();
-//        msg = new ReqMessage("testNip42_" + sender.toString(), filters);
-//        client.send(msg);
-//    }
-//*/
-//
-//    private int getRelayCount() {
-//        Properties properties = new Properties();
-//        try (InputStream is = getClass().getClassLoader().getResourceAsStream("relays.properties")) {
-//            if (is != null) {
-//                properties.load(is);
-//            } else {
-//                throw new IOException("Cannot find relays.properties on the classpath");
-//            }
-//        } catch (IOException e) {
-//            e.printStackTrace();
-//        }
-//        return properties.size();
-//    }
-//}
+package nostr.test.client;
+
+import nostr.base.PrivateKey;
+import nostr.client.Client;
+import nostr.context.impl.DefaultRequestContext;
+import nostr.event.BaseMessage;
+import nostr.event.message.EventMessage;
+import nostr.id.Identity;
+import nostr.test.EntityFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author squirrel
+ */
+class ClientTest {
+
+    private Client client;
+    private Identity identity;
+
+    public ClientTest() {
+    }
+
+    @BeforeEach
+    public void init() {
+        System.out.println("init");
+        identity = Identity.create(PrivateKey.generateRandomPrivKey());
+
+        var requestContext = new DefaultRequestContext();
+        requestContext.setPrivateKey(identity.getPrivateKey().getRawData());
+        requestContext.setRelays(Map.of("My local test relay", "ws://localhost:5555"));
+        try {
+            client = Client.getInstance().connect(requestContext);
+        } catch (TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //@AfterEach
+    public void dispose() {
+        System.out.println("dispose");
+        try {
+            this.client.disconnect();
+        } catch (TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+        this.client = null;
+        this.identity = null;
+    }
+
+    @Test
+    public void testSend() throws TimeoutException {
+        System.out.println("testSend");
+        var event = EntityFactory.Events.createTextNoteEvent(identity.getPublicKey());
+        identity.sign(event);
+        BaseMessage msg = new EventMessage(event);
+
+        client.send(msg);
+
+        assertTrue(true);
+    }
+
+    @Test
+    public void disconnect() throws TimeoutException {
+        System.out.println("disconnect");
+
+        var relayCount = getRelayCount();
+        Assertions.assertEquals(relayCount, client.getOpenConnectionsCount());
+        client.disconnect();
+
+        Assertions.assertEquals(0, client.getOpenConnectionsCount());
+    }
+
+/*
+    @Test
+    public void testNip42() throws TimeoutException {
+        System.out.println("testNip42");
+
+        var rcpt = Identity.generateRandomIdentity().getPublicKey();
+        var sender = identity.getPublicKey();
+        var event = EntityFactory.Events.createDirectMessageEvent(sender, rcpt, "Hello, World!");
+        identity.sign(event);
+        BaseMessage msg = new EventMessage(event);
+        client.send(msg);
+
+        var filters = Filters.builder().kinds(new KindList(4)).authors(new PublicKeyList(sender)).build();
+        msg = new ReqMessage("testNip42_" + sender.toString(), filters);
+        client.send(msg);
+    }
+*/
+
+    private int getRelayCount() {
+        Properties properties = new Properties();
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream("relays.properties")) {
+            if (is != null) {
+                properties.load(is);
+            } else {
+                throw new IOException("Cannot find relays.properties on the classpath");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return properties.size();
+    }
+}

--- a/nostr-java-test/src/test/java/nostr/test/event/BaseTagTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/BaseTagTest.java
@@ -1,0 +1,27 @@
+package nostr.test.event;
+
+import nostr.event.BaseTag;
+import nostr.event.impl.GenericTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BaseTagTest {
+  BaseTag genericTag = GenericTag.create("id", 1, "value");
+
+  @Test
+  void getNip() {
+    assertEquals(1, genericTag.getNip());
+  }
+
+  @Test
+  void testHashCode() {
+    assertEquals(112174237, genericTag.hashCode());
+  }
+
+  @Test
+  void testToString() {
+    String result = "GenericTag(code=id, nip=1, attributes=[ElementAttribute(name=param0, value=value, nip=null)])";
+    assertEquals(result, genericTag.toString());
+  }
+}

--- a/nostr-java-test/src/test/java/nostr/test/event/KindMappingTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/KindMappingTest.java
@@ -1,0 +1,28 @@
+package nostr.test.event;
+
+import nostr.event.Kind;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KindMappingTest {
+  @Test
+  void testKindValueOf() {
+    assertEquals("1", Kind.valueOf(1).toString());
+  }
+
+  @Test
+  void testKindName() {
+    assertEquals("text_note", Kind.valueOf(1).getName());
+  }
+
+  @Test
+  void testKindValueOfUndefined() {
+    assertEquals("-1", Kind.valueOf(9999999).toString());
+  }
+
+  @Test
+  void testKindUndefinedName() {
+    assertEquals("undefined", Kind.valueOf(9999999).getName());
+  }
+}

--- a/nostr-java-test/src/test/java/nostr/test/event/NIP99ImplTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/NIP99ImplTest.java
@@ -8,98 +8,112 @@ import nostr.event.impl.GenericTag;
 import nostr.event.tag.PriceTag;
 import nostr.id.Identity;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class NIP99ImplTest {
+  public final static String CONTENT = "ClassifiedListingEvent unit test content";
+  public final static String UNIT_TEST_TITLE = "unit test title";
+  public final static String UNIT_TEST_SUMMARY = "unit test summary";
+  public final static String CURRENCY = "BTC";
+  public final static String MONTH = "MONTH";
+  public final static String LOCATION = "pangea";
+  public final static PriceTag PRICE_TAG = new PriceTag(BigDecimal.valueOf(11111), CURRENCY, MONTH);
+  public final static Long PUBLISHED_AT = 1716513986268L;
+  static ClassifiedListing classifiedListing;
+  static Identity sender;
+  static NIP99<ClassifiedListingEvent> nip99;
+
+  @BeforeAll
+  static void setup() {
+    classifiedListing = new ClassifiedListing(
+        UNIT_TEST_TITLE,
+        UNIT_TEST_SUMMARY,
+        PRICE_TAG
+    );
+    classifiedListing.setLocation(LOCATION);
+    classifiedListing.setPublishedAt(PUBLISHED_AT);
+    sender = Identity.generateRandomIdentity();
+    nip99 = new NIP99<>(sender);
+  }
 
   @Test
   void testNIP99CreateClassifiedListingEventWithAllOptionalParameters() {
     System.out.println("testNIP99CreateClassifiedListingEventWithAllOptionalParameters");
 
-    Identity sender = Identity.generateRandomIdentity();
     List<BaseTag> baseTags = new ArrayList<BaseTag>();
-    final String CONTENT = "ClassifiedListingEvent unit test content";
-
-    var nip99 = new NIP99<ClassifiedListingEvent>(sender);
-    String unitTestTitle = "unit test title";
-    String unitTestSummary = "unit test summary";
-    String currency = "BTC";
-    String month = "MONTH";
-    String location = "pangea";
-    Long publishedAt = 1716513986268L;
-
-    ClassifiedListing classifiedListing = new ClassifiedListing(
-        unitTestTitle,
-        unitTestSummary,
-        new PriceTag(BigDecimal.valueOf(11111), currency, month)
-    );
-    classifiedListing.setLocation(location);
-    classifiedListing.setPublishedAt(publishedAt);
-
     ClassifiedListingEvent instance = nip99.createClassifiedListingEvent(baseTags, CONTENT, classifiedListing).getEvent();
     instance.update();
 
-    Assertions.assertNotNull(instance.getId());
+    assertNotNull(instance.getId());
+    assertNull(instance.getClassifiedListing().getId());
+    assertEquals(UNIT_TEST_TITLE, instance.getClassifiedListing().getTitle());
+    assertEquals(UNIT_TEST_SUMMARY, instance.getClassifiedListing().getSummary());
+    assertEquals(PUBLISHED_AT, instance.getClassifiedListing().getPublishedAt());
+    assertEquals(LOCATION, instance.getClassifiedListing().getLocation());
+    assertEquals(PRICE_TAG, instance.getClassifiedListing().getPriceTag());
+
+    ClassifiedListing classifiedListing2 = new ClassifiedListing(
+        UNIT_TEST_TITLE,
+        UNIT_TEST_SUMMARY,
+        PRICE_TAG
+    );
+    classifiedListing2.setLocation(LOCATION);
+    classifiedListing2.setPublishedAt(PUBLISHED_AT);
+    ClassifiedListingEvent instance2 = nip99.createClassifiedListingEvent(baseTags, CONTENT, classifiedListing).getEvent();
+    instance.update();
+
+    assertEquals(instance, instance2);
+    assertEquals(instance.getClassifiedListing(), instance2.getClassifiedListing());
   }
 
   @Test
   void testNIP99CreateClassifiedListingEventWithoutOptionalParameters() {
     System.out.println("testNIP99CreateClassifiedListingEventWithoutOptionalParameters");
 
-    Identity sender = Identity.generateRandomIdentity();
     List<BaseTag> baseTags = new ArrayList<BaseTag>();
-    final String CONTENT = "ClassifiedListingEvent unit test content";
-
-    var nip99 = new NIP99<ClassifiedListingEvent>(sender);
-    String unitTestTitle = "unit test title";
-    String unitTestSummary = "unit test summary";
-    String currency = "BTC";
-    String month = "MONTH";
-
-    ClassifiedListing classifiedListing = new ClassifiedListing(
-        unitTestTitle,
-        unitTestSummary,
-        new PriceTag(BigDecimal.valueOf(11111), currency, month)
-    );
 
     ClassifiedListingEvent instance = nip99.createClassifiedListingEvent(baseTags, CONTENT, classifiedListing).getEvent();
     instance.update();
 
-    Assertions.assertNotNull(instance.getId());
+    assertNotNull(instance.getId());
   }
 
   @Test
   void testNIP99CreateClassifiedListingEventWithDuplicateParameters() {
     System.out.println("testNIP99CreateClassifiedListingEventWithDuplicateParameters");
 
-    Identity sender = Identity.generateRandomIdentity();
     List<BaseTag> baseTags = new ArrayList<BaseTag>();
-    final String CONTENT = "ClassifiedListingEvent unit test content";
 
     var nip99 = new NIP99<ClassifiedListingEvent>(sender);
-    String unitTestTitle = "unit test title";
-    String unitTestSummary = "unit test summary";
-    String currency = "BTC";
-    String month = "MONTH";
-    String location = "pangea";
-    Long publishedAt = 1716513986268L;
 
-    ClassifiedListing classifiedListing = new ClassifiedListing(
-        unitTestTitle,
-        unitTestSummary,
-        new PriceTag(BigDecimal.valueOf(11111), currency, month)
-    );
-    classifiedListing.setLocation(location);
-    classifiedListing.setPublishedAt(publishedAt);
+    classifiedListing.setLocation(LOCATION);
+    classifiedListing.setPublishedAt(PUBLISHED_AT);
 
-    baseTags.add(GenericTag.create("published_at", 99, String.valueOf(publishedAt)));
+    baseTags.add(GenericTag.create("published_at", 99, String.valueOf(PUBLISHED_AT)));
     ClassifiedListingEvent instance = nip99.createClassifiedListingEvent(baseTags, CONTENT, classifiedListing).getEvent();
     instance.update();
 
-    Assertions.assertNotNull(instance.getId());
+    assertNotNull(instance.getId());
+    assertEquals(LOCATION, instance.getClassifiedListing().getLocation());
+    assertEquals(PUBLISHED_AT, instance.getClassifiedListing().getPublishedAt());
+  }
+
+  @Test
+  void testNIP99CreateClassifiedListingEventNullParameters() {
+    System.out.println("testNIP99CreateClassifiedListingEventNullParameters");
+    assertThrows(NullPointerException.class, () -> new ClassifiedListing(null, UNIT_TEST_SUMMARY, PRICE_TAG));
+    assertThrows(NullPointerException.class, () -> new ClassifiedListing(UNIT_TEST_TITLE, null, PRICE_TAG));
+    assertThrows(NullPointerException.class, () -> new ClassifiedListing(UNIT_TEST_TITLE, UNIT_TEST_SUMMARY, null));
   }
 }

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -194,9 +194,10 @@ public class JsonParseTest {
             + "\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\""
             + "}]";
 
-        GenericEvent event = new GenericEventDecoder(classifiedListingEventJson).decode();
+        GenericEvent event = new GenericEventDecoder<>(classifiedListingEventJson).decode();
         EventMessage message = NIP01.createEventMessage(event, "1");
-        assertEquals("{\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\",\"kind\":30402,\"content\":\"content ipsum\",\"pubkey\":\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\",\"created_at\":1687765220,\"tags\":[[\"p\",\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\"],[\"title\",\"title ipsum\"],[\"summary\",\"summary ipsum\"],[\"published_at\",\"1687765220\"],[\"location\",\"location ipsum\"],[\"price\",\"11111\",\"BTC\",\"1\"]],\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\"}", new BaseEventEncoder((BaseEvent) message.getEvent()).encode());
+        assertEquals(1, message.getNip());
+        assertEquals("{\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\",\"kind\":30402,\"content\":\"content ipsum\",\"pubkey\":\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\",\"created_at\":1687765220,\"tags\":[[\"p\",\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\"],[\"title\",\"title ipsum\"],[\"summary\",\"summary ipsum\"],[\"published_at\",\"1687765220\"],[\"location\",\"location ipsum\"],[\"price\",\"11111\",\"BTC\",\"1\"]],\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\"}", new BaseEventEncoder<>((BaseEvent) message.getEvent()).encode());
 
         assertEquals("28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a", event.getId());
         assertEquals(30402, event.getKind());

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -61,16 +61,16 @@ public class JsonParseTest {
         assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((ReqMessage) message).getSubscriptionId());
         assertEquals(1, ((ReqMessage) message).getFiltersList().size());
 
-        Filters filters = ((ReqMessage<?>) message).getFiltersList().getList().get(0);
+        var filters = ((ReqMessage<?>) message).getFiltersList().getList().get(0);
 
         assertEquals(1, filters.getKinds().size());
         assertEquals(1, filters.getKinds().getList().get(0));
 
         assertEquals(1, filters.getAuthors().size());
-        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", filters.getAuthors().getList().get(0));
+        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((PublicKey)filters.getAuthors().getList().get(0)).toBech32String());
 
         assertEquals(1, filters.getReferencedEvents().size());
-        assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", filters.getReferencedEvents().getList().get(0));
+        assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", ((EventList<GenericEvent>)filters.getReferencedEvents()).getList().get(0).getId());
     }
 
     @Test
@@ -287,7 +287,7 @@ public class JsonParseTest {
         genericTagQuery.setValue(geohashList);
         Filters filters = Filters.builder().genericTagQuery(genericTagQuery).build();
 
-        ReqMessage reqMessage = new ReqMessage("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9", new FiltersList(Filters.class, filters));
+        ReqMessage reqMessage = new ReqMessage("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9", new FiltersList(filters));
         BaseMessageEncoder encoder = new BaseMessageEncoder(reqMessage);
         String jsonMessage = encoder.encode();
 

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -61,13 +61,13 @@ public class JsonParseTest {
         assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((ReqMessage) message).getSubscriptionId());
         assertEquals(1, ((ReqMessage) message).getFiltersList().size());
 
-        var filters = ((ReqMessage<?>) message).getFiltersList().getList().get(0);
+        var filters = ((ReqMessage<Filters>) message).getFiltersList().getList().get(0);
 
         assertEquals(1, filters.getKinds().size());
         assertEquals(1, filters.getKinds().getList().get(0));
 
         assertEquals(1, filters.getAuthors().size());
-        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((PublicKey)filters.getAuthors().getList().get(0)).toBech32String());
+        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((PublicKey) filters.getAuthors().getList().get(0)).toBech32String());
 
         assertEquals(1, filters.getReferencedEvents().size());
         assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", ((EventList<GenericEvent>)filters.getReferencedEvents()).getList().get(0).getId());
@@ -77,7 +77,7 @@ public class JsonParseTest {
     public void testBaseReqMessageEncoder() {
         System.out.println("testBaseReqMessageEncoder");
 
-        final var filtersList = new FiltersList(Filters.class);
+        final var filtersList = new FiltersList();
         var publicKey = Identity.generateRandomIdentity().getPublicKey();
         filtersList.add(Filters.builder().authors(new PublicKeyList(publicKey)).kinds(new KindList(3, 5)).build());
         filtersList.add(Filters.builder().kinds(new KindList(0, 1)).build());

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -61,23 +61,23 @@ public class JsonParseTest {
         assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((ReqMessage) message).getSubscriptionId());
         assertEquals(1, ((ReqMessage) message).getFiltersList().size());
 
-        var filters = ((ReqMessage) message).getFiltersList().getList().get(0);
+        Filters filters = ((ReqMessage<?>) message).getFiltersList().getList().get(0);
 
         assertEquals(1, filters.getKinds().size());
-        assertEquals(1, filters.getKinds().getList().get(0).intValue());
+        assertEquals(1, filters.getKinds().getList().get(0));
 
         assertEquals(1, filters.getAuthors().size());
-        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", filters.getAuthors().getList().get(0).toBech32String());
+        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", filters.getAuthors().getList().get(0));
 
         assertEquals(1, filters.getReferencedEvents().size());
-        assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", filters.getReferencedEvents().getList().get(0).getId());
+        assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", filters.getReferencedEvents().getList().get(0));
     }
 
     @Test
     public void testBaseReqMessageEncoder() {
         System.out.println("testBaseReqMessageEncoder");
 
-        final var filtersList = new FiltersList();
+        final var filtersList = new FiltersList(Filters.class);
         var publicKey = Identity.generateRandomIdentity().getPublicKey();
         filtersList.add(Filters.builder().authors(new PublicKeyList(publicKey)).kinds(new KindList(3, 5)).build());
         filtersList.add(Filters.builder().kinds(new KindList(0, 1)).build());
@@ -287,7 +287,7 @@ public class JsonParseTest {
         genericTagQuery.setValue(geohashList);
         Filters filters = Filters.builder().genericTagQuery(genericTagQuery).build();
 
-        ReqMessage reqMessage = new ReqMessage("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9", new FiltersList(filters));
+        ReqMessage reqMessage = new ReqMessage("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9", new FiltersList(Filters.class, filters));
         BaseMessageEncoder encoder = new BaseMessageEncoder(reqMessage);
         String jsonMessage = encoder.encode();
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -141,6 +142,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
systematic base-level generics (mis)configuration results in improper/forced downstream (over)casting use- which propagates further abuse/misuse of generic types.  this PR rectifies those base-level issues and all existing classes that use them.

below is a general description of PR code changes or jump directly to PR code diffs and refer to the description here as contextual reference for code changes.

note: although numerous, each PR change is quite small, including unit tests- which all continue to pass.  

to that end, i've also introduced [jacoco code-coverage metrics/report plugin](https://www.jacoco.org/jacoco/trunk/index.html) as a part of this PR.  jacoco is lightweight java developer community standard unit/integration- testing tool which integrates automatically into maven build process (via maven-surefire plugin) and generates useful  visual/navigable metrics for every class' code coverage/un-coverage.  

to view/nagivate the report/metrics- perform your build as usual then simply point a browser to:

`nostr-java-test/target/site/jacoco-aggregate/index.html`

![nostr-java-test-jacoco-report](https://github.com/tcheeric/nostr-java/assets/5356510/24c84389-a85e-4f21-bef9-6feee1ed2a9f)

----

description of PR changes:
----

##### IElement

since IElement is not appropriate for classes which are not nips:
`Filters`
`GenericTagQuery`

the use of:
`GenericTagQuery implements IElement`
`Filters extends BaseEvent (which implements IElement)`

are now refactored to proper form:
`GenericTagQuery`
`Filters`

----
##### IDecoder

`IDecoder<IElement>` now properly properly genericized as `IDecoder<T extends IElement>`

formerly used via:
`GenericEventDecoder implements IDecoder<BaseMessage>`
`Nip05ContentDecoder implements IDecoder<BaseMessage>`   
`BaseMessageDecoder  implements IDecoder<BaseMessage>`
`GenericTagDecoder   implements IDecoder<BaseMessage>`
`BaseTagDecoder      implements IDecoder<BaseMessage>`

now refactored to proper generic form:
`GenericEventDecoder<T extends GenericEvent> implements IDecoder<T>`
`Nip05ContentDecoder<T extends Nip05Content> implements IDecoder<T>`
`BaseMessageDecoder <T extends BaseMessage>  implements IDecoder<T>`
`GenericTagDecoder  <T extends GenericTag>   implements IDecoder<T>`
`BaseTagDecoder     <T extends BaseTag>      implements IDecoder<T>`

###### decoding non-NIP classes  
###

since IElement is not appropriate for classes which are not nips:
`Filters`
`GenericTagQuery`

the use of `IDecoder<IElement>` is contextually incorrect for those classes.  `FDecoder<T>` has been introduced for them instead.

formerly used via:
`FiltersDecoder         implements IDecoder<Filters>`
`FiltersListDecoder     implements IDecoder<FiltersList>`
`GenericTagQueryDecoder implements IDecoder<GenericTagQuery>`

now refactored to proper generic form:
`FiltersDecoder                                    implements FDecoder<Filters>`
`FiltersListDecoder                                implements FDecoder<Filters>`
`GenericTagQueryDecoder<T extends GenericTagQuery> implements FDecoder<T>`

----
#### IEncoder

`IEncoder<IElement>`
	now properly properly genericized as:
`IEncoder<T extends IElement>`

formerly used via:
`BaseEventEncoder   implements IEncoder<BaseEvent>`
`BaseMessageEncoder implements IEncoder<BaseMessage>`
`GenericTagEncoder  implements IEncoder<GenericTag>`

now refactored to proper generic form:
`BaseEventEncoder  <T extends BaseEvent>   implements IEncoder<T>`
`BaseMessageEncoder<T extends BaseMessage> implements IEncoder<T>`
`GenericTagEncoder <T extends GenericTag>  implements IEncoder<T>`

###### encoding non-NIP classes
###


since IElement is not appropriate for classes which are not nips:
`Filters`
`GenericTagQuery`

the use of `IEncoder<IElement>` is contextually incorrect for those classes.  `FDecoder<T>` has been introduced for them instead.

formerly used via:
`FiltersEncoder         extends BaseEventEncoder (which implements IEncoder<T>)`
`FiltersListEncoder     extends BaseEventEncoder (which implements IEncoder<T>)`
`GenericTagQueryEncoder                                 implements IEncoder<GenericTagQuery>`

now refactored to proper generic form:
`FiltersEncoder                                    implements FEncoder<T>`
`FiltersListEncoder                                implements FEncoder<T>`
`GenericTagQueryEncoder<T extends GenericTagQuery> implements FEncoder<T>`

----
#### deserializers

`JsonDeserializer<[some explicit type]>` now properly properly genericized as `JsonDeserializer<T>`

formerly used via:
`CustomGenericTagQueryListDeserializer extends JsonDeserializer<GenericTagQueryList>`
`CustomGenericTagQueryListSerializer   extends JsonSerializer<GenericTagQueryList>`
`CustomPublicKeyListDeserializer       extends JsonDeserializer<PublicKeyList>`
`CustomEventListDeserializer           extends JsonDeserializer<EventList>`
`CustomIdEventListSerializer           extends JsonSerializer<EventList>`
`CustomBaseListSerializer              extends JsonSerializer<BaseList>`

now refactored to proper generic form:
`CustomGenericTagQueryListDeserializer<T extends GenericTagQueryList<U>, U extends GenericTagQuery> extends JsonDeserializer<T>`
`CustomGenericTagQueryListSerializer  <T extends GenericTagQueryList<U>, U extends GenericTagQuery> extends JsonSerializer<T>`
`CustomPublicKeyListDeserializer      <T extends PublicKeyList<U>,       U extends PublicKey>       extends JsonDeserializer<T>`
`CustomEventListDeserializer          <T extends EventList<U>,           U extends GenericEvent>    extends JsonDeserializer<T>`
`CustomIdEventListSerializer          <T extends EventList<U>,           U extends GenericEvent>    extends JsonSerializer<T>`
`CustomBaseListSerializer             <T extends BaseList<U>,            U extends BaseEvent>       extends JsonSerializer<T>`

----
#### INostrList

since `interface INostrList<T> extends IElement` exclusively pushes List responsibilies up to implementing classes, it has been converted to an abstracdt class w/ generic behavior refactored into it.

formerly used via:
`BaseList<T> implements INostrList<T>`

now refactored to proper generic form:
`BaseList<T extends BaseEvent> extends INostrList<T> implements IElement`
 
and it's subclasses formerly used via:
`EventList extends BaseList<GenericEvent>`
now refactored to proper generic form
`EventList<T extends GenericEvent> extends BaseList<T>`

----
#### BaseList

since BaseList is not appropriate for classes which are not nips:
`FiltersList`

the use of `extends BaseList<[some explicit type]>` is contextually incorrect for those classes.  `FNostrList<T>` has been introduced for them instead.

formerly used via:
`GenericTagQueryList extends BaseList<GenericTagQuery>  (which implements INostrList<T>)`
`PublicKeyList       extends BaseList<PublicKey>`
`KindList            extends BaseList<Integer>          (which implements INostrList<T>)`

now refactored to proper generic form
`GenericTagQueryList<T extends GenericTagQuery> extends FNostrList<T>`
`PublicKeyList      <T extends PublicKey>       extends INostrList<T>`
`KindList                                       extends FNostrList<Integer>`
     
----
#### Filters

formerly 
`Filters extends BaseEvent`
now simply:
`Filters`