### PR TITLE
TagDeserializer refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ To use the library in your project, add the following dependency to your pom.xml
 </dependency>
 ```
 
-I recommend having a look at the [nostr-example](https://github.com/tcheeric/nostr-java/tree/main/nostr-java-examples) module and the [nostr-client](https://github.com/tcheeric/nostr-client/) project for a simple example on how to use the library.
+I recommend having a look at:
+  - [nostr-example](https://github.com/tcheeric/nostr-java/tree/main/nostr-java-examples) module
+  - [nostr-client](https://github.com/tcheeric/nostr-client/) project
+  - [SuperConductor](https://github.com/avlo/superconductor) nostr relay
+
+for simple examples on how to use the library.
 
 ## Supported NIPs
 The following NIPs are supported by the API out-of-the-box:

--- a/nostr-java-event/src/main/java/nostr/event/impl/GenericTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/GenericTag.java
@@ -41,18 +41,16 @@ public class GenericTag extends BaseTag implements IGenericElement {
     }
 
     public static GenericTag create(String code, Integer nip, String... params) {
-        List<ElementAttribute> attributes = new ArrayList<>();
-        for (int i = 0; i < params.length; i++) {
-            String name = "param" + i;
-            var p = params[i];
-            attributes.add(i, ElementAttribute.builder().name(name).value(p).build());
-        }
-        return new GenericTag(code, nip, attributes);
+        return create(code, nip, List.of(params));
     }
 
-    public static GenericTag create(String code, Integer nip, String param) {
+    public static GenericTag create(String code, Integer nip, List<String> params) {
         List<ElementAttribute> attributes = new ArrayList<>();
-        attributes.add(0, ElementAttribute.builder().name("param0").value(param).build());
+        for (int i = 0; i < params.size(); i++) {
+            String name = "param" + i;
+            var p = params.get(i);
+            attributes.add(i, ElementAttribute.builder().name(name).value(p).build());
+        }
         return new GenericTag(code, nip, attributes);
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/TagDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/TagDeserializer.java
@@ -4,23 +4,25 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
-
-import java.io.IOException;
-import nostr.base.PublicKey;
 import nostr.event.BaseTag;
-import nostr.event.Marker;
 import nostr.event.json.codec.GenericTagDecoder;
 import nostr.event.tag.EventTag;
+import nostr.event.tag.GeohashTag;
+import nostr.event.tag.HashtagTag;
 import nostr.event.tag.NonceTag;
+import nostr.event.tag.PriceTag;
 import nostr.event.tag.PubKeyTag;
+import nostr.event.tag.RelaysTag;
 import nostr.event.tag.SubjectTag;
+
+import java.io.IOException;
 
 public class TagDeserializer<T extends BaseTag> extends JsonDeserializer<T> {
 
     @Override
     public T deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
-        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
 
+        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
         // Extract relevant data from the JSON node
         String code = node.get(0).asText();
 
@@ -28,78 +30,18 @@ public class TagDeserializer<T extends BaseTag> extends JsonDeserializer<T> {
             throw new IOException("Unknown tag code: " + null);
         } else // Perform custom deserialization logic based on the concrete class
         {
-            switch (code) {
-                case "p" -> {
-                    // Deserialization logic for ConcreteTag1
-                    PubKeyTag tag = new PubKeyTag();
+            return switch (code) {
+                case "e" -> EventTag.deserialize(node);
+                case "g" -> GeohashTag.deserialize(node);
+                case "p" -> PubKeyTag.deserialize(node);
+                case "t" -> HashtagTag.deserialize(node);
 
-                    final JsonNode nodePubKey = node.get(1);
-                    if (nodePubKey != null) {
-                        tag.setPublicKey(new PublicKey(nodePubKey.asText()));
-                    }
-
-                    final JsonNode nodeMainUrl = node.get(2);
-                    if (nodeMainUrl != null) {
-                        tag.setMainRelayUrl(nodeMainUrl.asText());
-                    }
-
-                    final JsonNode nodePetName = node.get(3);
-                    if (nodePetName != null) {
-                        tag.setPetName(nodePetName.asText());
-                    }
-
-                    return (T) tag;
-                }
-
-                case "nonce" -> {
-                    // Deserialization logic for ConcreteTag2
-                    NonceTag tag = new NonceTag();
-
-                    final JsonNode nodeNonce = node.get(1);
-                    if (nodeNonce != null) {
-                        tag.setNonce(Integer.valueOf(nodeNonce.asText()));
-                    }
-
-                    final JsonNode nodeDifficulty = node.get(2);
-                    if (nodeDifficulty != null) {
-                        tag.setDifficulty(Integer.valueOf(nodeDifficulty.asText()));
-                    }
-                    return (T) tag;
-                }
-                case "e" -> {
-                    // Deserialization logic for ConcreteTag2
-                    EventTag tag = new EventTag();
-
-                    final JsonNode nodeIdEvent = node.get(1);
-                    if (nodeIdEvent != null) {
-                        tag.setIdEvent(nodeIdEvent.asText());
-                    }
-
-                    final JsonNode nodeRelay = node.get(2);
-                    if (nodeRelay != null) {
-                        tag.setRecommendedRelayUrl(nodeRelay.asText());
-                    }
-
-                    final JsonNode nodeMarker = node.get(3);
-                    if (nodeMarker != null) {
-                        tag.setMarker(Marker.valueOf(nodeMarker.asText().toUpperCase()));
-                    }
-                    return (T) tag;
-                }
-                case "subject" -> {
-                    SubjectTag tag = new SubjectTag();
-
-                    final JsonNode nodeSubject = node.get(1);
-                    if (nodeSubject != null) {
-                        tag.setSubject(nodeSubject.asText());
-                    }
-                    return (T) tag;
-                }
-                default -> {
-                    return (T) new GenericTagDecoder<>().decode(node.toString());
-                }
-
-            }
+                case "nonce" -> NonceTag.deserialize(node);
+                case "price" -> PriceTag.deserialize(node);
+                case "relays" -> RelaysTag.deserialize(node);
+                case "subject" -> SubjectTag.deserialize(node);
+                default -> (T) new GenericTagDecoder<>().decode(node.toString());
+            };
         }
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/serializer/RelaysTagSerializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/serializer/RelaysTagSerializer.java
@@ -14,7 +14,7 @@ public class RelaysTagSerializer extends JsonSerializer<RelaysTag> {
   @Override
   public void serialize(@NonNull RelaysTag relaysTag, @NonNull JsonGenerator jsonGenerator, @NonNull SerializerProvider serializerProvider) throws IOException {
     jsonGenerator.writeStartArray();
-    jsonGenerator.writeFieldName("relays");
+    jsonGenerator.writeString("relays");
     relaysTag.getRelays().forEach(json -> writeString(jsonGenerator, json.getUri()));
     jsonGenerator.writeEndArray();
   }

--- a/nostr-java-event/src/main/java/nostr/event/tag/EventTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/EventTag.java
@@ -8,11 +8,13 @@ package nostr.event.tag;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import nostr.base.annotation.Key;
 import nostr.base.annotation.Tag;
 import nostr.event.BaseTag;
@@ -49,5 +51,25 @@ public class EventTag extends BaseTag {
         this.recommendedRelayUrl = null;
         this.idEvent = idEvent;
         this.marker = this.idEvent == null ? Marker.ROOT : Marker.REPLY;
+    }
+
+    public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {
+        EventTag tag = new EventTag();
+
+        final JsonNode nodeIdEvent = node.get(1);
+        if (nodeIdEvent != null) {
+            tag.setIdEvent(nodeIdEvent.asText());
+        }
+
+        final JsonNode nodeRelay = node.get(2);
+        if (nodeRelay != null) {
+            tag.setRecommendedRelayUrl(nodeRelay.asText());
+        }
+
+        final JsonNode nodeMarker = node.get(3);
+        if (nodeMarker != null) {
+            tag.setMarker(Marker.valueOf(nodeMarker.asText().toUpperCase()));
+        }
+        return (T) tag;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/GeohashTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/GeohashTag.java
@@ -1,11 +1,13 @@
 package nostr.event.tag;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import nostr.base.annotation.Key;
 import nostr.base.annotation.Tag;
 import nostr.event.BaseTag;
@@ -25,4 +27,15 @@ public class GeohashTag extends BaseTag {
     @Key
     @JsonProperty("g")
     private String location;
+
+    public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {
+        GeohashTag tag = new GeohashTag();
+
+        final JsonNode nodePubKey = node.get(1);
+        if (nodePubKey != null) {
+            tag.setLocation(nodePubKey.asText());
+        }
+
+        return (T) tag;
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/HashtagTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/HashtagTag.java
@@ -1,11 +1,13 @@
 package nostr.event.tag;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import nostr.base.annotation.Key;
 import nostr.base.annotation.Tag;
 import nostr.event.BaseTag;
@@ -26,4 +28,14 @@ public class HashtagTag extends BaseTag {
     @JsonProperty("t")
     private String hashTag;
 
+    public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {
+        HashtagTag tag = new HashtagTag();
+
+        final JsonNode nodePubKey = node.get(1);
+        if (nodePubKey != null) {
+            tag.setHashTag(nodePubKey.asText());
+        }
+
+        return (T) tag;
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/NonceTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/NonceTag.java
@@ -3,6 +3,7 @@ package nostr.event.tag;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
 import nostr.base.annotation.Key;
 import nostr.event.BaseTag;
 import lombok.Builder;
@@ -35,5 +36,20 @@ public class NonceTag extends BaseTag {
     public NonceTag(@NonNull Integer nonce, @NonNull Integer difficulty) {
         this.nonce = nonce;
         this.difficulty = difficulty;
+    }
+
+    public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {
+        NonceTag tag = new NonceTag();
+
+        final JsonNode nodeNonce = node.get(1);
+        if (nodeNonce != null) {
+            tag.setNonce(Integer.valueOf(nodeNonce.asText()));
+        }
+
+        final JsonNode nodeDifficulty = node.get(2);
+        if (nodeDifficulty != null) {
+            tag.setDifficulty(Integer.valueOf(nodeDifficulty.asText()));
+        }
+        return (T) tag;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/PriceTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/PriceTag.java
@@ -1,5 +1,6 @@
 package nostr.event.tag;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -9,6 +10,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import nostr.base.annotation.Key;
 import nostr.base.annotation.Tag;
 import nostr.event.BaseTag;
 
@@ -23,22 +25,26 @@ import java.util.Optional;
 @AllArgsConstructor
 @JsonPropertyOrder({"number", "currency", "frequency"})
 public class PriceTag extends BaseTag {
-  @JsonProperty
-  private final BigDecimal number;
 
+  @Key
   @JsonProperty
-  private final String currency;
+  @JsonFormat(shape = JsonFormat.Shape.STRING)
+  private BigDecimal number;
 
+  @Key
+  @JsonProperty
+  private String currency;
+
+  @Key
   @JsonProperty
   private String frequency;
 
   public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {
-    final JsonNode number = Optional.ofNullable(node.get(1)).orElseThrow();
-    final JsonNode currency = Optional.ofNullable(node.get(2)).orElseThrow();
+    String text = Optional.ofNullable(node.get(1)).orElseThrow().asText();
+    final BigDecimal number = new BigDecimal(text);
+    final String currency = Optional.ofNullable(node.get(2)).orElseThrow().asText();
 
-    PriceTag tag = new PriceTag(
-        new BigDecimal(number.bigIntegerValue()),
-        currency.asText());
+    PriceTag tag = PriceTag.builder().number(number).currency(currency).build();
     Optional.ofNullable(node.get(3)).ifPresent(jsonNode1 -> tag.setFrequency(jsonNode1.asText()));
 
     return (T) tag;

--- a/nostr-java-event/src/main/java/nostr/event/tag/PriceTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/PriceTag.java
@@ -2,20 +2,25 @@ package nostr.event.tag;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import nostr.base.annotation.Tag;
 import nostr.event.BaseTag;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 @Builder
 @Data
 @EqualsAndHashCode(callSuper = true)
 @Tag(code = "price", nip = 99)
 @RequiredArgsConstructor
+@AllArgsConstructor
 @JsonPropertyOrder({"number", "currency", "frequency"})
 public class PriceTag extends BaseTag {
   @JsonProperty
@@ -25,5 +30,17 @@ public class PriceTag extends BaseTag {
   private final String currency;
 
   @JsonProperty
-  private final String frequency;
+  private String frequency;
+
+  public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {
+    final JsonNode number = Optional.ofNullable(node.get(1)).orElseThrow();
+    final JsonNode currency = Optional.ofNullable(node.get(2)).orElseThrow();
+
+    PriceTag tag = new PriceTag(
+        new BigDecimal(number.bigIntegerValue()),
+        currency.asText());
+    Optional.ofNullable(node.get(3)).ifPresent(jsonNode1 -> tag.setFrequency(jsonNode1.asText()));
+
+    return (T) tag;
+  }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/PubKeyTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/PubKeyTag.java
@@ -8,7 +8,7 @@ package nostr.event.tag;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -53,5 +53,26 @@ public class PubKeyTag extends BaseTag {
         this.publicKey = publicKey;
         this.mainRelayUrl = mainRelayUrl;
         this.petName = petName;
+    }
+
+    public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {
+        PubKeyTag tag = new PubKeyTag();
+
+        final JsonNode nodePubKey = node.get(1);
+        if (nodePubKey != null) {
+            tag.setPublicKey(new PublicKey(nodePubKey.asText()));
+        }
+
+        final JsonNode nodeMainUrl = node.get(2);
+        if (nodeMainUrl != null) {
+            tag.setMainRelayUrl(nodeMainUrl.asText());
+        }
+
+        final JsonNode nodePetName = node.get(3);
+        if (nodePetName != null) {
+            tag.setPetName(nodePetName.asText());
+        }
+
+        return (T) tag;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/RelaysTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/RelaysTag.java
@@ -1,5 +1,6 @@
 package nostr.event.tag;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;
 import lombok.Data;
@@ -11,6 +12,7 @@ import nostr.event.BaseTag;
 import nostr.event.json.serializer.RelaysTagSerializer;
 
 import java.util.List;
+import java.util.Optional;
 
 @Builder
 @Data
@@ -26,5 +28,9 @@ public class RelaysTag extends BaseTag {
 
   public RelaysTag(@NonNull Relay... relays) {
     this(List.of(relays));
+  }
+
+  public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {
+    return (T) new RelaysTag(Optional.of(node).stream().map(jsonNode -> new Relay(jsonNode.asText())).toList());
   }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/RelaysTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/RelaysTag.java
@@ -31,6 +31,6 @@ public class RelaysTag extends BaseTag {
   }
 
   public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {
-    return (T) new RelaysTag(Optional.of(node).stream().map(jsonNode -> new Relay(jsonNode.asText())).toList());
+    return (T) new RelaysTag(Optional.of(node).stream().map(jsonNode -> new Relay(jsonNode.get(1).asText())).toList());
   }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/SubjectTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/SubjectTag.java
@@ -3,11 +3,13 @@ package nostr.event.tag;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import nostr.base.annotation.Key;
 import nostr.base.annotation.Tag;
 import nostr.event.BaseTag;
@@ -28,4 +30,14 @@ public final class SubjectTag extends BaseTag {
     @Key
     @JsonProperty("subject")
     private String subject;
+
+    public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {
+        SubjectTag tag = new SubjectTag();
+
+        final JsonNode nodeSubject = node.get(1);
+        if (nodeSubject != null) {
+            tag.setSubject(nodeSubject.asText());
+        }
+        return (T) tag;
+    }
 }

--- a/nostr-java-test/src/test/java/nostr/test/event/BaseTagTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/BaseTagTest.java
@@ -1,7 +1,10 @@
 package nostr.test.event;
 
+import lombok.SneakyThrows;
+import nostr.base.PublicKey;
 import nostr.event.BaseTag;
 import nostr.event.impl.GenericTag;
+import nostr.event.tag.PubKeyTag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -12,6 +15,14 @@ class BaseTagTest {
   @Test
   void getNip() {
     assertEquals(1, genericTag.getNip());
+  }
+
+  @SneakyThrows
+  @Test
+  void getSupportedFields() {
+    String sha256 = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+    PubKeyTag pubKeyTag = new PubKeyTag(new PublicKey(sha256));
+    assertEquals(sha256, pubKeyTag.getFieldValue(pubKeyTag.getSupportedFields().stream().findFirst().orElseThrow()));
   }
 
   @Test

--- a/nostr-java-test/src/test/java/nostr/test/event/BaseTagTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/BaseTagTest.java
@@ -1,10 +1,7 @@
 package nostr.test.event;
 
-import lombok.SneakyThrows;
-import nostr.base.PublicKey;
 import nostr.event.BaseTag;
 import nostr.event.impl.GenericTag;
-import nostr.event.tag.PubKeyTag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -15,14 +12,6 @@ class BaseTagTest {
   @Test
   void getNip() {
     assertEquals(1, genericTag.getNip());
-  }
-
-  @SneakyThrows
-  @Test
-  void getSupportedFields() {
-    String sha256 = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
-    PubKeyTag pubKeyTag = new PubKeyTag(new PublicKey(sha256));
-    assertEquals(sha256, pubKeyTag.getFieldValue(pubKeyTag.getSupportedFields().stream().findFirst().orElseThrow()));
   }
 
   @Test

--- a/nostr-java-test/src/test/java/nostr/test/event/EventTagTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/EventTagTest.java
@@ -1,0 +1,46 @@
+package nostr.test.event;
+
+import nostr.event.Marker;
+import nostr.event.tag.EventTag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EventTagTest {
+  @Test
+  void getSupportedFields() {
+    String eventId = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
+    String recommendedRelayUrl = "ws://localhost:5555";
+
+    EventTag eventTag = new EventTag(eventId);
+    eventTag.setMarker(Marker.REPLY);
+    eventTag.setRecommendedRelayUrl(recommendedRelayUrl);
+
+    assertDoesNotThrow(() -> {
+      List<Field> fields = eventTag.getSupportedFields();
+      assertTrue(fields.stream().anyMatch(field -> field.getName().equals("idEvent")));
+      assertTrue(fields.stream().anyMatch(field -> field.getName().equals("recommendedRelayUrl")));
+      assertTrue(fields.stream().anyMatch(field -> field.getName().equals("marker")));
+
+      assertTrue(fields.stream().map(field -> getFieldValue(field, eventTag)).anyMatch(fieldValue -> fieldValue.equals(eventId)));
+      assertTrue(fields.stream().map(field -> getFieldValue(field, eventTag)).anyMatch(fieldValue -> fieldValue.equalsIgnoreCase(Marker.REPLY.getValue())));
+      assertTrue(fields.stream().map(field -> getFieldValue(field, eventTag)).anyMatch(fieldValue -> fieldValue.equals(recommendedRelayUrl)));
+
+      assertFalse(fields.stream().anyMatch(field -> field.getName().equals("idEventXXX")));
+      assertFalse(fields.stream().map(field -> getFieldValue(field, eventTag)).anyMatch(fieldValue -> fieldValue.equals(eventId + "x")));
+    });
+  }
+
+  private String getFieldValue(Field field, EventTag eventTag) {
+    final String[] returnVal = new String[1];
+    assertDoesNotThrow(() -> {
+      returnVal[0] = eventTag.getFieldValue(field);
+    });
+    return returnVal[0];
+  }
+}

--- a/nostr-java-test/src/test/java/nostr/test/event/PriceTagTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/PriceTagTest.java
@@ -1,0 +1,23 @@
+package nostr.test.event;
+
+import nostr.event.tag.PriceTag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PriceTagTest {
+  @Test
+  void getSupportedFields() {
+    PriceTag priceTag = new PriceTag(new BigDecimal(11111), "BTC", "NANOSECONDS");
+    assertDoesNotThrow(() -> {
+      List<Field> list = priceTag.getSupportedFields().stream().toList();
+      assertTrue(List.of("number", "currency", "frequency").containsAll(list.stream().map(Field::getName).toList()));
+      assertTrue(List.of("java.math.BigDecimal", "java.lang.String").containsAll(list.stream().map(field -> field.getAnnotatedType().toString()).toList()));
+    });
+  }
+}

--- a/nostr-java-test/src/test/java/nostr/test/event/PubkeyTagTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/PubkeyTagTest.java
@@ -1,0 +1,24 @@
+package nostr.test.event;
+
+import nostr.base.PublicKey;
+import nostr.event.tag.PubKeyTag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PubkeyTagTest {
+  @Test
+  void getSupportedFields() {
+    String sha256 = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+    PubKeyTag pubKeyTag = new PubKeyTag(new PublicKey(sha256));
+    assertDoesNotThrow(() -> {
+      Field field = pubKeyTag.getSupportedFields().stream().findFirst().orElseThrow();
+      assertEquals("nostr.base.PublicKey", field.getAnnotatedType().toString());
+      assertEquals("publicKey", field.getName());
+      assertEquals(sha256, pubKeyTag.getFieldValue(field));
+    });
+  }
+}

--- a/nostr-java-test/src/test/java/nostr/test/event/RelaysTagTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/RelaysTagTest.java
@@ -1,0 +1,29 @@
+package nostr.test.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nostr.event.BaseTag;
+import nostr.event.tag.RelaysTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RelaysTagTest {
+
+  public final static String RELAYS_KEY = "relays";
+  public final static String HOST_VALUE = "ws://localhost:5555";
+  @Test
+  void testDeserializer() throws JsonProcessingException {
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode node = mapper.readTree("[\"relays\",\"ws://localhost:5555\"]");
+
+    assertDoesNotThrow(() -> {
+      BaseTag deserialize = RelaysTag.deserialize(node);
+      assertEquals(RELAYS_KEY, deserialize.getCode());
+      assertEquals(HOST_VALUE, ((RelaysTag) deserialize).getRelays().get(0).getUri());
+    });
+  }
+}

--- a/nostr-java-test/src/test/java/nostr/test/event/RelaysTagTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/RelaysTagTest.java
@@ -3,22 +3,37 @@ package nostr.test.event;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nostr.base.Relay;
 import nostr.event.BaseTag;
+import nostr.event.json.codec.BaseTagEncoder;
 import nostr.event.tag.RelaysTag;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RelaysTagTest {
-
   public final static String RELAYS_KEY = "relays";
   public final static String HOST_VALUE = "ws://localhost:5555";
-  @Test
-  void testDeserializer() throws JsonProcessingException {
+  public final static String HOST_VALUE2 = "ws://anotherlocalhost:5432";
+  ObjectMapper mapper = new ObjectMapper();
 
-    ObjectMapper mapper = new ObjectMapper();
-    JsonNode node = mapper.readTree("[\"relays\",\"ws://localhost:5555\"]");
+  @Test
+  void testSerialize() {
+    final String expected = "[\"relays\",\"ws://localhost:5555\",\"ws://anotherlocalhost:5432\"]";
+    RelaysTag relaysTag = new RelaysTag(List.of(new Relay(HOST_VALUE), new Relay(HOST_VALUE2)));
+    BaseTagEncoder baseTagEncoder = new BaseTagEncoder(relaysTag);
+    assertDoesNotThrow(() -> {
+      assertEquals(expected, baseTagEncoder.encode());
+    });
+  }
+
+  @Test
+  void testDeserialize() throws JsonProcessingException {
+    final String EXPECTED = "[\"relays\",\"ws://localhost:5555\"]";
+    JsonNode node = new ObjectMapper().readTree(EXPECTED);
 
     assertDoesNotThrow(() -> {
       BaseTag deserialize = RelaysTag.deserialize(node);


### PR DESCRIPTION
[TagDeserializer](https://github.com/avlo/nostr-java-avlo-fork/blob/deserializer_refactor/nostr-java-event/src/main/java/nostr/event/json/deserializer/TagDeserializer.java) deserialization logic refactored (and cleaned up) into the following classes, which extend BaseTag (as opposed to their previously being accommodated as GenericTags).  

Eachs' deserialization is now polymorphic (i.e.,  deserialization logic is implemented by each class as per its specific need):

```java
  nostr-java-event/src/main/java/nostr/event/tag/EventTag.java
  nostr-java-event/src/main/java/nostr/event/tag/GeohashTag.java
  nostr-java-event/src/main/java/nostr/event/tag/HashtagTag.java
  nostr-java-event/src/main/java/nostr/event/tag/NonceTag.java
  nostr-java-event/src/main/java/nostr/event/tag/PriceTag.java
  nostr-java-event/src/main/java/nostr/event/tag/PubKeyTag.java
  nostr-java-event/src/main/java/nostr/event/tag/RelaysTag.java
  nostr-java-event/src/main/java/nostr/event/tag/SubjectTag.java
```
additionally:
  - GenericTag additional constructor with List parameter (as opposed to just variad String...) and cleanup.
  - unit tests for all the above

Comment/suggest/deliberation/etc on this PR are welcome, otherwise I will merge ~48hours from now (Saturday, June 15 2024, 01:15:30 2024 UTC)