### PR TITLE
EventMessage "subscriptionId" related updates

### DIFF
--- a/nostr-java-api/src/main/java/nostr/api/NIP01.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP01.java
@@ -226,9 +226,7 @@ public class NIP01<T extends NIP01Event> extends EventNostr<T> {
      * @return an event message
      */
     public static EventMessage createEventMessage(@NonNull IEvent event, @NonNull String subscriptionId) {
-        var result = new EventMessageFactory(event).create();
-        result.setSubscriptionId(subscriptionId);
-        return result;
+        return new EventMessageFactory(event, subscriptionId).create();
     }
 
     /**

--- a/nostr-java-api/src/main/java/nostr/api/factory/impl/NIP01Impl.java
+++ b/nostr-java-api/src/main/java/nostr/api/factory/impl/NIP01Impl.java
@@ -127,8 +127,9 @@ public class NIP01Impl {
         private final IEvent event;
         private String subscriptionId;
 
-        public EventMessageFactory(@NonNull IEvent event) {
-            this.event = event;
+        public EventMessageFactory(@NonNull IEvent event, @NonNull String subscriptionId) {
+          this.event = event;
+          this.subscriptionId = subscriptionId;
         }
 
         @Override

--- a/nostr-java-event/src/main/java/nostr/event/message/CanonicalAuthenticationMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/CanonicalAuthenticationMessage.java
@@ -7,16 +7,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.SneakyThrows;
 import nostr.base.Command;
 import nostr.base.IEncoder;
+import nostr.base.Relay;
 import nostr.event.BaseMessage;
 import nostr.event.impl.CanonicalAuthenticationEvent;
+import nostr.event.impl.GenericEvent;
+import nostr.event.impl.GenericTag;
 import nostr.event.json.codec.BaseEventEncoder;
 
+import java.util.List;
 import java.util.Map;
 
 /**
- *
  * @author eric
  */
 @Setter
@@ -39,8 +43,26 @@ public class CanonicalAuthenticationMessage extends BaseAuthMessage {
                 new BaseEventEncoder<>(getEvent()).encode())));
   }
 
+  @SneakyThrows
   public static <T extends BaseMessage> T decode(@NonNull Map map, ObjectMapper mapper) {
-    var event = mapper.convertValue(map, new TypeReference<CanonicalAuthenticationEvent>() {});
-    return (T) new CanonicalAuthenticationMessage(event);
+    var event = mapper.convertValue(map, new TypeReference<GenericEvent>() {});
+
+    List<GenericTag> genericTags = event.getTags().stream()
+        .filter(GenericTag.class::isInstance)
+        .map(GenericTag.class::cast).toList();
+
+    CanonicalAuthenticationEvent canonEvent = new CanonicalAuthenticationEvent(
+        event.getPubKey(),
+        getAttributeValue(genericTags, "challenge"),
+        new Relay(
+            getAttributeValue(genericTags, "relay")));
+    canonEvent.setId(map.get("id").toString());
+
+    return (T) new CanonicalAuthenticationMessage(canonEvent);
+  }
+
+  private static String getAttributeValue(List<GenericTag> genericTags, String attributeName) {
+    return genericTags.stream()
+        .filter(tag -> tag.getCode().equalsIgnoreCase(attributeName)).map(GenericTag::getAttributes).toList().get(0).get(0).getValue().toString();
   }
 }

--- a/nostr-java-event/src/main/java/nostr/event/message/EventMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/EventMessage.java
@@ -42,6 +42,7 @@ public class EventMessage extends BaseMessage {
         return IEncoder.MAPPER.writeValueAsString(
             getArrayNode()
                 .add(getCommand())
+                .add(getSubscriptionId())
                 .add(IEncoder.MAPPER.readTree(
                     new BaseEventEncoder<>((BaseEvent)getEvent()).encode())));
     }


### PR DESCRIPTION
- added [NIP01 ***relay-to-client*** required (constructor parameter) "subscriptionId"](https://nostr-nips.com/nip-01#from-relay-to-client-sending-events-and-notices) to EventMessageFactory
```html
["EVENT", <subscription_id>, <event JSON as defined above>], used to send events requested by clients.
                 ↑
```
- fixed EventMessage.createEventMessage(...) create sequence
- added required arrayNode item "subscriptionId" to EventMessage encoder
- fixed CanonicalAuthenticationMessage decoder

unit/integration tests all pass as per usual