### PR TITLE
Req message validation

### DIFF
--- a/nostr-java-base/src/main/java/nostr/base/Signature.java
+++ b/nostr-java-base/src/main/java/nostr/base/Signature.java
@@ -31,7 +31,7 @@ public class Signature {
 
     public static Signature fromString(String sig) {
       Signature signature = new Signature();
-      signature.setRawData(NostrUtil.hexToBytes(sig));
+      signature.setRawData(NostrUtil.hex128ToBytes(sig));
       return signature;
     }
 }

--- a/nostr-java-crypto/src/main/java/nostr/crypto/nip04/EncryptedDirectMessage.java
+++ b/nostr-java-crypto/src/main/java/nostr/crypto/nip04/EncryptedDirectMessage.java
@@ -79,7 +79,7 @@ public class EncryptedDirectMessage {
     private static byte[] getSharedSecret(String privateKeyHex, String publicKeyHex) {
 
         SecP256K1Curve curve = new SecP256K1Curve();
-        ECPoint pubKeyPt = curve.decodePoint(NostrUtil.hexToBytes("02" + publicKeyHex));
+        ECPoint pubKeyPt = curve.decodePoint(NostrUtil.nip04PubKeyHexToBytes("02" + publicKeyHex));
         BigInteger tweakVal = new BigInteger(1, NostrUtil.hexToBytes(privateKeyHex));
         return pubKeyPt.multiply(tweakVal).getEncoded(true);
     }

--- a/nostr-java-event/src/main/java/nostr/event/Kind.java
+++ b/nostr-java-event/src/main/java/nostr/event/Kind.java
@@ -50,7 +50,7 @@ public enum Kind {
     @JsonCreator
     public static Kind valueOf(int value) {
         if (!ValueRange.of(0, 65535).isValidIntValue(value)) {
-            throw new IllegalArgumentException(String.format("Kind must be between 0 and 65536 but was [%d]", value));
+            throw new IllegalArgumentException(String.format("Kind must be between 0 and 65535 but was [%d]", value));
         }
         for (Kind k : values()) {
             if (k.getValue() == value) {

--- a/nostr-java-event/src/main/java/nostr/event/Kind.java
+++ b/nostr-java-event/src/main/java/nostr/event/Kind.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.temporal.ValueRange;
+
 /**
  *
  * @author squirrel
@@ -47,6 +49,9 @@ public enum Kind {
 
     @JsonCreator
     public static Kind valueOf(int value) {
+        if (!ValueRange.of(0, 65535).isValidIntValue(value)) {
+            throw new IllegalArgumentException(String.format("Kind must be between 0 and 65536 but was [%d]", value));
+        }
         for (Kind k : values()) {
             if (k.getValue() == value) {
                 return k;

--- a/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateStallEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateStallEvent.java
@@ -36,21 +36,21 @@ public class CreateOrUpdateStallEvent extends NostrMarketplaceEvent {
 
         @JsonProperty
         private final String id;
-        
+
         @JsonProperty
         private String name;
-        
+
         @JsonProperty
         private String description;
-        
+
         @JsonProperty
         private String currency;
-        
+
         @JsonProperty
-        private Shipping shipping;        
+        private Shipping shipping;
 
         public Stall() {
-            this.id = UUID.randomUUID().toString();
+            this.id = UUID.randomUUID().toString().concat(UUID.randomUUID().toString()).substring(0, 64);
         }
 
         @Data
@@ -58,13 +58,13 @@ public class CreateOrUpdateStallEvent extends NostrMarketplaceEvent {
 
             @JsonProperty
             private final String id;
-            
+
             @JsonProperty
             private String name;
-            
+
             @JsonProperty
             private Float cost;
-            
+
             @JsonProperty
             private List<String> countries;
 

--- a/nostr-java-event/src/main/java/nostr/event/impl/Filters.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/Filters.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.Setter;
 import nostr.base.PublicKey;
 import nostr.base.annotation.Key;
@@ -65,6 +66,20 @@ public class Filters {
     @Key(nip = 12)
     @Setter(AccessLevel.NONE)
     private Map<String, List<String>> genericTagQuery;
+
+    public void setUntil(@NonNull Long until) {
+        if (until < 0) {
+            throw new IllegalArgumentException("'until' filter cannot be negative.");
+        }
+        this.until = until;
+    }
+
+    public void setSince(@NonNull Long since) {
+        if (since < 0) {
+            throw new IllegalArgumentException("'since' filter cannot be negative.");
+        }
+        this.since = since;
+    }
 
     @JsonAnyGetter
     public Map<String, List<String>> getGenericTagQuery() {

--- a/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
@@ -98,7 +98,7 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
 
     public GenericEvent(@NonNull String id) {
         this();
-        this.id = id;
+        setId(id);
     }
 
     public GenericEvent(@NonNull PublicKey pubKey, @NonNull Kind kind) {
@@ -126,6 +126,11 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
 
         // Update parents
         updateTagsParents(tags);
+    }
+
+    public void setId(String id) {
+        NostrUtil.validateHexString(id, 64);
+        this.id = id;
     }
 
     @Override

--- a/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
@@ -26,6 +26,7 @@ import nostr.event.json.deserializer.PublicKeyDeserializer;
 import nostr.event.json.deserializer.SignatureDeserializer;
 import nostr.util.NostrException;
 import nostr.util.NostrUtil;
+import nostr.util.thread.HexStringValidator;
 
 import java.beans.Transient;
 import java.nio.charset.StandardCharsets;
@@ -129,7 +130,7 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
     }
 
     public void setId(String id) {
-        NostrUtil.validateHexString(id, 64);
+        HexStringValidator.validateHex(id, 64);
         this.id = id;
     }
 

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/SignatureDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/SignatureDeserializer.java
@@ -11,14 +11,14 @@ import nostr.base.Signature;
 import nostr.util.NostrUtil;
 
 public class SignatureDeserializer extends JsonDeserializer<Signature> {
-            
+
     @Override
     public Signature deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
         ObjectMapper objectMapper = (ObjectMapper) jsonParser.getCodec();
         JsonNode node = objectMapper.readTree(jsonParser);
 
         String sigValue = node.asText();
-        byte[] rawData = NostrUtil.hexToBytes(sigValue);
+        byte[] rawData = NostrUtil.hex128ToBytes(sigValue);
 
         Signature signature = new Signature();
         signature.setRawData(rawData);

--- a/nostr-java-event/src/main/java/nostr/event/message/ReqMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/ReqMessage.java
@@ -14,6 +14,7 @@ import nostr.event.BaseMessage;
 import nostr.event.impl.Filters;
 import nostr.event.json.codec.FiltersEncoder;
 
+import java.time.temporal.ValueRange;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,12 +33,15 @@ public class ReqMessage extends BaseMessage {
     @JsonProperty
     private final List<Filters> filtersList;
 
-    public ReqMessage(String subscriptionId, Filters filters) {
+    public ReqMessage(@NonNull String subscriptionId, Filters filters) {
         this(subscriptionId, List.of(filters));
     }
 
-    public ReqMessage(String subscriptionId, List<Filters> incomingFiltersList) {
+    public ReqMessage(@NonNull String subscriptionId, List<Filters> incomingFiltersList) {
         super(Command.REQ.name());
+        if (!ValueRange.of(1, 64).isValidIntValue(subscriptionId.length())) {
+            throw new IllegalArgumentException(String.format("subscriptionId length must be between 1 and 64 characters but was [%d]", subscriptionId.length()));
+        }
         this.subscriptionId = subscriptionId;
         this.filtersList = new ArrayList<>();
         this.filtersList.addAll(incomingFiltersList);

--- a/nostr-java-test/src/test/java/nostr/test/base/BaseKeyTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/base/BaseKeyTest.java
@@ -1,0 +1,80 @@
+package nostr.test.base;
+
+import nostr.base.PublicKey;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BaseKeyTest {
+  public static final String VALID_HEXPUBKEY = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+  public static final String INVALID_HEXPUBKEY_NON_HEX_DIGITS = "XYZdf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+  public static final String INVALID_HEXPUBKEY_LENGTH_TOO_SHORT = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6";
+  public static final String INVALID_HEXPUBKEY_LENGTH_TOO_LONG = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f666";
+  public static final String VALID_HEXPUBKEY_ALL_ZEROS = "0000000000000000000000000000000000000000000000000000000000000000";
+  public static final String VALID_HEXPUBKEY_ALL_FF = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+  public static final String INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+  public static final String INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6F";
+
+  @Test
+  public void testValidPublicKeyString() {
+    System.out.println("testValidPublicKeyString");
+    assertDoesNotThrow(() -> new PublicKey(VALID_HEXPUBKEY));
+  }
+
+  @Test
+  public void testValidPublicKeyByteArray() {
+    System.out.println("testValidPublicKeyByteArray");
+    assertDoesNotThrow(() -> new PublicKey(VALID_HEXPUBKEY.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  public void testInValidNullPublicKeyString() {
+    System.out.println("testInValidNullPublicKeyString");
+    assertThrows(IllegalArgumentException.class, () -> new PublicKey(""));
+  }
+
+  @Test
+  public void testInValidPublicKeyNonHexDigits() {
+    System.out.println("testInValidPublicKeyNonHexDigits");
+    assertThrows(IllegalArgumentException.class, () -> new PublicKey(INVALID_HEXPUBKEY_NON_HEX_DIGITS));
+  }
+
+  @Test
+  public void testInValidPublicKeyLengthTooShort() {
+    System.out.println("testInValidPublicKeyLengthTooShort");
+    assertThrows(IllegalArgumentException.class, () -> new PublicKey(INVALID_HEXPUBKEY_LENGTH_TOO_SHORT));
+  }
+
+  @Test
+  public void testInValidPublicKeyLengthTooLong() {
+    System.out.println("testInValidPublicKeyLengthTooShort");
+    assertThrows(IllegalArgumentException.class, () -> new PublicKey(INVALID_HEXPUBKEY_LENGTH_TOO_LONG));
+  }
+
+  @Test
+  public void testValidPublicKeyAllZeros() {
+    System.out.println("testValidPublicKeyAllZeros");
+    assertDoesNotThrow(() -> new PublicKey(VALID_HEXPUBKEY_ALL_ZEROS));
+  }
+
+  @Test
+  public void testValidPublicKeyAllFF() {
+    System.out.println("testValidPublicKeyAllFF");
+    assertDoesNotThrow(() -> new PublicKey(VALID_HEXPUBKEY_ALL_FF));
+  }
+
+  @Test
+  public void testInvalidPublicKeyMultipleUppercase() {
+    System.out.println("testInvalidPublicKeyMultipleUppercase");
+    assertThrows(IllegalArgumentException.class, () -> new PublicKey(INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE));
+  }
+
+  @Test
+  public void testInvalidPublicKeySingleUppercase() {
+    System.out.println("testInvalidPublicKeySingleUppercase");
+    assertThrows(IllegalArgumentException.class, () -> new PublicKey(INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE));
+  }
+}

--- a/nostr-java-test/src/test/java/nostr/test/base/NostrUtilTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/base/NostrUtilTest.java
@@ -1,9 +1,31 @@
 package nostr.test.base;
 
+import lombok.extern.java.Log;
+import nostr.util.NostrException;
+import nostr.util.NostrUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
- *
  * @author squirrel
  */
+@Log
 public class NostrUtilTest {
-
+  /**
+   * test intended to confirm conversion routines:
+   *    (1) Hex string to byte[], then
+   *    (2) btye[] back to Hex string
+   * are properly functioning inversions of each other
+   */
+  @Test
+  public void testHexToBytesHex() throws NostrException {
+    System.out.println("testBech32HexToBytesToBech32");
+    String pubKeyString = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+    assertEquals(
+        pubKeyString,
+        NostrUtil.bytesToHex( // (2)
+            NostrUtil.hexToBytes( // (1)
+                pubKeyString)));
+  }
 }

--- a/nostr-java-test/src/test/java/nostr/test/base/NostrUtilTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/base/NostrUtilTest.java
@@ -1,7 +1,6 @@
 package nostr.test.base;
 
 import lombok.extern.java.Log;
-import nostr.util.NostrException;
 import nostr.util.NostrUtil;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +18,7 @@ public class NostrUtilTest {
    * are properly functioning inversions of each other
    */
   @Test
-  public void testHexToBytesHex() throws NostrException {
+  public void testHexToBytesHex() {
     System.out.println("testBech32HexToBytesToBech32");
     String pubKeyString = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
     assertEquals(

--- a/nostr-java-test/src/test/java/nostr/test/base/NostrUtilTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/base/NostrUtilTest.java
@@ -14,12 +14,12 @@ public class NostrUtilTest {
   /**
    * test intended to confirm conversion routines:
    *    (1) Hex string to byte[], then
-   *    (2) btye[] back to Hex string
+   *    (2) byte[] back to Hex string
    * are properly functioning inversions of each other
    */
   @Test
   public void testHexToBytesHex() {
-    System.out.println("testBech32HexToBytesToBech32");
+    log.info("testHexToBytesHex");
     String pubKeyString = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
     assertEquals(
         pubKeyString,

--- a/nostr-java-test/src/test/java/nostr/test/event/ApiEventTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/ApiEventTest.java
@@ -62,7 +62,7 @@ public class ApiEventTest {
   public void testNIP01CreateTextNoteEvent() throws NostrException {
     System.out.println("testNIP01CreateTextNoteEvent");
 
-    PublicKey publicKey = new PublicKey("");
+    PublicKey publicKey = new PublicKey(NOSTR_JAVA_PUBKEY);
     var recipient = NIP01.createPubKeyTag(publicKey);
     List<BaseTag> tags = new ArrayList<>();
     tags.add(recipient);

--- a/nostr-java-test/src/test/java/nostr/test/event/EventTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/EventTest.java
@@ -50,21 +50,6 @@ public class EventTest {
     }
 
     @Test
-    public void testEventIdConstraints() {
-        log.info("testCreateTextNoteEvent");
-        PublicKey publicKey = Identity.generateRandomIdentity().getPublicKey();
-        GenericEvent genericEvent = EntityFactory.Events.createTextNoteEvent(publicKey);
-        String id64chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
-        assertDoesNotThrow(() -> genericEvent.setId(id64chars));
-
-        String id63chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71";
-        assertThrows(IllegalArgumentException.class, () -> genericEvent.setId(id63chars));
-
-        String id65chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71";
-        assertThrows(IllegalArgumentException.class, () -> genericEvent.setId(id65chars));
-    }
-
-    @Test
     public void testCreateGenericTag() {
         log.info("testCreateGenericTag");
         PublicKey publicKey = Identity.generateRandomIdentity().getPublicKey();
@@ -175,5 +160,24 @@ public class EventTest {
 
         var muattr = (msg.getAttributes().iterator().next().getValue()).toString();
         assertEquals(attr, muattr);
+    }
+
+    @Test
+    public void testEventIdConstraints() {
+        log.info("testCreateTextNoteEvent");
+        PublicKey publicKey = Identity.generateRandomIdentity().getPublicKey();
+        GenericEvent genericEvent = EntityFactory.Events.createTextNoteEvent(publicKey);
+        String id64chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
+        assertDoesNotThrow(() -> genericEvent.setId(id64chars));
+
+        String id63chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71";
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> genericEvent.setId(id63chars))
+                .getMessage().contains("[fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71], length: [63], target length: [64]"));
+
+        String id65chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123";
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> genericEvent.setId(id65chars))
+                .getMessage().contains("[fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123], length: [65], target length: [64]"));;
     }
 }

--- a/nostr-java-test/src/test/java/nostr/test/event/EventTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/EventTest.java
@@ -158,7 +158,7 @@ public class EventTest {
         String attr = "challenge-string";
         msg.addAttribute(ElementAttribute.builder().name("challenge").value(attr).build());
 
-        var muattr = (msg.getAttributes().iterator().next().getValue()).toString();
+        var muattr = (msg.getAttributes().getFirst().getValue()).toString();
         assertEquals(attr, muattr);
     }
 
@@ -178,6 +178,6 @@ public class EventTest {
         String id65chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123";
         assertTrue(
             assertThrows(IllegalArgumentException.class, () -> genericEvent.setId(id65chars))
-                .getMessage().contains("[fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123], length: [65], target length: [64]"));;
+                .getMessage().contains("[fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123], length: [65], target length: [64]"));
     }
 }

--- a/nostr-java-test/src/test/java/nostr/test/event/EventTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/EventTest.java
@@ -50,6 +50,21 @@ public class EventTest {
     }
 
     @Test
+    public void testEventIdConstraints() {
+        log.info("testCreateTextNoteEvent");
+        PublicKey publicKey = Identity.generateRandomIdentity().getPublicKey();
+        GenericEvent genericEvent = EntityFactory.Events.createTextNoteEvent(publicKey);
+        String id64chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
+        assertDoesNotThrow(() -> genericEvent.setId(id64chars));
+
+        String id63chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71";
+        assertThrows(IllegalArgumentException.class, () -> genericEvent.setId(id63chars));
+
+        String id65chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71";
+        assertThrows(IllegalArgumentException.class, () -> genericEvent.setId(id65chars));
+    }
+
+    @Test
     public void testCreateGenericTag() {
         log.info("testCreateGenericTag");
         PublicKey publicKey = Identity.generateRandomIdentity().getPublicKey();

--- a/nostr-java-test/src/test/java/nostr/test/event/KindMappingTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/KindMappingTest.java
@@ -15,14 +15,4 @@ public class KindMappingTest {
   void testKindName() {
     assertEquals("text_note", Kind.valueOf(1).getName());
   }
-
-  @Test
-  void testKindValueOfUndefined() {
-    assertEquals("-1", Kind.valueOf(9999999).toString());
-  }
-
-  @Test
-  void testKindUndefinedName() {
-    assertEquals("undefined", Kind.valueOf(9999999).getName());
-  }
 }

--- a/nostr-java-test/src/test/java/nostr/test/event/SignatureTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/event/SignatureTest.java
@@ -1,0 +1,20 @@
+package nostr.test.event;
+
+import nostr.base.Signature;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SignatureTest {
+  @Test
+  public void testSignatureStringLength() {
+    assertDoesNotThrow(() ->
+        Signature.fromString("86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546"));
+
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> Signature.fromString("86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546a"))
+            .getMessage().contains("[129], target length: [128]"));
+  }
+}

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -475,4 +475,20 @@ public class JsonParseTest {
             "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id63chars + "\"]}]";
         assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId63chars));
     }
+
+    @Test
+    public void testBaseMessageDecoderKind() {
+        log.info("testBaseMessageDecoderKind");
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget(0)));
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget(65535)));
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget(-1)));
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget(65536)));
+    }
+
+    private static String kindTarget(int kind) {
+        return "[\"REQ\", " +
+            "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+            "{\"kinds\": [" + kind + "]" +
+            "}]";
+    }
 }

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -106,7 +107,6 @@ public class JsonParseTest {
 
         final String parseTarget
             = "[\"EVENT\","
-            + "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\","
             + "{"
             + "\"content\":\"直んないわ。まあええか\","
             + "\"created_at\":1686199583,"
@@ -134,7 +134,6 @@ public class JsonParseTest {
 
         final String json = "["
             + "\"EVENT\","
-            + "\"temp20230627\","
             + "{"
             + "\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\","
             + "\"kind\":1,"
@@ -447,5 +446,32 @@ public class JsonParseTest {
         expectedFilters.setGenericTagQuery(uuidKey, expectedIdentityTagValuesList);
         ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
         assertEquals(expectedReqMessage, decodedReqMessage);
+    }
+
+    @Test
+    public void testReqMessageSubscriptionIdLength() {
+        log.info("testReqMessageSubscriptionIdLength");
+        String id65Chars = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9ab";
+        assertThrows(IllegalArgumentException.class, () -> new ReqMessage(id65Chars, new Filters()));
+//        assertDoesNotThrow(() -> new ReqMessage(id65Chars, new Filters()));
+    }
+
+    @Test
+    public void testReqMessageFilterIdLength() {
+        log.info("testReqMessageFilterIdLength");
+        String id64chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
+        String reqJsonId64Chars =
+            "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id64chars + "\"]}]";
+        assertDoesNotThrow(() -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId64Chars));
+
+        String id65chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123";
+        String reqJsonId65Chars =
+            "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id65chars + "\"]}]";
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId65Chars));
+
+        String id63chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71";
+        String reqJsonId63chars =
+            "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id63chars + "\"]}]";
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId63chars));
     }
 }

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -34,7 +34,6 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiPredicate;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -49,447 +48,504 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Log
 public class JsonParseTest {
 
-    @Test
-    public void testBaseMessageDecoder() {
-        log.info("testBaseMessageDecoder");
-
-        final String parseTarget =
-            "[\"REQ\", " +
-                "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
-                "{\"kinds\": [1], " +
-                "\"authors\": [\"f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75\"]," +
-                "\"#e\": [\"fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712\"]}]";
-
-        final var message = new BaseMessageDecoder<>().decode(parseTarget);
-
-        assertEquals(Command.REQ.toString(), message.getCommand());
-        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((ReqMessage) message).getSubscriptionId());
-        assertEquals(1, ((ReqMessage) message).getFiltersList().size());
-
-        var filters = ((ReqMessage) message).getFiltersList().get(0);
-
-        assertEquals(1, filters.getKinds().size());
-        assertEquals(Kind.TEXT_NOTE, filters.getKinds().get(0));
-
-        assertEquals(1, filters.getAuthors().size());
-        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", filters.getAuthors().get(0).toBech32String());
-
-        assertEquals(1, filters.getReferencedEvents().size());
-        assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", (filters.getReferencedEvents().get(0).getId()));
-    }
-
-    @Test
-    public void testBaseReqMessageDecoder() {
-        log.info("testBaseReqMessageDecoder");
-
-        final var filtersList = new ArrayList<Filters>();
-        var publicKey = Identity.generateRandomIdentity().getPublicKey();
-        filtersList.add(Filters.builder().authors(new ArrayList<>(List.of(publicKey))).kinds(new ArrayList<>(List.of(Kind.CONTACT_LIST, Kind.DELETION))).build());
-        filtersList.add(Filters.builder().kinds(new ArrayList<>(List.of(Kind.SET_METADATA, Kind.TEXT_NOTE))).build());
-        final var reqMessage = new ReqMessage(publicKey.toString(), filtersList);
-
-        assertDoesNotThrow(() -> {
-            String jsonMessage = reqMessage.encode();
-
-            String jsonMsg = jsonMessage.substring(1, jsonMessage.length() - 1);
-            String[] parts = jsonMsg.split(",");
-            assertEquals("\"REQ\"", parts[0]);
-            assertEquals("\"" + publicKey.toString() + "\"", parts[1]);
-            assertFalse(parts[2].startsWith("["));
-            assertFalse(parts[parts.length - 1].endsWith("]"));
-
-            BaseMessage message = new BaseMessageDecoder<>().decode(jsonMessage);
-
-            assertEquals(reqMessage, message);
-        });
-    }
-
-    @Test
-    public void testBaseEventMessageDecoder() {
-        log.info("testBaseEventMessageDecoder");
-
-        final String parseTarget
-            = "[\"EVENT\","
-            + "{"
-            + "\"content\":\"直んないわ。まあええか\","
-            + "\"created_at\":1686199583,"
-            + "\"id\":\"fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712\","
-            + "\"kind\":1,"
-            + "\"pubkey\":\"8c59239319637f97e007dad0d681e65ce35b1ace333b629e2d33f9465c132608\","
-            + "\"sig\":\"9584afd231c52fcbcec6ce668a2cc4b6dc9b4d9da20510dcb9005c6844679b4844edb7a2e1e0591958b0295241567c774dbf7d39a73932877542de1a5f963f4b\","
-            + "\"tags\":[]"
-            + "}]";
-
-        final var message = new BaseMessageDecoder<>().decode(parseTarget);
-
-        assertEquals(Command.EVENT.toString(), message.getCommand());
-
-        final var event = (GenericEvent) (((EventMessage) message).getEvent());
-        assertEquals(1, event.getKind().intValue());
-        assertEquals(1686199583, event.getCreatedAt().longValue());
-        assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", event.getId());
-    }
-
-    @Test
-    public void testBaseEventMessageMarkerDecoder() {
-        log.info("testBaseEventMessageMarkerDecoder");
-
-        final String json = "["
-            + "\"EVENT\","
-            + "{"
-            + "\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\","
-            + "\"kind\":1,"
-            + "\"pubkey\":\"2bed79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76984\","
-            + "\"created_at\":1687765220,"
-            + "\"content\":\"手順書が間違ってたら作業者は無理だな\","
-            + "\"tags\":["
-            + "[\"e\",\"494001ac0c8af2a10f60f23538e5b35d3cdacb8e1cc956fe7a16dfa5cbfc4346\",\"\",\"root\"],"
-            + "[\"p\",\"2bed79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76984\"]"
-            + "],"
-            + "\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\""
-            + "}]";
-
-        BaseMessage message = new BaseMessageDecoder<>().decode(json);
-
-        final var event = (GenericEvent) (((EventMessage) message).getEvent());
-        var tags = event.getTags();
-        for (BaseTag t : tags) {
-            if (t.getCode().equalsIgnoreCase("e")) {
-                EventTag et = (EventTag) t;
-                assertEquals(Marker.ROOT, et.getMarker());
-            }
-        }
-    }
-
-    @Test
-    public void testGenericTagDecoder() {
-        log.info("testGenericTagDecoder");
-        final String jsonString = "[\"saturn\", \"jetpack\", false]";
-
-        var tag = new GenericTagDecoder<>().decode(jsonString);
-
-        assertEquals("saturn", tag.getCode());
-        assertEquals(2, tag.getAttributes().size());
-        assertEquals("jetpack", ((ElementAttribute) (tag.getAttributes().toArray())[0]).getValue());
-        assertEquals(false, Boolean.valueOf(((ElementAttribute) (tag.getAttributes().toArray())[1]).getValue().toString()));
-    }
-
-    @Test
-    public void testClassifiedListingTagSerializer() {
-        log.info("testClassifiedListingSerializer");
-        final String classifiedListingEventJson = "{"
-            + "\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\","
-            + "\"kind\":30402,"
-            + "\"content\":\"content ipsum\","
-            + "\"pubkey\":\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\","
-            + "\"created_at\":1687765220,"
-            + "\"tags\":["
-            + "[\"p\",\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\"],"
-            + "[\"title\",\"title ipsum\"],"
-            + "[\"summary\",\"summary ipsum\"],"
-            + "[\"published_at\",\"1687765220\"],"
-            + "[\"location\",\"location ipsum\"],"
-            + "[\"price\",\"11111\",\"BTC\",\"1\"]],"
-            + "\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\""
-            + "}]";
-
-        GenericEvent event = new GenericEventDecoder<>().decode(classifiedListingEventJson);
-        EventMessage message = NIP01.createEventMessage(event, "1");
-        assertEquals(1, message.getNip());
-        String encoded = new BaseEventEncoder<>((BaseEvent) message.getEvent()).encode();
-        assertEquals("{\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\",\"kind\":30402,\"content\":\"content ipsum\",\"pubkey\":\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\",\"created_at\":1687765220,\"tags\":[[\"p\",\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\"],[\"title\",\"title ipsum\"],[\"summary\",\"summary ipsum\"],[\"published_at\",\"1687765220\"],[\"location\",\"location ipsum\"],[\"price\",\"11111\",\"BTC\",\"1\"]],\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\"}", encoded);
-
-        assertEquals("28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a", event.getId());
-        assertEquals(30402, event.getKind());
-        assertEquals("content ipsum", event.getContent());
-        assertEquals("ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de", event.getPubKey().toString());
-        assertEquals(1687765220L, event.getCreatedAt());
-        assertEquals("86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546", event.getSignature().toString());
-
-        assertEquals(new BigDecimal("11111"), event.getTags().stream().filter(baseTag ->
-                baseTag.getCode().equalsIgnoreCase("price"))
-            .filter(PriceTag.class::isInstance)
-            .map(PriceTag.class::cast)
-            .map(PriceTag::getNumber).findFirst().orElseThrow());
-
-        assertEquals("BTC", event.getTags().stream().filter(baseTag ->
-                baseTag.getCode().equalsIgnoreCase("price"))
-            .filter(PriceTag.class::isInstance)
-            .map(PriceTag.class::cast)
-            .map(PriceTag::getCurrency).findFirst().orElseThrow());
-
-        assertEquals("1", event.getTags().stream().filter(baseTag ->
-                baseTag.getCode().equalsIgnoreCase("price"))
-            .filter(PriceTag.class::isInstance)
-            .map(PriceTag.class::cast)
-            .map(PriceTag::getFrequency).findFirst().orElseThrow());
-
-        List<GenericTag> genericTags = event.getTags().stream()
-            .filter(GenericTag.class::isInstance)
-            .map(GenericTag.class::cast).toList();
-
-        assertEquals("title ipsum", genericTags.stream()
-            .filter(tag -> tag.getCode().equalsIgnoreCase("title")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
-
-        assertEquals("summary ipsum", genericTags.stream()
-            .filter(tag -> tag.getCode().equalsIgnoreCase("summary")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
-
-        assertEquals("1687765220", genericTags.stream()
-            .filter(tag -> tag.getCode().equalsIgnoreCase("published_at")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
-
-        assertEquals("location ipsum", genericTags.stream()
-            .filter(tag -> tag.getCode().equalsIgnoreCase("location")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
-    }
-
-    @Test
-    public void testDeserializeTag() {
-        log.info("testDeserializeTag");
-
-        assertDoesNotThrow(() -> {
-            String npubHex = new PublicKey(NostrUtil.hexToBytes(Bech32.fromBech32(("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9")))).toString();
-
-            final String jsonString = "[\"p\", \"" + npubHex + "\", \"wss://nostr.java\", \"alice\"]";
-            var tag = new BaseTagDecoder<>().decode(jsonString);
-
-            assertTrue(tag instanceof PubKeyTag);
-
-            PubKeyTag pTag = (PubKeyTag) tag;
-            assertEquals("wss://nostr.java", pTag.getMainRelayUrl());
-            assertEquals(npubHex, pTag.getPublicKey().toString());
-            assertEquals("alice", pTag.getPetName());
-        });
-    }
-
-    @Test
-    public void testDeserializeGenericTag() {
-        log.info("testDeserializeGenericTag");
-        assertDoesNotThrow(() -> {
-            String npubHex = new PublicKey(Bech32.decode("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9").data).toString();
-            final String jsonString = "[\"gt\", \"" + npubHex + "\", \"wss://nostr.java\", \"alice\"]";
-            var tag = new BaseTagDecoder<>().decode(jsonString);
-
-            assertTrue(tag instanceof GenericTag);
-
-            GenericTag gTag = (GenericTag) tag;
-            assertEquals("gt", gTag.getCode());
-        });
-    }
-
-    @Test
-    public void testFiltersEncoder() {
-        log.info("testFiltersEncoder");
-
-        String new_geohash = "2vghde";
-        List<String> geohashList = new ArrayList<>();
-        geohashList.add(new_geohash);
-        Filters filters = Filters.builder().genericTagQuery(Map.of("#g", geohashList)).build();
-
-        FiltersEncoder encoder = new FiltersEncoder(filters);
-        String jsonMessage = encoder.encode();
-        assertEquals("{\"#g\":[\"2vghde\"]}", jsonMessage);
-    }
-
-    @Test
-    public void testReqMessageFilterListSerializer() {
-        log.info("testReqMessageFilterListSerializer");
-
-        String new_geohash = "2vghde";
-        String second_geohash = "3abcde";
-        List<String> geohashList = new ArrayList<>();
-        geohashList.add(new_geohash);
-        geohashList.add(second_geohash);
-        Filters filters = Filters.builder().genericTagQuery(Map.of("#g", geohashList)).build();
-
-        ReqMessage reqMessage = new ReqMessage("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9", new ArrayList<Filters>(List.of(filters)));
-        assertDoesNotThrow(() -> {
-            String jsonMessage = reqMessage.encode();
-
-            assertEquals("[\"REQ\",\"npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9\",{\"#g\":[\"2vghde\",\"3abcde\"]}]", jsonMessage);
-        });
-    }
-
-    @Test
-    public void testReqMessageFiltersDecoder() {
-        log.info("testReqMessageFiltersDecoder");
-
-        String geohashKey = "#g";
-        String geohashValue = "2vghde";
-        String reqJsonWithCustomTagQueryFilterToDecode = "{\"" + geohashKey + "\":[\"" + geohashValue + "\"]}";
-
-        Filters decodedFilters = new FiltersDecoder<>().decode(reqJsonWithCustomTagQueryFilterToDecode);
-
-        Filters expectedFilters = new Filters();
-        List<String> expectedGeohashValueList = List.of(geohashValue);
-        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValueList);
-
-        assertEquals(expectedFilters, decodedFilters);
-    }
-
-    @Test
-    public void testReqMessageFiltersListDecoder() {
-        log.info("testReqMessageFiltersListDecoder");
-
-        String geohashKey = "#g";
-        String geohashValue1 = "2vghde";
-        String geohashValue2 = "3abcde";
-        String reqJsonWithCustomTagQueryFilterToDecode = "{\"" + geohashKey + "\":[\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]}";
-
-        Filters decodedFilters = new FiltersDecoder<>().decode(reqJsonWithCustomTagQueryFilterToDecode);
-
-        Filters expectedFilters = new Filters();
-        List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
-        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
-
-        assertEquals(expectedFilters, decodedFilters);
-    }
-
-    @Test
-    public void testReqMessageDeserializer() {
-        log.info("testReqMessageDeserializer");
-
-        String subscriptionId = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9";
-        String geohashKey = "#g";
-        String geohashValue = "2vghde";
-        String reqJsonWithCustomTagQueryFilterToDecode = "[\"REQ\",\"" + subscriptionId + "\",{\"" + geohashKey + "\":[\"" + geohashValue + "\"]}]";
-
-        ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
-
-        Filters expectedFilters = new Filters();
-        List<String> expectedGeohashValuesList = List.of(geohashValue);
-        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
-
-        ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
-        assertEquals(expectedReqMessage, decodedReqMessage);
-    }
-
-    @Test
-    public void testReqMessageFilterListDecoder() {
-        log.info("testReqMessageFilterListDecoder");
-
-        String subscriptionId = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9";
-        String geohashKey = "#g";
-        String geohashValue1 = "2vghde";
-        String geohashValue2 = "3abcde";
-        String reqJsonWithCustomTagQueryFiltersToDecode = "[\"REQ\",\"" + subscriptionId + "\",{\"" + geohashKey + "\":[\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]}]";
-
-        ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFiltersToDecode);
-
-        Filters expectedFilters = new Filters();
-        List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
-        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
-
-        ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
-        assertEquals(expectedReqMessage, decodedReqMessage);
-    }
-
-    @Test
-    public void testReqMessagePopulatedFilterDecoder() {
-        log.info("testReqMessagePopulatedFilterDecoder");
-
-        String subscriptionId = "npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh";
-        String kind = "1";
-        String author = "f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75";
-        String geohashKey = "#g";
-        String geohashValue1 = "2vghde";
-        String geohashValue2 = "3abcde";
-        String referencedEventId = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
-        String reqJsonWithCustomTagQueryFilterToDecode =
-            "[\"REQ\", " +
-                "\"" + subscriptionId + "\", " +
-                "{\"kinds\": [" + kind + "], " +
-                "\"authors\": [\"" + author + "\"]," +
-                "\"" + geohashKey + "\": [\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]," +
-                "\"#e\": [\"" + referencedEventId + "\"]}]";
-
-        ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
-
-        Filters expectedFilters = new Filters();
-        expectedFilters.setKinds(List.of(Kind.TEXT_NOTE));
-        expectedFilters.setAuthors(List.of(new PublicKey(author)));
-        expectedFilters.setReferencedEvents(List.of(new GenericEvent(referencedEventId)));
-        List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
-        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
-
-        ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
-        assertEquals(expectedReqMessage, decodedReqMessage);
-    }
-
-    @Test
-    public void testReqMessagePopulatedListOfFiltersListDecoder() {
-        log.info("testReqMessagePopulatedListOfFiltersListDecoder");
-
-        String subscriptionId = "npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh";
-        String kind = "1";
-        String author = "f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75";
-        String geohashKey = "#g";
-        String geohashValue1 = "2vghde";
-        String geohashValue2 = "3abcde";
-        String referencedEventId = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
-        String uuidKey = "#d";
-        String uuidValue1 = "UUID-1";
-        String uuidValue2 = "UUID-2";
-        String reqJsonWithCustomTagQueryFilterToDecode =
-            "[\"REQ\", " +
-                "\"" + subscriptionId + "\", " +
-                "{\"kinds\": [" + kind + "], " +
-                "\"authors\": [\"" + author + "\"]," +
-                "\"" + geohashKey + "\": [\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]," +
-                "\"" + uuidKey + "\": [\"" + uuidValue1 + "\",\"" + uuidValue2 + "\"]," +
-                "\"#e\": [\"" + referencedEventId + "\"]}]";
-
-        ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
-
-        Filters expectedFilters = new Filters();
-        expectedFilters.setKinds(List.of(Kind.TEXT_NOTE));
-        expectedFilters.setAuthors(List.of(new PublicKey(author)));
-        expectedFilters.setReferencedEvents(List.of(new GenericEvent(referencedEventId)));
-        List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
-        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
-        List<String> expectedIdentityTagValuesList = List.of(uuidValue1, uuidValue2);
-        expectedFilters.setGenericTagQuery(uuidKey, expectedIdentityTagValuesList);
-        ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
-        assertEquals(expectedReqMessage, decodedReqMessage);
-    }
-
-    @Test
-    public void testReqMessageSubscriptionIdLength() {
-        log.info("testReqMessageSubscriptionIdLength");
-        String id65Chars = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9ab";
-        assertThrows(IllegalArgumentException.class, () -> new ReqMessage(id65Chars, new Filters()));
-//        assertDoesNotThrow(() -> new ReqMessage(id65Chars, new Filters()));
-    }
-
-    @Test
-    public void testReqMessageFilterIdLength() {
-        log.info("testReqMessageFilterIdLength");
-        String id64chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
-        String reqJsonId64Chars =
-            "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id64chars + "\"]}]";
-        assertDoesNotThrow(() -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId64Chars));
-
-        String id65chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123";
-        String reqJsonId65Chars =
-            "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id65chars + "\"]}]";
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId65Chars));
-
-        String id63chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71";
-        String reqJsonId63chars =
-            "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id63chars + "\"]}]";
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId63chars));
-    }
-
-    @Test
-    public void testBaseMessageDecoderKind() {
-        log.info("testBaseMessageDecoderKind");
-
-        Function<Integer, String> kindTarget = kind -> "[\"REQ\", " +
+  @Test
+  public void testBaseMessageDecoder() {
+    log.info("testBaseMessageDecoder");
+
+    final String parseTarget =
+        "[\"REQ\", " +
             "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
-            "{\"kinds\": [" + kind + "]" +
-            "}]";
+            "{\"kinds\": [1], " +
+            "\"authors\": [\"f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75\"]," +
+            "\"#e\": [\"fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712\"]}]";
 
-        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(0)));
-        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(65535)));
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(-1)));
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(65536)));
+    final var message = new BaseMessageDecoder<>().decode(parseTarget);
+
+    assertEquals(Command.REQ.toString(), message.getCommand());
+    assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((ReqMessage) message).getSubscriptionId());
+    assertEquals(1, ((ReqMessage) message).getFiltersList().size());
+
+    var filters = ((ReqMessage) message).getFiltersList().get(0);
+
+    assertEquals(1, filters.getKinds().size());
+    assertEquals(Kind.TEXT_NOTE, filters.getKinds().get(0));
+
+    assertEquals(1, filters.getAuthors().size());
+    assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", filters.getAuthors().get(0).toBech32String());
+
+    assertEquals(1, filters.getReferencedEvents().size());
+    assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", (filters.getReferencedEvents().get(0).getId()));
+  }
+
+  @Test
+  public void testBaseReqMessageDecoder() {
+    log.info("testBaseReqMessageDecoder");
+
+    final var filtersList = new ArrayList<Filters>();
+    var publicKey = Identity.generateRandomIdentity().getPublicKey();
+    filtersList.add(Filters.builder().authors(new ArrayList<>(List.of(publicKey))).kinds(new ArrayList<>(List.of(Kind.CONTACT_LIST, Kind.DELETION))).build());
+    filtersList.add(Filters.builder().kinds(new ArrayList<>(List.of(Kind.SET_METADATA, Kind.TEXT_NOTE))).build());
+    final var reqMessage = new ReqMessage(publicKey.toString(), filtersList);
+
+    assertDoesNotThrow(() -> {
+      String jsonMessage = reqMessage.encode();
+
+      String jsonMsg = jsonMessage.substring(1, jsonMessage.length() - 1);
+      String[] parts = jsonMsg.split(",");
+      assertEquals("\"REQ\"", parts[0]);
+      assertEquals("\"" + publicKey.toString() + "\"", parts[1]);
+      assertFalse(parts[2].startsWith("["));
+      assertFalse(parts[parts.length - 1].endsWith("]"));
+
+      BaseMessage message = new BaseMessageDecoder<>().decode(jsonMessage);
+
+      assertEquals(reqMessage, message);
+    });
+  }
+
+  @Test
+  public void testBaseEventMessageDecoder() {
+    log.info("testBaseEventMessageDecoder");
+
+    final String parseTarget
+        = "[\"EVENT\","
+        + "{"
+        + "\"content\":\"直んないわ。まあええか\","
+        + "\"created_at\":1686199583,"
+        + "\"id\":\"fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712\","
+        + "\"kind\":1,"
+        + "\"pubkey\":\"8c59239319637f97e007dad0d681e65ce35b1ace333b629e2d33f9465c132608\","
+        + "\"sig\":\"9584afd231c52fcbcec6ce668a2cc4b6dc9b4d9da20510dcb9005c6844679b4844edb7a2e1e0591958b0295241567c774dbf7d39a73932877542de1a5f963f4b\","
+        + "\"tags\":[]"
+        + "}]";
+
+    final var message = new BaseMessageDecoder<>().decode(parseTarget);
+
+    assertEquals(Command.EVENT.toString(), message.getCommand());
+
+    final var event = (GenericEvent) (((EventMessage) message).getEvent());
+    assertEquals(1, event.getKind().intValue());
+    assertEquals(1686199583, event.getCreatedAt().longValue());
+    assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", event.getId());
+  }
+
+  @Test
+  public void testBaseEventMessageMarkerDecoder() {
+    log.info("testBaseEventMessageMarkerDecoder");
+
+    final String json = "["
+        + "\"EVENT\","
+        + "{"
+        + "\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\","
+        + "\"kind\":1,"
+        + "\"pubkey\":\"2bed79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76984\","
+        + "\"created_at\":1687765220,"
+        + "\"content\":\"手順書が間違ってたら作業者は無理だな\","
+        + "\"tags\":["
+        + "[\"e\",\"494001ac0c8af2a10f60f23538e5b35d3cdacb8e1cc956fe7a16dfa5cbfc4346\",\"\",\"root\"],"
+        + "[\"p\",\"2bed79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76984\"]"
+        + "],"
+        + "\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\""
+        + "}]";
+
+    BaseMessage message = new BaseMessageDecoder<>().decode(json);
+
+    final var event = (GenericEvent) (((EventMessage) message).getEvent());
+    var tags = event.getTags();
+    for (BaseTag t : tags) {
+      if (t.getCode().equalsIgnoreCase("e")) {
+        EventTag et = (EventTag) t;
+        assertEquals(Marker.ROOT, et.getMarker());
+      }
     }
+  }
+
+  @Test
+  public void testGenericTagDecoder() {
+    log.info("testGenericTagDecoder");
+    final String jsonString = "[\"saturn\", \"jetpack\", false]";
+
+    var tag = new GenericTagDecoder<>().decode(jsonString);
+
+    assertEquals("saturn", tag.getCode());
+    assertEquals(2, tag.getAttributes().size());
+    assertEquals("jetpack", ((ElementAttribute) (tag.getAttributes().toArray())[0]).getValue());
+    assertEquals(false, Boolean.valueOf(((ElementAttribute) (tag.getAttributes().toArray())[1]).getValue().toString()));
+  }
+
+  @Test
+  public void testClassifiedListingTagSerializer() {
+    log.info("testClassifiedListingSerializer");
+    final String classifiedListingEventJson = "{"
+        + "\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\","
+        + "\"kind\":30402,"
+        + "\"content\":\"content ipsum\","
+        + "\"pubkey\":\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\","
+        + "\"created_at\":1687765220,"
+        + "\"tags\":["
+        + "[\"p\",\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\"],"
+        + "[\"title\",\"title ipsum\"],"
+        + "[\"summary\",\"summary ipsum\"],"
+        + "[\"published_at\",\"1687765220\"],"
+        + "[\"location\",\"location ipsum\"],"
+        + "[\"price\",\"11111\",\"BTC\",\"1\"]],"
+        + "\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\""
+        + "}]";
+
+    GenericEvent event = new GenericEventDecoder<>().decode(classifiedListingEventJson);
+    EventMessage message = NIP01.createEventMessage(event, "1");
+    assertEquals(1, message.getNip());
+    String encoded = new BaseEventEncoder<>((BaseEvent) message.getEvent()).encode();
+    assertEquals("{\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\",\"kind\":30402,\"content\":\"content ipsum\",\"pubkey\":\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\",\"created_at\":1687765220,\"tags\":[[\"p\",\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\"],[\"title\",\"title ipsum\"],[\"summary\",\"summary ipsum\"],[\"published_at\",\"1687765220\"],[\"location\",\"location ipsum\"],[\"price\",\"11111\",\"BTC\",\"1\"]],\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\"}", encoded);
+
+    assertEquals("28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a", event.getId());
+    assertEquals(30402, event.getKind());
+    assertEquals("content ipsum", event.getContent());
+    assertEquals("ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de", event.getPubKey().toString());
+    assertEquals(1687765220L, event.getCreatedAt());
+    assertEquals("86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546", event.getSignature().toString());
+
+    assertEquals(new BigDecimal("11111"), event.getTags().stream().filter(baseTag ->
+            baseTag.getCode().equalsIgnoreCase("price"))
+        .filter(PriceTag.class::isInstance)
+        .map(PriceTag.class::cast)
+        .map(PriceTag::getNumber).findFirst().orElseThrow());
+
+    assertEquals("BTC", event.getTags().stream().filter(baseTag ->
+            baseTag.getCode().equalsIgnoreCase("price"))
+        .filter(PriceTag.class::isInstance)
+        .map(PriceTag.class::cast)
+        .map(PriceTag::getCurrency).findFirst().orElseThrow());
+
+    assertEquals("1", event.getTags().stream().filter(baseTag ->
+            baseTag.getCode().equalsIgnoreCase("price"))
+        .filter(PriceTag.class::isInstance)
+        .map(PriceTag.class::cast)
+        .map(PriceTag::getFrequency).findFirst().orElseThrow());
+
+    List<GenericTag> genericTags = event.getTags().stream()
+        .filter(GenericTag.class::isInstance)
+        .map(GenericTag.class::cast).toList();
+
+    assertEquals("title ipsum", genericTags.stream()
+        .filter(tag -> tag.getCode().equalsIgnoreCase("title")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+
+    assertEquals("summary ipsum", genericTags.stream()
+        .filter(tag -> tag.getCode().equalsIgnoreCase("summary")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+
+    assertEquals("1687765220", genericTags.stream()
+        .filter(tag -> tag.getCode().equalsIgnoreCase("published_at")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+
+    assertEquals("location ipsum", genericTags.stream()
+        .filter(tag -> tag.getCode().equalsIgnoreCase("location")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+  }
+
+  @Test
+  public void testDeserializeTag() {
+    log.info("testDeserializeTag");
+
+    assertDoesNotThrow(() -> {
+      String npubHex = new PublicKey(NostrUtil.hexToBytes(Bech32.fromBech32(("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9")))).toString();
+
+      final String jsonString = "[\"p\", \"" + npubHex + "\", \"wss://nostr.java\", \"alice\"]";
+      var tag = new BaseTagDecoder<>().decode(jsonString);
+
+      assertTrue(tag instanceof PubKeyTag);
+
+      PubKeyTag pTag = (PubKeyTag) tag;
+      assertEquals("wss://nostr.java", pTag.getMainRelayUrl());
+      assertEquals(npubHex, pTag.getPublicKey().toString());
+      assertEquals("alice", pTag.getPetName());
+    });
+  }
+
+  @Test
+  public void testDeserializeGenericTag() {
+    log.info("testDeserializeGenericTag");
+    assertDoesNotThrow(() -> {
+      String npubHex = new PublicKey(Bech32.decode("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9").data).toString();
+      final String jsonString = "[\"gt\", \"" + npubHex + "\", \"wss://nostr.java\", \"alice\"]";
+      var tag = new BaseTagDecoder<>().decode(jsonString);
+
+      assertTrue(tag instanceof GenericTag);
+
+      GenericTag gTag = (GenericTag) tag;
+      assertEquals("gt", gTag.getCode());
+    });
+  }
+
+  @Test
+  public void testFiltersEncoder() {
+    log.info("testFiltersEncoder");
+
+    String new_geohash = "2vghde";
+    List<String> geohashList = new ArrayList<>();
+    geohashList.add(new_geohash);
+    Filters filters = Filters.builder().genericTagQuery(Map.of("#g", geohashList)).build();
+
+    FiltersEncoder encoder = new FiltersEncoder(filters);
+    String jsonMessage = encoder.encode();
+    assertEquals("{\"#g\":[\"2vghde\"]}", jsonMessage);
+  }
+
+  @Test
+  public void testReqMessageFilterListSerializer() {
+    log.info("testReqMessageFilterListSerializer");
+
+    String new_geohash = "2vghde";
+    String second_geohash = "3abcde";
+    List<String> geohashList = new ArrayList<>();
+    geohashList.add(new_geohash);
+    geohashList.add(second_geohash);
+    Filters filters = Filters.builder().genericTagQuery(Map.of("#g", geohashList)).build();
+
+    ReqMessage reqMessage = new ReqMessage("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9", new ArrayList<Filters>(List.of(filters)));
+    assertDoesNotThrow(() -> {
+      String jsonMessage = reqMessage.encode();
+
+      assertEquals("[\"REQ\",\"npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9\",{\"#g\":[\"2vghde\",\"3abcde\"]}]", jsonMessage);
+    });
+  }
+
+  @Test
+  public void testReqMessageFiltersDecoder() {
+    log.info("testReqMessageFiltersDecoder");
+
+    String geohashKey = "#g";
+    String geohashValue = "2vghde";
+    String reqJsonWithCustomTagQueryFilterToDecode = "{\"" + geohashKey + "\":[\"" + geohashValue + "\"]}";
+
+    Filters decodedFilters = new FiltersDecoder<>().decode(reqJsonWithCustomTagQueryFilterToDecode);
+
+    Filters expectedFilters = new Filters();
+    List<String> expectedGeohashValueList = List.of(geohashValue);
+    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValueList);
+
+    assertEquals(expectedFilters, decodedFilters);
+  }
+
+  @Test
+  public void testReqMessageFiltersListDecoder() {
+    log.info("testReqMessageFiltersListDecoder");
+
+    String geohashKey = "#g";
+    String geohashValue1 = "2vghde";
+    String geohashValue2 = "3abcde";
+    String reqJsonWithCustomTagQueryFilterToDecode = "{\"" + geohashKey + "\":[\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]}";
+
+    Filters decodedFilters = new FiltersDecoder<>().decode(reqJsonWithCustomTagQueryFilterToDecode);
+
+    Filters expectedFilters = new Filters();
+    List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
+    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
+
+    assertEquals(expectedFilters, decodedFilters);
+  }
+
+  @Test
+  public void testReqMessageDeserializer() {
+    log.info("testReqMessageDeserializer");
+
+    String subscriptionId = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9";
+    String geohashKey = "#g";
+    String geohashValue = "2vghde";
+    String reqJsonWithCustomTagQueryFilterToDecode = "[\"REQ\",\"" + subscriptionId + "\",{\"" + geohashKey + "\":[\"" + geohashValue + "\"]}]";
+
+    ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
+
+    Filters expectedFilters = new Filters();
+    List<String> expectedGeohashValuesList = List.of(geohashValue);
+    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
+
+    ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
+    assertEquals(expectedReqMessage, decodedReqMessage);
+  }
+
+  @Test
+  public void testReqMessageFilterListDecoder() {
+    log.info("testReqMessageFilterListDecoder");
+
+    String subscriptionId = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9";
+    String geohashKey = "#g";
+    String geohashValue1 = "2vghde";
+    String geohashValue2 = "3abcde";
+    String reqJsonWithCustomTagQueryFiltersToDecode = "[\"REQ\",\"" + subscriptionId + "\",{\"" + geohashKey + "\":[\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]}]";
+
+    ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFiltersToDecode);
+
+    Filters expectedFilters = new Filters();
+    List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
+    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
+
+    ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
+    assertEquals(expectedReqMessage, decodedReqMessage);
+  }
+
+  @Test
+  public void testReqMessagePopulatedFilterDecoder() {
+    log.info("testReqMessagePopulatedFilterDecoder");
+
+    String subscriptionId = "npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh";
+    String kind = "1";
+    String author = "f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75";
+    String geohashKey = "#g";
+    String geohashValue1 = "2vghde";
+    String geohashValue2 = "3abcde";
+    String referencedEventId = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
+    String reqJsonWithCustomTagQueryFilterToDecode =
+        "[\"REQ\", " +
+            "\"" + subscriptionId + "\", " +
+            "{\"kinds\": [" + kind + "], " +
+            "\"authors\": [\"" + author + "\"]," +
+            "\"" + geohashKey + "\": [\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]," +
+            "\"#e\": [\"" + referencedEventId + "\"]}]";
+
+    ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
+
+    Filters expectedFilters = new Filters();
+    expectedFilters.setKinds(List.of(Kind.TEXT_NOTE));
+    expectedFilters.setAuthors(List.of(new PublicKey(author)));
+    expectedFilters.setReferencedEvents(List.of(new GenericEvent(referencedEventId)));
+    List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
+    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
+
+    ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
+    assertEquals(expectedReqMessage, decodedReqMessage);
+  }
+
+  @Test
+  public void testReqMessagePopulatedListOfFiltersListDecoder() {
+    log.info("testReqMessagePopulatedListOfFiltersListDecoder");
+
+    String subscriptionId = "npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh";
+    String kind = "1";
+    String author = "f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75";
+    String geohashKey = "#g";
+    String geohashValue1 = "2vghde";
+    String geohashValue2 = "3abcde";
+    String referencedEventId = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
+    String uuidKey = "#d";
+    String uuidValue1 = "UUID-1";
+    String uuidValue2 = "UUID-2";
+    String reqJsonWithCustomTagQueryFilterToDecode =
+        "[\"REQ\", " +
+            "\"" + subscriptionId + "\", " +
+            "{\"kinds\": [" + kind + "], " +
+            "\"authors\": [\"" + author + "\"]," +
+            "\"" + geohashKey + "\": [\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]," +
+            "\"" + uuidKey + "\": [\"" + uuidValue1 + "\",\"" + uuidValue2 + "\"]," +
+            "\"#e\": [\"" + referencedEventId + "\"]}]";
+
+    ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
+
+    Filters expectedFilters = new Filters();
+    expectedFilters.setKinds(List.of(Kind.TEXT_NOTE));
+    expectedFilters.setAuthors(List.of(new PublicKey(author)));
+    expectedFilters.setReferencedEvents(List.of(new GenericEvent(referencedEventId)));
+    List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
+    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
+    List<String> expectedIdentityTagValuesList = List.of(uuidValue1, uuidValue2);
+    expectedFilters.setGenericTagQuery(uuidKey, expectedIdentityTagValuesList);
+    ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
+    assertEquals(expectedReqMessage, decodedReqMessage);
+  }
+
+  @Test
+  public void testReqMessageSubscriptionIdLength() {
+    log.info("testReqMessageSubscriptionIdLength");
+    String id65Chars = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9ab";
+    assertThrows(IllegalArgumentException.class, () -> new ReqMessage(id65Chars, new Filters()));
+//        assertDoesNotThrow(() -> new ReqMessage(id65Chars, new Filters()));
+  }
+
+  @Test
+  public void testReqMessageFilterIdLength() {
+    log.info("testReqMessageFilterIdLength");
+    String id64chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
+    String reqJsonId64Chars =
+        "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id64chars + "\"]}]";
+    assertDoesNotThrow(() -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId64Chars));
+
+    String id65chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123";
+    String reqJsonId65Chars =
+        "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id65chars + "\"]}]";
+    assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId65Chars));
+
+    String id63chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71";
+    String reqJsonId63chars =
+        "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id63chars + "\"]}]";
+    assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId63chars));
+  }
+
+  @Test
+  public void testReqMessageDecoderKind() {
+    log.info("testReqMessageDecoderKind");
+
+    Function<Integer, String> kindTarget = kind -> "[\"REQ\", " +
+        "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+        "{\"kinds\": [" + kind + "]" +
+        "}]";
+
+    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(0)));
+    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(65535)));
+    assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(-1)));
+    assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(65536)));
+  }
+
+  @Test
+  public void testReqMessageDecoderETag() {
+    log.info("testReqMessageDecoderETag");
+
+    String VALID_EVENTID = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+    String VALID_EVENTID_ALL_ZEROS = "0000000000000000000000000000000000000000000000000000000000000000";
+    String VALID_EVENTID_ALL_FF = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    String INVALID_EVENTID_NON_HEX_DIGITS = "XYZdf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+    String INVALID_EVENTID_LENGTH_TOO_SHORT = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6";
+    String INVALID_EVENTID_LENGTH_TOO_LONG = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f666";
+    String INVALID_EVENTID_HAS_MULTIPLE_UPPERCASE = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+    String INVALID_EVENTID_HAS_SINGLE_UPPERCASE = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6F";
+
+    Function<String, String> eTagTarget = eTag -> "[\"REQ\", " +
+        "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+        "{\"#e\": [\"" + eTag + "\"]}]";
+
+    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_EVENTID)));
+    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_EVENTID_ALL_ZEROS)));
+    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_EVENTID_ALL_FF)));
+
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_NON_HEX_DIGITS))).getMessage().contains("has non-hex characters"));
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_SHORT))).getMessage().contains("target length"));
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_LONG))).getMessage().contains("target length"));
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_MULTIPLE_UPPERCASE))).getMessage().contains("non-hex characters"));
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_SINGLE_UPPERCASE))).getMessage().contains("has uppcase characters"));
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_SINGLE_UPPERCASE))).getMessage().contains("has non-hex characters"));
+  }
+
+  @Test
+  public void testReqMessageDecoderPTag() {
+    log.info("testReqMessageDecoderPTag");
+
+    String VALID_HEXPUBKEY = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+    String VALID_HEXPUBKEY_ALL_ZEROS = "0000000000000000000000000000000000000000000000000000000000000000";
+    String VALID_HEXPUBKEY_ALL_FF = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    String INVALID_HEXPUBKEY_NON_HEX_DIGITS = "XYZdf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+    String INVALID_HEXPUBKEY_LENGTH_TOO_SHORT = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6";
+    String INVALID_HEXPUBKEY_LENGTH_TOO_LONG = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f666";
+    String INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+    String INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6F";
+
+    Function<String, String> eTagTarget = pTag -> "[\"REQ\", " +
+        "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+        "{\"#p\": [\"" + pTag + "\"]}]";
+
+    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY)));
+    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY_ALL_ZEROS)));
+    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY_ALL_FF)));
+      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_NON_HEX_DIGITS))).getMessage().contains("has non-hex characters"));
+      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_SHORT))).getMessage().contains("target length"));
+      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_LONG))).getMessage().contains("target length"));
+      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE))).getMessage().contains("non-hex characters"));
+      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE))).getMessage().contains("has uppcase characters"));
+      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE))).getMessage().contains("has non-hex characters"));
+  }
 }

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -66,16 +67,16 @@ public class JsonParseTest {
         assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((ReqMessage) message).getSubscriptionId());
         assertEquals(1, ((ReqMessage) message).getFiltersList().size());
 
-        var filters = ((ReqMessage) message).getFiltersList().get(0);
+        var filters = ((ReqMessage) message).getFiltersList().getFirst();
 
         assertEquals(1, filters.getKinds().size());
-        assertEquals(Kind.TEXT_NOTE, filters.getKinds().get(0));
+        assertEquals(Kind.TEXT_NOTE, filters.getKinds().getFirst());
 
         assertEquals(1, filters.getAuthors().size());
-        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", filters.getAuthors().get(0).toBech32String());
+        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", filters.getAuthors().getFirst().toBech32String());
 
         assertEquals(1, filters.getReferencedEvents().size());
-        assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", (filters.getReferencedEvents().get(0).getId()));
+        assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", (filters.getReferencedEvents().getFirst().getId()));
     }
 
     @Test
@@ -229,16 +230,16 @@ public class JsonParseTest {
             .map(GenericTag.class::cast).toList();
 
         assertEquals("title ipsum", genericTags.stream()
-            .filter(tag -> tag.getCode().equalsIgnoreCase("title")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+            .filter(tag -> tag.getCode().equalsIgnoreCase("title")).map(GenericTag::getAttributes).toList().getFirst().getFirst().getValue());
 
         assertEquals("summary ipsum", genericTags.stream()
-            .filter(tag -> tag.getCode().equalsIgnoreCase("summary")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+            .filter(tag -> tag.getCode().equalsIgnoreCase("summary")).map(GenericTag::getAttributes).toList().getFirst().getFirst().getValue());
 
         assertEquals("1687765220", genericTags.stream()
-            .filter(tag -> tag.getCode().equalsIgnoreCase("published_at")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+            .filter(tag -> tag.getCode().equalsIgnoreCase("published_at")).map(GenericTag::getAttributes).toList().getFirst().getFirst().getValue());
 
         assertEquals("location ipsum", genericTags.stream()
-            .filter(tag -> tag.getCode().equalsIgnoreCase("location")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+            .filter(tag -> tag.getCode().equalsIgnoreCase("location")).map(GenericTag::getAttributes).toList().getFirst().getFirst().getValue());
     }
 
     @Test
@@ -246,12 +247,12 @@ public class JsonParseTest {
         log.info("testDeserializeTag");
 
         assertDoesNotThrow(() -> {
-            String npubHex = new PublicKey(NostrUtil.hexToBytes(Bech32.fromBech32(("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9")))).toString();
+            String npubHex = new PublicKey(NostrUtil.hexToBytes(Bech32.fromBech32("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9"))).toString();
 
             final String jsonString = "[\"p\", \"" + npubHex + "\", \"wss://nostr.java\", \"alice\"]";
             var tag = new BaseTagDecoder<>().decode(jsonString);
 
-            assertTrue(tag instanceof PubKeyTag);
+            assertInstanceOf(PubKeyTag.class, tag);
 
             PubKeyTag pTag = (PubKeyTag) tag;
             assertEquals("wss://nostr.java", pTag.getMainRelayUrl());
@@ -268,7 +269,7 @@ public class JsonParseTest {
             final String jsonString = "[\"gt\", \"" + npubHex + "\", \"wss://nostr.java\", \"alice\"]";
             var tag = new BaseTagDecoder<>().decode(jsonString);
 
-            assertTrue(tag instanceof GenericTag);
+            assertInstanceOf(GenericTag.class, tag);
 
             GenericTag gTag = (GenericTag) tag;
             assertEquals("gt", gTag.getCode());
@@ -300,7 +301,7 @@ public class JsonParseTest {
         geohashList.add(second_geohash);
         Filters filters = Filters.builder().genericTagQuery(Map.of("#g", geohashList)).build();
 
-        ReqMessage reqMessage = new ReqMessage("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9", new ArrayList<Filters>(List.of(filters)));
+        ReqMessage reqMessage = new ReqMessage("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9", new ArrayList<>(List.of(filters)));
         assertDoesNotThrow(() -> {
             String jsonMessage = reqMessage.encode();
 

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -1,5 +1,6 @@
 package nostr.test.json;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import lombok.extern.java.Log;
 import nostr.api.NIP01;
 import nostr.base.Command;
@@ -454,8 +455,9 @@ public class JsonParseTest {
   public void testReqMessageSubscriptionIdLength() {
     log.info("testReqMessageSubscriptionIdLength");
     String id65Chars = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9ab";
-    assertThrows(IllegalArgumentException.class, () -> new ReqMessage(id65Chars, new Filters()));
-//        assertDoesNotThrow(() -> new ReqMessage(id65Chars, new Filters()));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new ReqMessage(id65Chars, new Filters()))
+            .getMessage().contains("subscriptionId length must be between 1 and 64 characters but was [65]"));
   }
 
   @Test
@@ -469,12 +471,16 @@ public class JsonParseTest {
     String id65chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123";
     String reqJsonId65Chars =
         "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id65chars + "\"]}]";
-    assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId65Chars));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId65Chars))
+            .getMessage().contains("[fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123], length: [65], target length: [64]"));
 
     String id63chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71";
     String reqJsonId63chars =
         "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id63chars + "\"]}]";
-    assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId63chars));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId63chars))
+            .getMessage().contains("[fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71], length: [63], target length: [64]"));
   }
 
   @Test
@@ -488,8 +494,13 @@ public class JsonParseTest {
 
     assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(0)));
     assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(65535)));
-    assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(-1)));
-    assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(65536)));
+
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(-1)))
+            .getMessage().contains("Kind must be between 0 and 65535 but was [-1]"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(65536)))
+            .getMessage().contains("Kind must be between 0 and 65535 but was [65536]"));
   }
 
   @Test
@@ -513,11 +524,21 @@ public class JsonParseTest {
     assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_EVENTID_ALL_ZEROS)));
     assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_EVENTID_ALL_FF)));
 
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_NON_HEX_DIGITS))).getMessage().contains("has non-hex characters"));
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_SHORT))).getMessage().contains("target length"));
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_LONG))).getMessage().contains("target length"));
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_MULTIPLE_UPPERCASE))).getMessage().contains("has uppcase characters"));
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_SINGLE_UPPERCASE))).getMessage().contains("has uppcase characters"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_NON_HEX_DIGITS)))
+            .getMessage().contains("has non-hex characters"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_SHORT)))
+            .getMessage().contains("target length"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_LONG)))
+            .getMessage().contains("target length"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_MULTIPLE_UPPERCASE)))
+            .getMessage().contains("has uppcase characters"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_SINGLE_UPPERCASE)))
+            .getMessage().contains("has uppcase characters"));
   }
 
   @Test
@@ -540,10 +561,57 @@ public class JsonParseTest {
     assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY)));
     assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY_ALL_ZEROS)));
     assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY_ALL_FF)));
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_NON_HEX_DIGITS))).getMessage().contains("has non-hex characters"));
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_SHORT))).getMessage().contains("target length"));
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_LONG))).getMessage().contains("target length"));
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE))).getMessage().contains("has uppcase characters"));
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE))).getMessage().contains("has uppcase characters"));
+
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_NON_HEX_DIGITS)))
+            .getMessage().contains("has non-hex characters"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_SHORT)))
+            .getMessage().contains("target length"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_LONG)))
+            .getMessage().contains("target length"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE)))
+            .getMessage().contains("has uppcase characters"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE)))
+            .getMessage().contains("has uppcase characters"));
+  }
+
+  @Test
+  public void testReqMessageFilterSince() {
+    log.info("testReqMessageFilterSince");
+    Function<String, String> sinceTarget = since -> "[\"REQ\", " +
+        "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+        "{\"since\": " + since + "}]";
+
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(sinceTarget.apply(null)))
+            .getMessage().contains("since is marked non-null but is null"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(sinceTarget.apply("-1")))
+            .getMessage().contains("'since' filter cannot be negative"));
+    assertTrue(
+        assertThrows(JsonMappingException.class, () -> new BaseMessageDecoder<>().decode(sinceTarget.apply("a")))
+            .getMessage().contains("Unrecognized token 'a'"));
+  }
+
+  @Test
+  public void testReqMessageFilterUntil() {
+    log.info("testReqMessageFilterUntil");
+    Function<String, String> untilTarget = until -> "[\"REQ\", " +
+        "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+        "{\"until\": " + until + "}]";
+
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(untilTarget.apply(null)))
+            .getMessage().contains("until is marked non-null but is null"));
+    assertTrue(
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(untilTarget.apply("-1")))
+            .getMessage().contains("'until' filter cannot be negative"));
+    assertTrue(
+        assertThrows(JsonMappingException.class, () -> new BaseMessageDecoder<>().decode(untilTarget.apply("a")))
+            .getMessage().contains("Unrecognized token 'a'"));
   }
 }

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -34,6 +34,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -479,16 +481,15 @@ public class JsonParseTest {
     @Test
     public void testBaseMessageDecoderKind() {
         log.info("testBaseMessageDecoderKind");
-        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget(0)));
-        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget(65535)));
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget(-1)));
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget(65536)));
-    }
 
-    private static String kindTarget(int kind) {
-        return "[\"REQ\", " +
+        Function<Integer, String> kindTarget = kind -> "[\"REQ\", " +
             "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
             "{\"kinds\": [" + kind + "]" +
             "}]";
+
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(0)));
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(65535)));
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(-1)));
+        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(65536)));
     }
 }

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -516,9 +516,8 @@ public class JsonParseTest {
     assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_NON_HEX_DIGITS))).getMessage().contains("has non-hex characters"));
     assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_SHORT))).getMessage().contains("target length"));
     assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_LONG))).getMessage().contains("target length"));
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_MULTIPLE_UPPERCASE))).getMessage().contains("non-hex characters"));
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_MULTIPLE_UPPERCASE))).getMessage().contains("has uppcase characters"));
     assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_SINGLE_UPPERCASE))).getMessage().contains("has uppcase characters"));
-    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_SINGLE_UPPERCASE))).getMessage().contains("has non-hex characters"));
   }
 
   @Test
@@ -541,11 +540,10 @@ public class JsonParseTest {
     assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY)));
     assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY_ALL_ZEROS)));
     assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY_ALL_FF)));
-      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_NON_HEX_DIGITS))).getMessage().contains("has non-hex characters"));
-      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_SHORT))).getMessage().contains("target length"));
-      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_LONG))).getMessage().contains("target length"));
-      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE))).getMessage().contains("non-hex characters"));
-      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE))).getMessage().contains("has uppcase characters"));
-      assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE))).getMessage().contains("has non-hex characters"));
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_NON_HEX_DIGITS))).getMessage().contains("has non-hex characters"));
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_SHORT))).getMessage().contains("target length"));
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_LONG))).getMessage().contains("target length"));
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE))).getMessage().contains("has uppcase characters"));
+    assertTrue(assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE))).getMessage().contains("has uppcase characters"));
   }
 }

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -49,569 +49,569 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Log
 public class JsonParseTest {
 
-  @Test
-  public void testBaseMessageDecoder() {
-    log.info("testBaseMessageDecoder");
+    @Test
+    public void testBaseMessageDecoder() {
+        log.info("testBaseMessageDecoder");
 
-    final String parseTarget =
-        "[\"REQ\", " +
-            "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
-            "{\"kinds\": [1], " +
-            "\"authors\": [\"f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75\"]," +
-            "\"#e\": [\"fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712\"]}]";
+        final String parseTarget =
+            "[\"REQ\", " +
+                "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+                "{\"kinds\": [1], " +
+                "\"authors\": [\"f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75\"]," +
+                "\"#e\": [\"fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712\"]}]";
 
-    final var message = new BaseMessageDecoder<>().decode(parseTarget);
+        final var message = new BaseMessageDecoder<>().decode(parseTarget);
 
-    assertEquals(Command.REQ.toString(), message.getCommand());
-    assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((ReqMessage) message).getSubscriptionId());
-    assertEquals(1, ((ReqMessage) message).getFiltersList().size());
+        assertEquals(Command.REQ.toString(), message.getCommand());
+        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((ReqMessage) message).getSubscriptionId());
+        assertEquals(1, ((ReqMessage) message).getFiltersList().size());
 
-    var filters = ((ReqMessage) message).getFiltersList().get(0);
+        var filters = ((ReqMessage) message).getFiltersList().get(0);
 
-    assertEquals(1, filters.getKinds().size());
-    assertEquals(Kind.TEXT_NOTE, filters.getKinds().get(0));
+        assertEquals(1, filters.getKinds().size());
+        assertEquals(Kind.TEXT_NOTE, filters.getKinds().get(0));
 
-    assertEquals(1, filters.getAuthors().size());
-    assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", filters.getAuthors().get(0).toBech32String());
+        assertEquals(1, filters.getAuthors().size());
+        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", filters.getAuthors().get(0).toBech32String());
 
-    assertEquals(1, filters.getReferencedEvents().size());
-    assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", (filters.getReferencedEvents().get(0).getId()));
-  }
-
-  @Test
-  public void testBaseReqMessageDecoder() {
-    log.info("testBaseReqMessageDecoder");
-
-    final var filtersList = new ArrayList<Filters>();
-    var publicKey = Identity.generateRandomIdentity().getPublicKey();
-    filtersList.add(Filters.builder().authors(new ArrayList<>(List.of(publicKey))).kinds(new ArrayList<>(List.of(Kind.CONTACT_LIST, Kind.DELETION))).build());
-    filtersList.add(Filters.builder().kinds(new ArrayList<>(List.of(Kind.SET_METADATA, Kind.TEXT_NOTE))).build());
-    final var reqMessage = new ReqMessage(publicKey.toString(), filtersList);
-
-    assertDoesNotThrow(() -> {
-      String jsonMessage = reqMessage.encode();
-
-      String jsonMsg = jsonMessage.substring(1, jsonMessage.length() - 1);
-      String[] parts = jsonMsg.split(",");
-      assertEquals("\"REQ\"", parts[0]);
-      assertEquals("\"" + publicKey.toString() + "\"", parts[1]);
-      assertFalse(parts[2].startsWith("["));
-      assertFalse(parts[parts.length - 1].endsWith("]"));
-
-      BaseMessage message = new BaseMessageDecoder<>().decode(jsonMessage);
-
-      assertEquals(reqMessage, message);
-    });
-  }
-
-  @Test
-  public void testBaseEventMessageDecoder() {
-    log.info("testBaseEventMessageDecoder");
-
-    final String parseTarget
-        = "[\"EVENT\","
-        + "{"
-        + "\"content\":\"直んないわ。まあええか\","
-        + "\"created_at\":1686199583,"
-        + "\"id\":\"fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712\","
-        + "\"kind\":1,"
-        + "\"pubkey\":\"8c59239319637f97e007dad0d681e65ce35b1ace333b629e2d33f9465c132608\","
-        + "\"sig\":\"9584afd231c52fcbcec6ce668a2cc4b6dc9b4d9da20510dcb9005c6844679b4844edb7a2e1e0591958b0295241567c774dbf7d39a73932877542de1a5f963f4b\","
-        + "\"tags\":[]"
-        + "}]";
-
-    final var message = new BaseMessageDecoder<>().decode(parseTarget);
-
-    assertEquals(Command.EVENT.toString(), message.getCommand());
-
-    final var event = (GenericEvent) (((EventMessage) message).getEvent());
-    assertEquals(1, event.getKind().intValue());
-    assertEquals(1686199583, event.getCreatedAt().longValue());
-    assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", event.getId());
-  }
-
-  @Test
-  public void testBaseEventMessageMarkerDecoder() {
-    log.info("testBaseEventMessageMarkerDecoder");
-
-    final String json = "["
-        + "\"EVENT\","
-        + "{"
-        + "\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\","
-        + "\"kind\":1,"
-        + "\"pubkey\":\"2bed79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76984\","
-        + "\"created_at\":1687765220,"
-        + "\"content\":\"手順書が間違ってたら作業者は無理だな\","
-        + "\"tags\":["
-        + "[\"e\",\"494001ac0c8af2a10f60f23538e5b35d3cdacb8e1cc956fe7a16dfa5cbfc4346\",\"\",\"root\"],"
-        + "[\"p\",\"2bed79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76984\"]"
-        + "],"
-        + "\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\""
-        + "}]";
-
-    BaseMessage message = new BaseMessageDecoder<>().decode(json);
-
-    final var event = (GenericEvent) (((EventMessage) message).getEvent());
-    var tags = event.getTags();
-    for (BaseTag t : tags) {
-      if (t.getCode().equalsIgnoreCase("e")) {
-        EventTag et = (EventTag) t;
-        assertEquals(Marker.ROOT, et.getMarker());
-      }
+        assertEquals(1, filters.getReferencedEvents().size());
+        assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", (filters.getReferencedEvents().get(0).getId()));
     }
-  }
-
-  @Test
-  public void testGenericTagDecoder() {
-    log.info("testGenericTagDecoder");
-    final String jsonString = "[\"saturn\", \"jetpack\", false]";
-
-    var tag = new GenericTagDecoder<>().decode(jsonString);
-
-    assertEquals("saturn", tag.getCode());
-    assertEquals(2, tag.getAttributes().size());
-    assertEquals("jetpack", ((ElementAttribute) (tag.getAttributes().toArray())[0]).getValue());
-    assertEquals(false, Boolean.valueOf(((ElementAttribute) (tag.getAttributes().toArray())[1]).getValue().toString()));
-  }
-
-  @Test
-  public void testClassifiedListingTagSerializer() {
-    log.info("testClassifiedListingSerializer");
-    final String classifiedListingEventJson = "{"
-        + "\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\","
-        + "\"kind\":30402,"
-        + "\"content\":\"content ipsum\","
-        + "\"pubkey\":\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\","
-        + "\"created_at\":1687765220,"
-        + "\"tags\":["
-        + "[\"p\",\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\"],"
-        + "[\"title\",\"title ipsum\"],"
-        + "[\"summary\",\"summary ipsum\"],"
-        + "[\"published_at\",\"1687765220\"],"
-        + "[\"location\",\"location ipsum\"],"
-        + "[\"price\",\"11111\",\"BTC\",\"1\"]],"
-        + "\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\""
-        + "}]";
-
-    GenericEvent event = new GenericEventDecoder<>().decode(classifiedListingEventJson);
-    EventMessage message = NIP01.createEventMessage(event, "1");
-    assertEquals(1, message.getNip());
-    String encoded = new BaseEventEncoder<>((BaseEvent) message.getEvent()).encode();
-    assertEquals("{\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\",\"kind\":30402,\"content\":\"content ipsum\",\"pubkey\":\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\",\"created_at\":1687765220,\"tags\":[[\"p\",\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\"],[\"title\",\"title ipsum\"],[\"summary\",\"summary ipsum\"],[\"published_at\",\"1687765220\"],[\"location\",\"location ipsum\"],[\"price\",\"11111\",\"BTC\",\"1\"]],\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\"}", encoded);
-
-    assertEquals("28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a", event.getId());
-    assertEquals(30402, event.getKind());
-    assertEquals("content ipsum", event.getContent());
-    assertEquals("ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de", event.getPubKey().toString());
-    assertEquals(1687765220L, event.getCreatedAt());
-    assertEquals("86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546", event.getSignature().toString());
-
-    assertEquals(new BigDecimal("11111"), event.getTags().stream().filter(baseTag ->
-            baseTag.getCode().equalsIgnoreCase("price"))
-        .filter(PriceTag.class::isInstance)
-        .map(PriceTag.class::cast)
-        .map(PriceTag::getNumber).findFirst().orElseThrow());
-
-    assertEquals("BTC", event.getTags().stream().filter(baseTag ->
-            baseTag.getCode().equalsIgnoreCase("price"))
-        .filter(PriceTag.class::isInstance)
-        .map(PriceTag.class::cast)
-        .map(PriceTag::getCurrency).findFirst().orElseThrow());
-
-    assertEquals("1", event.getTags().stream().filter(baseTag ->
-            baseTag.getCode().equalsIgnoreCase("price"))
-        .filter(PriceTag.class::isInstance)
-        .map(PriceTag.class::cast)
-        .map(PriceTag::getFrequency).findFirst().orElseThrow());
-
-    List<GenericTag> genericTags = event.getTags().stream()
-        .filter(GenericTag.class::isInstance)
-        .map(GenericTag.class::cast).toList();
-
-    assertEquals("title ipsum", genericTags.stream()
-        .filter(tag -> tag.getCode().equalsIgnoreCase("title")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
-
-    assertEquals("summary ipsum", genericTags.stream()
-        .filter(tag -> tag.getCode().equalsIgnoreCase("summary")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
-
-    assertEquals("1687765220", genericTags.stream()
-        .filter(tag -> tag.getCode().equalsIgnoreCase("published_at")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
-
-    assertEquals("location ipsum", genericTags.stream()
-        .filter(tag -> tag.getCode().equalsIgnoreCase("location")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
-  }
-
-  @Test
-  public void testDeserializeTag() {
-    log.info("testDeserializeTag");
-
-    assertDoesNotThrow(() -> {
-      String npubHex = new PublicKey(NostrUtil.hexToBytes(Bech32.fromBech32(("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9")))).toString();
-
-      final String jsonString = "[\"p\", \"" + npubHex + "\", \"wss://nostr.java\", \"alice\"]";
-      var tag = new BaseTagDecoder<>().decode(jsonString);
-
-      assertTrue(tag instanceof PubKeyTag);
-
-      PubKeyTag pTag = (PubKeyTag) tag;
-      assertEquals("wss://nostr.java", pTag.getMainRelayUrl());
-      assertEquals(npubHex, pTag.getPublicKey().toString());
-      assertEquals("alice", pTag.getPetName());
-    });
-  }
-
-  @Test
-  public void testDeserializeGenericTag() {
-    log.info("testDeserializeGenericTag");
-    assertDoesNotThrow(() -> {
-      String npubHex = new PublicKey(Bech32.decode("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9").data).toString();
-      final String jsonString = "[\"gt\", \"" + npubHex + "\", \"wss://nostr.java\", \"alice\"]";
-      var tag = new BaseTagDecoder<>().decode(jsonString);
 
-      assertTrue(tag instanceof GenericTag);
-
-      GenericTag gTag = (GenericTag) tag;
-      assertEquals("gt", gTag.getCode());
-    });
-  }
-
-  @Test
-  public void testFiltersEncoder() {
-    log.info("testFiltersEncoder");
-
-    String new_geohash = "2vghde";
-    List<String> geohashList = new ArrayList<>();
-    geohashList.add(new_geohash);
-    Filters filters = Filters.builder().genericTagQuery(Map.of("#g", geohashList)).build();
-
-    FiltersEncoder encoder = new FiltersEncoder(filters);
-    String jsonMessage = encoder.encode();
-    assertEquals("{\"#g\":[\"2vghde\"]}", jsonMessage);
-  }
-
-  @Test
-  public void testReqMessageFilterListSerializer() {
-    log.info("testReqMessageFilterListSerializer");
-
-    String new_geohash = "2vghde";
-    String second_geohash = "3abcde";
-    List<String> geohashList = new ArrayList<>();
-    geohashList.add(new_geohash);
-    geohashList.add(second_geohash);
-    Filters filters = Filters.builder().genericTagQuery(Map.of("#g", geohashList)).build();
-
-    ReqMessage reqMessage = new ReqMessage("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9", new ArrayList<Filters>(List.of(filters)));
-    assertDoesNotThrow(() -> {
-      String jsonMessage = reqMessage.encode();
-
-      assertEquals("[\"REQ\",\"npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9\",{\"#g\":[\"2vghde\",\"3abcde\"]}]", jsonMessage);
-    });
-  }
-
-  @Test
-  public void testReqMessageFiltersDecoder() {
-    log.info("testReqMessageFiltersDecoder");
-
-    String geohashKey = "#g";
-    String geohashValue = "2vghde";
-    String reqJsonWithCustomTagQueryFilterToDecode = "{\"" + geohashKey + "\":[\"" + geohashValue + "\"]}";
-
-    Filters decodedFilters = new FiltersDecoder<>().decode(reqJsonWithCustomTagQueryFilterToDecode);
-
-    Filters expectedFilters = new Filters();
-    List<String> expectedGeohashValueList = List.of(geohashValue);
-    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValueList);
-
-    assertEquals(expectedFilters, decodedFilters);
-  }
-
-  @Test
-  public void testReqMessageFiltersListDecoder() {
-    log.info("testReqMessageFiltersListDecoder");
-
-    String geohashKey = "#g";
-    String geohashValue1 = "2vghde";
-    String geohashValue2 = "3abcde";
-    String reqJsonWithCustomTagQueryFilterToDecode = "{\"" + geohashKey + "\":[\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]}";
-
-    Filters decodedFilters = new FiltersDecoder<>().decode(reqJsonWithCustomTagQueryFilterToDecode);
-
-    Filters expectedFilters = new Filters();
-    List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
-    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
-
-    assertEquals(expectedFilters, decodedFilters);
-  }
-
-  @Test
-  public void testReqMessageDeserializer() {
-    log.info("testReqMessageDeserializer");
-
-    String subscriptionId = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9";
-    String geohashKey = "#g";
-    String geohashValue = "2vghde";
-    String reqJsonWithCustomTagQueryFilterToDecode = "[\"REQ\",\"" + subscriptionId + "\",{\"" + geohashKey + "\":[\"" + geohashValue + "\"]}]";
-
-    ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
-
-    Filters expectedFilters = new Filters();
-    List<String> expectedGeohashValuesList = List.of(geohashValue);
-    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
-
-    ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
-    assertEquals(expectedReqMessage, decodedReqMessage);
-  }
-
-  @Test
-  public void testReqMessageFilterListDecoder() {
-    log.info("testReqMessageFilterListDecoder");
-
-    String subscriptionId = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9";
-    String geohashKey = "#g";
-    String geohashValue1 = "2vghde";
-    String geohashValue2 = "3abcde";
-    String reqJsonWithCustomTagQueryFiltersToDecode = "[\"REQ\",\"" + subscriptionId + "\",{\"" + geohashKey + "\":[\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]}]";
-
-    ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFiltersToDecode);
-
-    Filters expectedFilters = new Filters();
-    List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
-    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
-
-    ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
-    assertEquals(expectedReqMessage, decodedReqMessage);
-  }
-
-  @Test
-  public void testReqMessagePopulatedFilterDecoder() {
-    log.info("testReqMessagePopulatedFilterDecoder");
-
-    String subscriptionId = "npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh";
-    String kind = "1";
-    String author = "f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75";
-    String geohashKey = "#g";
-    String geohashValue1 = "2vghde";
-    String geohashValue2 = "3abcde";
-    String referencedEventId = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
-    String reqJsonWithCustomTagQueryFilterToDecode =
-        "[\"REQ\", " +
-            "\"" + subscriptionId + "\", " +
-            "{\"kinds\": [" + kind + "], " +
-            "\"authors\": [\"" + author + "\"]," +
-            "\"" + geohashKey + "\": [\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]," +
-            "\"#e\": [\"" + referencedEventId + "\"]}]";
-
-    ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
-
-    Filters expectedFilters = new Filters();
-    expectedFilters.setKinds(List.of(Kind.TEXT_NOTE));
-    expectedFilters.setAuthors(List.of(new PublicKey(author)));
-    expectedFilters.setReferencedEvents(List.of(new GenericEvent(referencedEventId)));
-    List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
-    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
-
-    ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
-    assertEquals(expectedReqMessage, decodedReqMessage);
-  }
-
-  @Test
-  public void testReqMessagePopulatedListOfFiltersListDecoder() {
-    log.info("testReqMessagePopulatedListOfFiltersListDecoder");
-
-    String subscriptionId = "npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh";
-    String kind = "1";
-    String author = "f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75";
-    String geohashKey = "#g";
-    String geohashValue1 = "2vghde";
-    String geohashValue2 = "3abcde";
-    String referencedEventId = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
-    String uuidKey = "#d";
-    String uuidValue1 = "UUID-1";
-    String uuidValue2 = "UUID-2";
-    String reqJsonWithCustomTagQueryFilterToDecode =
-        "[\"REQ\", " +
-            "\"" + subscriptionId + "\", " +
-            "{\"kinds\": [" + kind + "], " +
-            "\"authors\": [\"" + author + "\"]," +
-            "\"" + geohashKey + "\": [\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]," +
-            "\"" + uuidKey + "\": [\"" + uuidValue1 + "\",\"" + uuidValue2 + "\"]," +
-            "\"#e\": [\"" + referencedEventId + "\"]}]";
-
-    ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
-
-    Filters expectedFilters = new Filters();
-    expectedFilters.setKinds(List.of(Kind.TEXT_NOTE));
-    expectedFilters.setAuthors(List.of(new PublicKey(author)));
-    expectedFilters.setReferencedEvents(List.of(new GenericEvent(referencedEventId)));
-    List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
-    expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
-    List<String> expectedIdentityTagValuesList = List.of(uuidValue1, uuidValue2);
-    expectedFilters.setGenericTagQuery(uuidKey, expectedIdentityTagValuesList);
-    ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
-    assertEquals(expectedReqMessage, decodedReqMessage);
-  }
-
-  @Test
-  public void testReqMessageSubscriptionIdLength() {
-    log.info("testReqMessageSubscriptionIdLength");
-    String id65Chars = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9ab";
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new ReqMessage(id65Chars, new Filters()))
-            .getMessage().contains("subscriptionId length must be between 1 and 64 characters but was [65]"));
-  }
-
-  @Test
-  public void testReqMessageFilterIdLength() {
-    log.info("testReqMessageFilterIdLength");
-    String id64chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
-    String reqJsonId64Chars =
-        "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id64chars + "\"]}]";
-    assertDoesNotThrow(() -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId64Chars));
-
-    String id65chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123";
-    String reqJsonId65Chars =
-        "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id65chars + "\"]}]";
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId65Chars))
-            .getMessage().contains("[fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123], length: [65], target length: [64]"));
-
-    String id63chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71";
-    String reqJsonId63chars =
-        "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id63chars + "\"]}]";
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId63chars))
-            .getMessage().contains("[fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71], length: [63], target length: [64]"));
-  }
-
-  @Test
-  public void testReqMessageDecoderKind() {
-    log.info("testReqMessageDecoderKind");
-
-    Function<Integer, String> kindTarget = kind -> "[\"REQ\", " +
-        "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
-        "{\"kinds\": [" + kind + "]" +
-        "}]";
-
-    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(0)));
-    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(65535)));
-
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(-1)))
-            .getMessage().contains("Kind must be between 0 and 65535 but was [-1]"));
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(65536)))
-            .getMessage().contains("Kind must be between 0 and 65535 but was [65536]"));
-  }
-
-  @Test
-  public void testReqMessageDecoderETag() {
-    log.info("testReqMessageDecoderETag");
-
-    String VALID_EVENTID = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
-    String VALID_EVENTID_ALL_ZEROS = "0000000000000000000000000000000000000000000000000000000000000000";
-    String VALID_EVENTID_ALL_FF = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-    String INVALID_EVENTID_NON_HEX_DIGITS = "XYZdf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
-    String INVALID_EVENTID_LENGTH_TOO_SHORT = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6";
-    String INVALID_EVENTID_LENGTH_TOO_LONG = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f666";
-    String INVALID_EVENTID_HAS_MULTIPLE_UPPERCASE = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
-    String INVALID_EVENTID_HAS_SINGLE_UPPERCASE = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6F";
-
-    Function<String, String> eTagTarget = eTag -> "[\"REQ\", " +
-        "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
-        "{\"#e\": [\"" + eTag + "\"]}]";
-
-    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_EVENTID)));
-    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_EVENTID_ALL_ZEROS)));
-    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_EVENTID_ALL_FF)));
-
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_NON_HEX_DIGITS)))
-            .getMessage().contains("has non-hex characters"));
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_SHORT)))
-            .getMessage().contains("target length"));
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_LONG)))
-            .getMessage().contains("target length"));
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_MULTIPLE_UPPERCASE)))
-            .getMessage().contains("has uppcase characters"));
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_SINGLE_UPPERCASE)))
-            .getMessage().contains("has uppcase characters"));
-  }
-
-  @Test
-  public void testReqMessageDecoderPTag() {
-    log.info("testReqMessageDecoderPTag");
-
-    String VALID_HEXPUBKEY = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
-    String VALID_HEXPUBKEY_ALL_ZEROS = "0000000000000000000000000000000000000000000000000000000000000000";
-    String VALID_HEXPUBKEY_ALL_FF = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-    String INVALID_HEXPUBKEY_NON_HEX_DIGITS = "XYZdf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
-    String INVALID_HEXPUBKEY_LENGTH_TOO_SHORT = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6";
-    String INVALID_HEXPUBKEY_LENGTH_TOO_LONG = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f666";
-    String INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
-    String INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6F";
-
-    Function<String, String> eTagTarget = pTag -> "[\"REQ\", " +
-        "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
-        "{\"#p\": [\"" + pTag + "\"]}]";
-
-    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY)));
-    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY_ALL_ZEROS)));
-    assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY_ALL_FF)));
-
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_NON_HEX_DIGITS)))
-            .getMessage().contains("has non-hex characters"));
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_SHORT)))
-            .getMessage().contains("target length"));
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_LONG)))
-            .getMessage().contains("target length"));
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE)))
-            .getMessage().contains("has uppcase characters"));
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE)))
-            .getMessage().contains("has uppcase characters"));
-  }
-
-  @Test
-  public void testReqMessageFilterSince() {
-    log.info("testReqMessageFilterSince");
-    Function<String, String> sinceTarget = since -> "[\"REQ\", " +
-        "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
-        "{\"since\": " + since + "}]";
-
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(sinceTarget.apply(null)))
-            .getMessage().contains("since is marked non-null but is null"));
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(sinceTarget.apply("-1")))
-            .getMessage().contains("'since' filter cannot be negative"));
-    assertTrue(
-        assertThrows(JsonMappingException.class, () -> new BaseMessageDecoder<>().decode(sinceTarget.apply("a")))
-            .getMessage().contains("Unrecognized token 'a'"));
-  }
-
-  @Test
-  public void testReqMessageFilterUntil() {
-    log.info("testReqMessageFilterUntil");
-    Function<String, String> untilTarget = until -> "[\"REQ\", " +
-        "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
-        "{\"until\": " + until + "}]";
-
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(untilTarget.apply(null)))
-            .getMessage().contains("until is marked non-null but is null"));
-    assertTrue(
-        assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(untilTarget.apply("-1")))
-            .getMessage().contains("'until' filter cannot be negative"));
-    assertTrue(
-        assertThrows(JsonMappingException.class, () -> new BaseMessageDecoder<>().decode(untilTarget.apply("a")))
-            .getMessage().contains("Unrecognized token 'a'"));
-  }
+    @Test
+    public void testBaseReqMessageDecoder() {
+        log.info("testBaseReqMessageDecoder");
+
+        final var filtersList = new ArrayList<Filters>();
+        var publicKey = Identity.generateRandomIdentity().getPublicKey();
+        filtersList.add(Filters.builder().authors(new ArrayList<>(List.of(publicKey))).kinds(new ArrayList<>(List.of(Kind.CONTACT_LIST, Kind.DELETION))).build());
+        filtersList.add(Filters.builder().kinds(new ArrayList<>(List.of(Kind.SET_METADATA, Kind.TEXT_NOTE))).build());
+        final var reqMessage = new ReqMessage(publicKey.toString(), filtersList);
+
+        assertDoesNotThrow(() -> {
+            String jsonMessage = reqMessage.encode();
+
+            String jsonMsg = jsonMessage.substring(1, jsonMessage.length() - 1);
+            String[] parts = jsonMsg.split(",");
+            assertEquals("\"REQ\"", parts[0]);
+            assertEquals("\"" + publicKey.toString() + "\"", parts[1]);
+            assertFalse(parts[2].startsWith("["));
+            assertFalse(parts[parts.length - 1].endsWith("]"));
+
+            BaseMessage message = new BaseMessageDecoder<>().decode(jsonMessage);
+
+            assertEquals(reqMessage, message);
+        });
+    }
+
+    @Test
+    public void testBaseEventMessageDecoder() {
+        log.info("testBaseEventMessageDecoder");
+
+        final String parseTarget
+            = "[\"EVENT\","
+            + "{"
+            + "\"content\":\"直んないわ。まあええか\","
+            + "\"created_at\":1686199583,"
+            + "\"id\":\"fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712\","
+            + "\"kind\":1,"
+            + "\"pubkey\":\"8c59239319637f97e007dad0d681e65ce35b1ace333b629e2d33f9465c132608\","
+            + "\"sig\":\"9584afd231c52fcbcec6ce668a2cc4b6dc9b4d9da20510dcb9005c6844679b4844edb7a2e1e0591958b0295241567c774dbf7d39a73932877542de1a5f963f4b\","
+            + "\"tags\":[]"
+            + "}]";
+
+        final var message = new BaseMessageDecoder<>().decode(parseTarget);
+
+        assertEquals(Command.EVENT.toString(), message.getCommand());
+
+        final var event = (GenericEvent) (((EventMessage) message).getEvent());
+        assertEquals(1, event.getKind().intValue());
+        assertEquals(1686199583, event.getCreatedAt().longValue());
+        assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", event.getId());
+    }
+
+    @Test
+    public void testBaseEventMessageMarkerDecoder() {
+        log.info("testBaseEventMessageMarkerDecoder");
+
+        final String json = "["
+            + "\"EVENT\","
+            + "{"
+            + "\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\","
+            + "\"kind\":1,"
+            + "\"pubkey\":\"2bed79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76984\","
+            + "\"created_at\":1687765220,"
+            + "\"content\":\"手順書が間違ってたら作業者は無理だな\","
+            + "\"tags\":["
+            + "[\"e\",\"494001ac0c8af2a10f60f23538e5b35d3cdacb8e1cc956fe7a16dfa5cbfc4346\",\"\",\"root\"],"
+            + "[\"p\",\"2bed79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76984\"]"
+            + "],"
+            + "\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\""
+            + "}]";
+
+        BaseMessage message = new BaseMessageDecoder<>().decode(json);
+
+        final var event = (GenericEvent) (((EventMessage) message).getEvent());
+        var tags = event.getTags();
+        for (BaseTag t : tags) {
+            if (t.getCode().equalsIgnoreCase("e")) {
+                EventTag et = (EventTag) t;
+                assertEquals(Marker.ROOT, et.getMarker());
+            }
+        }
+    }
+
+    @Test
+    public void testGenericTagDecoder() {
+        log.info("testGenericTagDecoder");
+        final String jsonString = "[\"saturn\", \"jetpack\", false]";
+
+        var tag = new GenericTagDecoder<>().decode(jsonString);
+
+        assertEquals("saturn", tag.getCode());
+        assertEquals(2, tag.getAttributes().size());
+        assertEquals("jetpack", ((ElementAttribute) (tag.getAttributes().toArray())[0]).getValue());
+        assertEquals(false, Boolean.valueOf(((ElementAttribute) (tag.getAttributes().toArray())[1]).getValue().toString()));
+    }
+
+    @Test
+    public void testClassifiedListingTagSerializer() {
+        log.info("testClassifiedListingSerializer");
+        final String classifiedListingEventJson = "{"
+            + "\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\","
+            + "\"kind\":30402,"
+            + "\"content\":\"content ipsum\","
+            + "\"pubkey\":\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\","
+            + "\"created_at\":1687765220,"
+            + "\"tags\":["
+            + "[\"p\",\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\"],"
+            + "[\"title\",\"title ipsum\"],"
+            + "[\"summary\",\"summary ipsum\"],"
+            + "[\"published_at\",\"1687765220\"],"
+            + "[\"location\",\"location ipsum\"],"
+            + "[\"price\",\"11111\",\"BTC\",\"1\"]],"
+            + "\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\""
+            + "}]";
+
+        GenericEvent event = new GenericEventDecoder<>().decode(classifiedListingEventJson);
+        EventMessage message = NIP01.createEventMessage(event, "1");
+        assertEquals(1, message.getNip());
+        String encoded = new BaseEventEncoder<>((BaseEvent) message.getEvent()).encode();
+        assertEquals("{\"id\":\"28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a\",\"kind\":30402,\"content\":\"content ipsum\",\"pubkey\":\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\",\"created_at\":1687765220,\"tags\":[[\"p\",\"ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de\"],[\"title\",\"title ipsum\"],[\"summary\",\"summary ipsum\"],[\"published_at\",\"1687765220\"],[\"location\",\"location ipsum\"],[\"price\",\"11111\",\"BTC\",\"1\"]],\"sig\":\"86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546\"}", encoded);
+
+        assertEquals("28f2fc030e335d061f0b9d03ce0e2c7d1253e6fadb15d89bd47379a96b2c861a", event.getId());
+        assertEquals(30402, event.getKind());
+        assertEquals("content ipsum", event.getContent());
+        assertEquals("ec0762fe78b0f0b763d1324452d973a38bef576d1d76662722d2b8ff948af1de", event.getPubKey().toString());
+        assertEquals(1687765220L, event.getCreatedAt());
+        assertEquals("86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546", event.getSignature().toString());
+
+        assertEquals(new BigDecimal("11111"), event.getTags().stream().filter(baseTag ->
+                baseTag.getCode().equalsIgnoreCase("price"))
+            .filter(PriceTag.class::isInstance)
+            .map(PriceTag.class::cast)
+            .map(PriceTag::getNumber).findFirst().orElseThrow());
+
+        assertEquals("BTC", event.getTags().stream().filter(baseTag ->
+                baseTag.getCode().equalsIgnoreCase("price"))
+            .filter(PriceTag.class::isInstance)
+            .map(PriceTag.class::cast)
+            .map(PriceTag::getCurrency).findFirst().orElseThrow());
+
+        assertEquals("1", event.getTags().stream().filter(baseTag ->
+                baseTag.getCode().equalsIgnoreCase("price"))
+            .filter(PriceTag.class::isInstance)
+            .map(PriceTag.class::cast)
+            .map(PriceTag::getFrequency).findFirst().orElseThrow());
+
+        List<GenericTag> genericTags = event.getTags().stream()
+            .filter(GenericTag.class::isInstance)
+            .map(GenericTag.class::cast).toList();
+
+        assertEquals("title ipsum", genericTags.stream()
+            .filter(tag -> tag.getCode().equalsIgnoreCase("title")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+
+        assertEquals("summary ipsum", genericTags.stream()
+            .filter(tag -> tag.getCode().equalsIgnoreCase("summary")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+
+        assertEquals("1687765220", genericTags.stream()
+            .filter(tag -> tag.getCode().equalsIgnoreCase("published_at")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+
+        assertEquals("location ipsum", genericTags.stream()
+            .filter(tag -> tag.getCode().equalsIgnoreCase("location")).map(GenericTag::getAttributes).toList().get(0).get(0).getValue());
+    }
+
+    @Test
+    public void testDeserializeTag() {
+        log.info("testDeserializeTag");
+
+        assertDoesNotThrow(() -> {
+            String npubHex = new PublicKey(NostrUtil.hexToBytes(Bech32.fromBech32(("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9")))).toString();
+
+            final String jsonString = "[\"p\", \"" + npubHex + "\", \"wss://nostr.java\", \"alice\"]";
+            var tag = new BaseTagDecoder<>().decode(jsonString);
+
+            assertTrue(tag instanceof PubKeyTag);
+
+            PubKeyTag pTag = (PubKeyTag) tag;
+            assertEquals("wss://nostr.java", pTag.getMainRelayUrl());
+            assertEquals(npubHex, pTag.getPublicKey().toString());
+            assertEquals("alice", pTag.getPetName());
+        });
+    }
+
+    @Test
+    public void testDeserializeGenericTag() {
+        log.info("testDeserializeGenericTag");
+        assertDoesNotThrow(() -> {
+            String npubHex = new PublicKey(Bech32.decode("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9").data).toString();
+            final String jsonString = "[\"gt\", \"" + npubHex + "\", \"wss://nostr.java\", \"alice\"]";
+            var tag = new BaseTagDecoder<>().decode(jsonString);
+
+            assertTrue(tag instanceof GenericTag);
+
+            GenericTag gTag = (GenericTag) tag;
+            assertEquals("gt", gTag.getCode());
+        });
+    }
+
+    @Test
+    public void testFiltersEncoder() {
+        log.info("testFiltersEncoder");
+
+        String new_geohash = "2vghde";
+        List<String> geohashList = new ArrayList<>();
+        geohashList.add(new_geohash);
+        Filters filters = Filters.builder().genericTagQuery(Map.of("#g", geohashList)).build();
+
+        FiltersEncoder encoder = new FiltersEncoder(filters);
+        String jsonMessage = encoder.encode();
+        assertEquals("{\"#g\":[\"2vghde\"]}", jsonMessage);
+    }
+
+    @Test
+    public void testReqMessageFilterListSerializer() {
+        log.info("testReqMessageFilterListSerializer");
+
+        String new_geohash = "2vghde";
+        String second_geohash = "3abcde";
+        List<String> geohashList = new ArrayList<>();
+        geohashList.add(new_geohash);
+        geohashList.add(second_geohash);
+        Filters filters = Filters.builder().genericTagQuery(Map.of("#g", geohashList)).build();
+
+        ReqMessage reqMessage = new ReqMessage("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9", new ArrayList<Filters>(List.of(filters)));
+        assertDoesNotThrow(() -> {
+            String jsonMessage = reqMessage.encode();
+
+            assertEquals("[\"REQ\",\"npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9\",{\"#g\":[\"2vghde\",\"3abcde\"]}]", jsonMessage);
+        });
+    }
+
+    @Test
+    public void testReqMessageFiltersDecoder() {
+        log.info("testReqMessageFiltersDecoder");
+
+        String geohashKey = "#g";
+        String geohashValue = "2vghde";
+        String reqJsonWithCustomTagQueryFilterToDecode = "{\"" + geohashKey + "\":[\"" + geohashValue + "\"]}";
+
+        Filters decodedFilters = new FiltersDecoder<>().decode(reqJsonWithCustomTagQueryFilterToDecode);
+
+        Filters expectedFilters = new Filters();
+        List<String> expectedGeohashValueList = List.of(geohashValue);
+        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValueList);
+
+        assertEquals(expectedFilters, decodedFilters);
+    }
+
+    @Test
+    public void testReqMessageFiltersListDecoder() {
+        log.info("testReqMessageFiltersListDecoder");
+
+        String geohashKey = "#g";
+        String geohashValue1 = "2vghde";
+        String geohashValue2 = "3abcde";
+        String reqJsonWithCustomTagQueryFilterToDecode = "{\"" + geohashKey + "\":[\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]}";
+
+        Filters decodedFilters = new FiltersDecoder<>().decode(reqJsonWithCustomTagQueryFilterToDecode);
+
+        Filters expectedFilters = new Filters();
+        List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
+        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
+
+        assertEquals(expectedFilters, decodedFilters);
+    }
+
+    @Test
+    public void testReqMessageDeserializer() {
+        log.info("testReqMessageDeserializer");
+
+        String subscriptionId = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9";
+        String geohashKey = "#g";
+        String geohashValue = "2vghde";
+        String reqJsonWithCustomTagQueryFilterToDecode = "[\"REQ\",\"" + subscriptionId + "\",{\"" + geohashKey + "\":[\"" + geohashValue + "\"]}]";
+
+        ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
+
+        Filters expectedFilters = new Filters();
+        List<String> expectedGeohashValuesList = List.of(geohashValue);
+        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
+
+        ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
+        assertEquals(expectedReqMessage, decodedReqMessage);
+    }
+
+    @Test
+    public void testReqMessageFilterListDecoder() {
+        log.info("testReqMessageFilterListDecoder");
+
+        String subscriptionId = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9";
+        String geohashKey = "#g";
+        String geohashValue1 = "2vghde";
+        String geohashValue2 = "3abcde";
+        String reqJsonWithCustomTagQueryFiltersToDecode = "[\"REQ\",\"" + subscriptionId + "\",{\"" + geohashKey + "\":[\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]}]";
+
+        ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFiltersToDecode);
+
+        Filters expectedFilters = new Filters();
+        List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
+        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
+
+        ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
+        assertEquals(expectedReqMessage, decodedReqMessage);
+    }
+
+    @Test
+    public void testReqMessagePopulatedFilterDecoder() {
+        log.info("testReqMessagePopulatedFilterDecoder");
+
+        String subscriptionId = "npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh";
+        String kind = "1";
+        String author = "f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75";
+        String geohashKey = "#g";
+        String geohashValue1 = "2vghde";
+        String geohashValue2 = "3abcde";
+        String referencedEventId = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
+        String reqJsonWithCustomTagQueryFilterToDecode =
+            "[\"REQ\", " +
+                "\"" + subscriptionId + "\", " +
+                "{\"kinds\": [" + kind + "], " +
+                "\"authors\": [\"" + author + "\"]," +
+                "\"" + geohashKey + "\": [\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]," +
+                "\"#e\": [\"" + referencedEventId + "\"]}]";
+
+        ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
+
+        Filters expectedFilters = new Filters();
+        expectedFilters.setKinds(List.of(Kind.TEXT_NOTE));
+        expectedFilters.setAuthors(List.of(new PublicKey(author)));
+        expectedFilters.setReferencedEvents(List.of(new GenericEvent(referencedEventId)));
+        List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
+        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
+
+        ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
+        assertEquals(expectedReqMessage, decodedReqMessage);
+    }
+
+    @Test
+    public void testReqMessagePopulatedListOfFiltersListDecoder() {
+        log.info("testReqMessagePopulatedListOfFiltersListDecoder");
+
+        String subscriptionId = "npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh";
+        String kind = "1";
+        String author = "f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75";
+        String geohashKey = "#g";
+        String geohashValue1 = "2vghde";
+        String geohashValue2 = "3abcde";
+        String referencedEventId = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
+        String uuidKey = "#d";
+        String uuidValue1 = "UUID-1";
+        String uuidValue2 = "UUID-2";
+        String reqJsonWithCustomTagQueryFilterToDecode =
+            "[\"REQ\", " +
+                "\"" + subscriptionId + "\", " +
+                "{\"kinds\": [" + kind + "], " +
+                "\"authors\": [\"" + author + "\"]," +
+                "\"" + geohashKey + "\": [\"" + geohashValue1 + "\",\"" + geohashValue2 + "\"]," +
+                "\"" + uuidKey + "\": [\"" + uuidValue1 + "\",\"" + uuidValue2 + "\"]," +
+                "\"#e\": [\"" + referencedEventId + "\"]}]";
+
+        ReqMessage decodedReqMessage = new BaseMessageDecoder<ReqMessage>().decode(reqJsonWithCustomTagQueryFilterToDecode);
+
+        Filters expectedFilters = new Filters();
+        expectedFilters.setKinds(List.of(Kind.TEXT_NOTE));
+        expectedFilters.setAuthors(List.of(new PublicKey(author)));
+        expectedFilters.setReferencedEvents(List.of(new GenericEvent(referencedEventId)));
+        List<String> expectedGeohashValuesList = List.of(geohashValue1, geohashValue2);
+        expectedFilters.setGenericTagQuery(geohashKey, expectedGeohashValuesList);
+        List<String> expectedIdentityTagValuesList = List.of(uuidValue1, uuidValue2);
+        expectedFilters.setGenericTagQuery(uuidKey, expectedIdentityTagValuesList);
+        ReqMessage expectedReqMessage = new ReqMessage(subscriptionId, expectedFilters);
+        assertEquals(expectedReqMessage, decodedReqMessage);
+    }
+
+    @Test
+    public void testReqMessageSubscriptionIdLength() {
+        log.info("testReqMessageSubscriptionIdLength");
+        String id65Chars = "npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9ab";
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new ReqMessage(id65Chars, new Filters()))
+                .getMessage().contains("subscriptionId length must be between 1 and 64 characters but was [65]"));
+    }
+
+    @Test
+    public void testReqMessageFilterIdLength() {
+        log.info("testReqMessageFilterIdLength");
+        String id64chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712";
+        String reqJsonId64Chars =
+            "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id64chars + "\"]}]";
+        assertDoesNotThrow(() -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId64Chars));
+
+        String id65chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123";
+        String reqJsonId65Chars =
+            "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id65chars + "\"]}]";
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId65Chars))
+                .getMessage().contains("[fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a7123], length: [65], target length: [64]"));
+
+        String id63chars = "fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71";
+        String reqJsonId63chars =
+            "[\"REQ\",\"" + "subscriber_id" + "\",{\"ids\":[\"" + id63chars + "\"]}]";
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<ReqMessage>().decode(reqJsonId63chars))
+                .getMessage().contains("[fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a71], length: [63], target length: [64]"));
+    }
+
+    @Test
+    public void testReqMessageDecoderKind() {
+        log.info("testReqMessageDecoderKind");
+
+        Function<Integer, String> kindTarget = kind -> "[\"REQ\", " +
+            "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+            "{\"kinds\": [" + kind + "]" +
+            "}]";
+
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(0)));
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(kindTarget.apply(65535)));
+
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(-1)))
+                .getMessage().contains("Kind must be between 0 and 65535 but was [-1]"));
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(kindTarget.apply(65536)))
+                .getMessage().contains("Kind must be between 0 and 65535 but was [65536]"));
+    }
+
+    @Test
+    public void testReqMessageDecoderETag() {
+        log.info("testReqMessageDecoderETag");
+
+        String VALID_EVENTID = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+        String VALID_EVENTID_ALL_ZEROS = "0000000000000000000000000000000000000000000000000000000000000000";
+        String VALID_EVENTID_ALL_FF = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        String INVALID_EVENTID_NON_HEX_DIGITS = "XYZdf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+        String INVALID_EVENTID_LENGTH_TOO_SHORT = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6";
+        String INVALID_EVENTID_LENGTH_TOO_LONG = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f666";
+        String INVALID_EVENTID_HAS_MULTIPLE_UPPERCASE = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+        String INVALID_EVENTID_HAS_SINGLE_UPPERCASE = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6F";
+
+        Function<String, String> eTagTarget = eTag -> "[\"REQ\", " +
+            "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+            "{\"#e\": [\"" + eTag + "\"]}]";
+
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_EVENTID)));
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_EVENTID_ALL_ZEROS)));
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_EVENTID_ALL_FF)));
+
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_NON_HEX_DIGITS)))
+                .getMessage().contains("has non-hex characters"));
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_SHORT)))
+                .getMessage().contains("target length"));
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_LENGTH_TOO_LONG)))
+                .getMessage().contains("target length"));
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_MULTIPLE_UPPERCASE)))
+                .getMessage().contains("has uppcase characters"));
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_EVENTID_HAS_SINGLE_UPPERCASE)))
+                .getMessage().contains("has uppcase characters"));
+    }
+
+    @Test
+    public void testReqMessageDecoderPTag() {
+        log.info("testReqMessageDecoderPTag");
+
+        String VALID_HEXPUBKEY = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+        String VALID_HEXPUBKEY_ALL_ZEROS = "0000000000000000000000000000000000000000000000000000000000000000";
+        String VALID_HEXPUBKEY_ALL_FF = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        String INVALID_HEXPUBKEY_NON_HEX_DIGITS = "XYZdf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f";
+        String INVALID_HEXPUBKEY_LENGTH_TOO_SHORT = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6";
+        String INVALID_HEXPUBKEY_LENGTH_TOO_LONG = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f666";
+        String INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
+        String INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE = "56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6F";
+
+        Function<String, String> eTagTarget = pTag -> "[\"REQ\", " +
+            "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+            "{\"#p\": [\"" + pTag + "\"]}]";
+
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY)));
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY_ALL_ZEROS)));
+        assertDoesNotThrow(() -> new BaseMessageDecoder<>().decode(eTagTarget.apply(VALID_HEXPUBKEY_ALL_FF)));
+
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_NON_HEX_DIGITS)))
+                .getMessage().contains("has non-hex characters"));
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_SHORT)))
+                .getMessage().contains("target length"));
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_LENGTH_TOO_LONG)))
+                .getMessage().contains("target length"));
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_MULTIPLE_UPPERCASE)))
+                .getMessage().contains("has uppcase characters"));
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(eTagTarget.apply(INVALID_HEXPUBKEY_HAS_SINGLE_UPPERCASE)))
+                .getMessage().contains("has uppcase characters"));
+    }
+
+    @Test
+    public void testReqMessageFilterSince() {
+        log.info("testReqMessageFilterSince");
+        Function<String, String> sinceTarget = since -> "[\"REQ\", " +
+            "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+            "{\"since\": " + since + "}]";
+
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(sinceTarget.apply(null)))
+                .getMessage().contains("since is marked non-null but is null"));
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(sinceTarget.apply("-1")))
+                .getMessage().contains("'since' filter cannot be negative"));
+        assertTrue(
+            assertThrows(JsonMappingException.class, () -> new BaseMessageDecoder<>().decode(sinceTarget.apply("a")))
+                .getMessage().contains("Unrecognized token 'a'"));
+    }
+
+    @Test
+    public void testReqMessageFilterUntil() {
+        log.info("testReqMessageFilterUntil");
+        Function<String, String> untilTarget = until -> "[\"REQ\", " +
+            "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+            "{\"until\": " + until + "}]";
+
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(untilTarget.apply(null)))
+                .getMessage().contains("until is marked non-null but is null"));
+        assertTrue(
+            assertThrows(IllegalArgumentException.class, () -> new BaseMessageDecoder<>().decode(untilTarget.apply("-1")))
+                .getMessage().contains("'until' filter cannot be negative"));
+        assertTrue(
+            assertThrows(JsonMappingException.class, () -> new BaseMessageDecoder<>().decode(untilTarget.apply("a")))
+                .getMessage().contains("Unrecognized token 'a'"));
+    }
 }

--- a/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
+++ b/nostr-java-test/src/test/java/nostr/test/json/JsonParseTest.java
@@ -27,6 +27,7 @@ import nostr.event.tag.EventTag;
 import nostr.event.tag.PriceTag;
 import nostr.event.tag.PubKeyTag;
 import nostr.id.Identity;
+import nostr.util.NostrUtil;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -122,7 +123,6 @@ public class JsonParseTest {
         assertEquals(Command.EVENT.toString(), message.getCommand());
 
         final var event = (GenericEvent) (((EventMessage) message).getEvent());
-        assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((EventMessage) message).getSubscriptionId());
         assertEquals(1, event.getKind().intValue());
         assertEquals(1686199583, event.getCreatedAt().longValue());
         assertEquals("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712", event.getId());
@@ -244,7 +244,8 @@ public class JsonParseTest {
         log.info("testDeserializeTag");
 
         assertDoesNotThrow(() -> {
-            String npubHex = new PublicKey(Bech32.decode("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9").data).toString();
+            String npubHex = new PublicKey(NostrUtil.hexToBytes(Bech32.fromBech32(("npub1clk6vc9xhjp8q5cws262wuf2eh4zuvwupft03hy4ttqqnm7e0jrq3upup9")))).toString();
+
             final String jsonString = "[\"p\", \"" + npubHex + "\", \"wss://nostr.java\", \"alice\"]";
             var tag = new BaseTagDecoder<>().decode(jsonString);
 

--- a/nostr-java-util/src/main/java/nostr/util/NostrUtil.java
+++ b/nostr-java-util/src/main/java/nostr/util/NostrUtil.java
@@ -16,104 +16,104 @@ import java.util.Arrays;
  */
 public class NostrUtil {
 
-  private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+    private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
-  public static String bytesToHex(byte[] b) {
-    char[] hexChars = new char[b.length * 2];
-    for (int j = 0; j < b.length; j++) {
-      int v = b[j] & 0xFF;
-      hexChars[j * 2] = HEX_ARRAY[v >>> 4];
-      hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
-    }
-    return new String(hexChars).toLowerCase();
-  }
-
-  public static byte[] hexToBytes(String s) {
-    HexStringValidator.validateHex(s, 64);
-    return hexToBytesConvert(s);
-  }
-
-  public static byte[] hex128ToBytes(String s) {
-    HexStringValidator.validateHex(s, 128);
-    return hexToBytesConvert(s);
-  }
-
-  private static byte[] hexToBytesConvert(String s) {
-    int len = s.length();
-    byte[] buf = new byte[len / 2];
-    for (int i = 0; i < len; i += 2) {
-      buf[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
-    }
-    return buf;
-  }
-
-  public static byte[] bytesFromInt(int n) {
-    return ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(n).array();
-  }
-
-  public static byte[] bytesFromBigInteger(BigInteger n) {
-
-    byte[] b = n.toByteArray();
-
-    if (b.length == 32) {
-      return b;
-    } else if (b.length > 32) {
-      return Arrays.copyOfRange(b, b.length - 32, b.length);
-    } else {
-      byte[] buf = new byte[32];
-      System.arraycopy(b, 0, buf, buf.length - b.length, b.length);
-      return buf;
-    }
-  }
-
-  public static BigInteger bigIntFromBytes(byte[] b) {
-    return new BigInteger(1, b);
-  }
-
-  public static byte[] sha256(byte[] b) throws NoSuchAlgorithmException {
-    MessageDigest digest = MessageDigest.getInstance("SHA-256");
-    return digest.digest(b);
-  }
-
-  public static byte[] xor(byte[] b0, byte[] b1) {
-
-    if (b0.length != b1.length) {
-      return null;
+    public static String bytesToHex(byte[] b) {
+        char[] hexChars = new char[b.length * 2];
+        for (int j = 0; j < b.length; j++) {
+            int v = b[j] & 0xFF;
+            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+        }
+        return new String(hexChars).toLowerCase();
     }
 
-    byte[] ret = new byte[b0.length];
-    int i = 0;
-    for (byte b : b0) {
-      ret[i] = (byte) (b ^ b1[i]);
-      i++;
+    public static byte[] hexToBytes(String s) {
+        HexStringValidator.validateHex(s, 64);
+        return hexToBytesConvert(s);
     }
 
-    return ret;
-  }
+    public static byte[] hex128ToBytes(String s) {
+        HexStringValidator.validateHex(s, 128);
+        return hexToBytesConvert(s);
+    }
 
-  public static byte[] createRandomByteArray(int len) {
-    byte[] b = new byte[len];
-    new SecureRandom().nextBytes(b);
-    return b;
-  }
+    private static byte[] hexToBytesConvert(String s) {
+        int len = s.length();
+        byte[] buf = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            buf[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
+        }
+        return buf;
+    }
 
-  public static String escapeJsonString(String jsonString) {
-    return jsonString.replace("\\", "\\\\")
-        .replace("\"", "\\\"")
-        .replace("\b", "\\b")
-        .replace("\f", "\\f")
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t");
-  }
+    public static byte[] bytesFromInt(int n) {
+        return ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(n).array();
+    }
 
-  public static String unEscapeJsonString(String jsonString) {
-    return jsonString.replace("\\\\", "\\")
-        .replace("\\\"", "\"")
-        .replace("\\b", "\b")
-        .replace("\\f", "\f")
-        .replace("\\n", "\n")
-        .replace("\\r", "\r")
-        .replace("\\t", "\t");
-  }
+    public static byte[] bytesFromBigInteger(BigInteger n) {
+
+        byte[] b = n.toByteArray();
+
+        if (b.length == 32) {
+            return b;
+        } else if (b.length > 32) {
+            return Arrays.copyOfRange(b, b.length - 32, b.length);
+        } else {
+            byte[] buf = new byte[32];
+            System.arraycopy(b, 0, buf, buf.length - b.length, b.length);
+            return buf;
+        }
+    }
+
+    public static BigInteger bigIntFromBytes(byte[] b) {
+        return new BigInteger(1, b);
+    }
+
+    public static byte[] sha256(byte[] b) throws NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return digest.digest(b);
+    }
+
+    public static byte[] xor(byte[] b0, byte[] b1) {
+
+        if (b0.length != b1.length) {
+            return null;
+        }
+
+        byte[] ret = new byte[b0.length];
+        int i = 0;
+        for (byte b : b0) {
+            ret[i] = (byte) (b ^ b1[i]);
+            i++;
+        }
+
+        return ret;
+    }
+
+    public static byte[] createRandomByteArray(int len) {
+        byte[] b = new byte[len];
+        new SecureRandom().nextBytes(b);
+        return b;
+    }
+
+    public static String escapeJsonString(String jsonString) {
+        return jsonString.replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\b", "\\b")
+            .replace("\f", "\\f")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t");
+    }
+
+    public static String unEscapeJsonString(String jsonString) {
+        return jsonString.replace("\\\\", "\\")
+            .replace("\\\"", "\"")
+            .replace("\\b", "\b")
+            .replace("\\f", "\f")
+            .replace("\\n", "\n")
+            .replace("\\r", "\r")
+            .replace("\\t", "\t");
+    }
 }

--- a/nostr-java-util/src/main/java/nostr/util/NostrUtil.java
+++ b/nostr-java-util/src/main/java/nostr/util/NostrUtil.java
@@ -1,5 +1,7 @@
 package nostr.util;
 
+import nostr.util.thread.HexStringValidator;
+
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -7,7 +9,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.Optional;
 
 /**
  *
@@ -15,112 +16,104 @@ import java.util.Optional;
  */
 public class NostrUtil {
 
-    private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+  private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
-    public static String bytesToHex(byte[] b) {
-        char[] hexChars = new char[b.length * 2];
-        for (int j = 0; j < b.length; j++) {
-            int v = b[j] & 0xFF;
-            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
-            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
-        }
-        return new String(hexChars).toLowerCase();
+  public static String bytesToHex(byte[] b) {
+    char[] hexChars = new char[b.length * 2];
+    for (int j = 0; j < b.length; j++) {
+      int v = b[j] & 0xFF;
+      hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+      hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+    }
+    return new String(hexChars).toLowerCase();
+  }
+
+  public static byte[] hexToBytes(String s) {
+    HexStringValidator.validateHex(s, 64);
+    return hexToBytesConvert(s);
+  }
+
+  public static byte[] hex128ToBytes(String s) {
+    HexStringValidator.validateHex(s, 128);
+    return hexToBytesConvert(s);
+  }
+
+  private static byte[] hexToBytesConvert(String s) {
+    int len = s.length();
+    byte[] buf = new byte[len / 2];
+    for (int i = 0; i < len; i += 2) {
+      buf[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
+    }
+    return buf;
+  }
+
+  public static byte[] bytesFromInt(int n) {
+    return ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(n).array();
+  }
+
+  public static byte[] bytesFromBigInteger(BigInteger n) {
+
+    byte[] b = n.toByteArray();
+
+    if (b.length == 32) {
+      return b;
+    } else if (b.length > 32) {
+      return Arrays.copyOfRange(b, b.length - 32, b.length);
+    } else {
+      byte[] buf = new byte[32];
+      System.arraycopy(b, 0, buf, buf.length - b.length, b.length);
+      return buf;
+    }
+  }
+
+  public static BigInteger bigIntFromBytes(byte[] b) {
+    return new BigInteger(1, b);
+  }
+
+  public static byte[] sha256(byte[] b) throws NoSuchAlgorithmException {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    return digest.digest(b);
+  }
+
+  public static byte[] xor(byte[] b0, byte[] b1) {
+
+    if (b0.length != b1.length) {
+      return null;
     }
 
-    public static byte[] hexToBytes(String s) {
-        validateHexString(s, 64);
-        return hexToBytesConvert(s);
+    byte[] ret = new byte[b0.length];
+    int i = 0;
+    for (byte b : b0) {
+      ret[i] = (byte) (b ^ b1[i]);
+      i++;
     }
 
-    public static byte[] hex128ToBytes(String s) {
-        validateHexString(s, 128);
-        return hexToBytesConvert(s);
-    }
+    return ret;
+  }
 
-    private static byte[] hexToBytesConvert(String s) {
-        int len = s.length();
-        byte[] buf = new byte[len / 2];
-        for (int i = 0; i < len; i += 2) {
-            buf[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
-        }
-        return buf;
-    }
+  public static byte[] createRandomByteArray(int len) {
+    byte[] b = new byte[len];
+    new SecureRandom().nextBytes(b);
+    return b;
+  }
 
-    public static void validateHexString(String hexString, int targetLength) {
-        Optional.ofNullable(hexString) // non-null enforcement
-            .filter(s -> s.length() == targetLength)  // length enforcement
-            .filter(s -> s.toLowerCase().equals(s)) // case-sensitivity enforcement, potentially swappable for line below
-//                .map(String::toLowerCase)               // if upper-case leniency is desirable, followed by explicit lower-casing
-            .orElseThrow(() -> new IllegalArgumentException(String.format("Invalid hex string: [%s], length: [%d], target length: [%d]", hexString, hexString.length(), targetLength)));
-    }
+  public static String escapeJsonString(String jsonString) {
+    return jsonString.replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\b", "\\b")
+        .replace("\f", "\\f")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t");
+  }
 
-    public static byte[] bytesFromInt(int n) {
-        return ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(n).array();
-    }
-
-    public static byte[] bytesFromBigInteger(BigInteger n) {
-
-        byte[] b = n.toByteArray();
-
-        if (b.length == 32) {
-            return b;
-        } else if (b.length > 32) {
-            return Arrays.copyOfRange(b, b.length - 32, b.length);
-        } else {
-            byte[] buf = new byte[32];
-            System.arraycopy(b, 0, buf, buf.length - b.length, b.length);
-            return buf;
-        }
-    }
-
-    public static BigInteger bigIntFromBytes(byte[] b) {
-        return new BigInteger(1, b);
-    }
-
-    public static byte[] sha256(byte[] b) throws NoSuchAlgorithmException {
-        MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        return digest.digest(b);
-    }
-
-    public static byte[] xor(byte[] b0, byte[] b1) {
-
-        if (b0.length != b1.length) {
-            return null;
-        }
-
-        byte[] ret = new byte[b0.length];
-        int i = 0;
-        for (byte b : b0) {
-            ret[i] = (byte) (b ^ b1[i]);
-            i++;
-        }
-
-        return ret;
-    }
-
-    public static byte[] createRandomByteArray(int len) {
-        byte[] b = new byte[len];
-        new SecureRandom().nextBytes(b);
-        return b;
-    }
-
-    public static String escapeJsonString(String jsonString) {
-        return jsonString.replace("\\", "\\\\")
-            .replace("\"", "\\\"")
-            .replace("\b", "\\b")
-            .replace("\f", "\\f")
-            .replace("\n", "\\n")
-            .replace("\r", "\\r")
-            .replace("\t", "\\t");
-    }
-
-    public static String unEscapeJsonString(String jsonString) {
-        return jsonString.replace("\\\\", "\\")
-            .replace("\\\"", "\"")
-            .replace("\\b", "\b")
-            .replace("\\f", "\f")
-            .replace("\\n", "\n")
-            .replace("\\r", "\r")
-            .replace("\\t", "\t");
-    }
+  public static String unEscapeJsonString(String jsonString) {
+    return jsonString.replace("\\\\", "\\")
+        .replace("\\\"", "\"")
+        .replace("\\b", "\b")
+        .replace("\\f", "\f")
+        .replace("\\n", "\n")
+        .replace("\\r", "\r")
+        .replace("\\t", "\t");
+  }
 }

--- a/nostr-java-util/src/main/java/nostr/util/NostrUtil.java
+++ b/nostr-java-util/src/main/java/nostr/util/NostrUtil.java
@@ -38,6 +38,11 @@ public class NostrUtil {
         return hexToBytesConvert(s);
     }
 
+    public static byte[] nip04PubKeyHexToBytes(String s) {
+        HexStringValidator.validateHex(s, 66);
+        return hexToBytesConvert(s);
+    }
+
     private static byte[] hexToBytesConvert(String s) {
         int len = s.length();
         byte[] buf = new byte[len / 2];

--- a/nostr-java-util/src/main/java/nostr/util/NostrUtil.java
+++ b/nostr-java-util/src/main/java/nostr/util/NostrUtil.java
@@ -7,6 +7,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.Optional;
 
 /**
  *
@@ -27,12 +28,30 @@ public class NostrUtil {
     }
 
     public static byte[] hexToBytes(String s) {
+        validateHexString(s, 64);
+        return hexToBytesConvert(s);
+    }
+
+    public static byte[] hex128ToBytes(String s) {
+        validateHexString(s, 128);
+        return hexToBytesConvert(s);
+    }
+
+    private static byte[] hexToBytesConvert(String s) {
         int len = s.length();
         byte[] buf = new byte[len / 2];
         for (int i = 0; i < len; i += 2) {
             buf[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
         }
         return buf;
+    }
+
+    public static void validateHexString(String hexString, int targetLength) {
+        Optional.ofNullable(hexString) // non-null enforcement
+            .filter(s -> s.length() == targetLength)  // length enforcement
+            .filter(s -> s.toLowerCase().equals(s)) // case-sensitivity enforcement, potentially swappable for line below
+//                .map(String::toLowerCase)               // if upper-case leniency is desirable, followed by explicit lower-casing
+            .orElseThrow(() -> new IllegalArgumentException(String.format("Invalid hex string: [%s], length: [%d], length targetLength: [%d]", hexString, hexString.length(), targetLength)));
     }
 
     public static byte[] bytesFromInt(int n) {
@@ -87,21 +106,21 @@ public class NostrUtil {
 
     public static String escapeJsonString(String jsonString) {
         return jsonString.replace("\\", "\\\\")
-                .replace("\"", "\\\"")
-                .replace("\b", "\\b")
-                .replace("\f", "\\f")
-                .replace("\n", "\\n")
-                .replace("\r", "\\r")
-                .replace("\t", "\\t");
+            .replace("\"", "\\\"")
+            .replace("\b", "\\b")
+            .replace("\f", "\\f")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t");
     }
 
     public static String unEscapeJsonString(String jsonString) {
         return jsonString.replace("\\\\", "\\")
-                .replace("\\\"", "\"")
-                .replace("\\b", "\b")
-                .replace("\\f", "\f")
-                .replace("\\n", "\n")
-                .replace("\\r", "\r")
-                .replace("\\t", "\t");
+            .replace("\\\"", "\"")
+            .replace("\\b", "\b")
+            .replace("\\f", "\f")
+            .replace("\\n", "\n")
+            .replace("\\r", "\r")
+            .replace("\\t", "\t");
     }
 }

--- a/nostr-java-util/src/main/java/nostr/util/NostrUtil.java
+++ b/nostr-java-util/src/main/java/nostr/util/NostrUtil.java
@@ -51,7 +51,7 @@ public class NostrUtil {
             .filter(s -> s.length() == targetLength)  // length enforcement
             .filter(s -> s.toLowerCase().equals(s)) // case-sensitivity enforcement, potentially swappable for line below
 //                .map(String::toLowerCase)               // if upper-case leniency is desirable, followed by explicit lower-casing
-            .orElseThrow(() -> new IllegalArgumentException(String.format("Invalid hex string: [%s], length: [%d], length targetLength: [%d]", hexString, hexString.length(), targetLength)));
+            .orElseThrow(() -> new IllegalArgumentException(String.format("Invalid hex string: [%s], length: [%d], target length: [%d]", hexString, hexString.length(), targetLength)));
     }
 
     public static byte[] bytesFromInt(int n) {

--- a/nostr-java-util/src/main/java/nostr/util/thread/HexStringValidator.java
+++ b/nostr-java-util/src/main/java/nostr/util/thread/HexStringValidator.java
@@ -1,0 +1,50 @@
+package nostr.util.thread;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class HexStringValidator {
+  private static final String validHexChars = "0123456789ABCDEF";
+
+  private static BiFunction<String, Integer, Boolean> lengthCheck = (s, targetLength) -> s.length() == targetLength;
+  private static Function<String, Boolean> hexCharsCheck = HexStringValidator::checkValidHexChars;
+  private static Function<String, Boolean> upperCaseCheck = s -> s.toLowerCase().equals(s);
+
+  public static void validateHex(String hexString, int targetLength) {
+    List<String> exceptions = new ArrayList<>();
+    Optional.ofNullable(hexString) // non-null enforcement
+        .filter(s -> {
+          if (!lengthCheck.apply(s, targetLength)) {
+            return exceptions.add(String.format("Invalid hex string: [%s], length: [%d], target length: [%d]", hexString, hexString.length(), targetLength));
+          }
+          return true;
+        })
+        .filter(s -> {
+          if (!hexCharsCheck.apply(s)) {
+            exceptions.add(String.format("Invalid hex string: [%s] has non-hex characters", hexString));
+          }
+          return true;
+        })
+        .filter(s -> {
+          if (!upperCaseCheck.apply(s)) {
+            exceptions.add(String.format("Invalid hex string: [%s] has uppcase characters", hexString));
+          }
+          return true;
+        });
+
+    if (!exceptions.isEmpty()) {
+      throw new IllegalArgumentException(exceptions.getFirst());
+    }
+  }
+
+  private static Boolean checkValidHexChars(String aHexString) {
+    for (char a : aHexString.toCharArray()) {
+      if (validHexChars.toLowerCase().indexOf(a) < 0)
+        return false;
+    }
+    return true;
+  }
+}

--- a/nostr-java-util/src/main/java/nostr/util/thread/HexStringValidator.java
+++ b/nostr-java-util/src/main/java/nostr/util/thread/HexStringValidator.java
@@ -7,7 +7,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public class HexStringValidator {
-  private static final String validHexChars = "0123456789ABCDEF";
+  private static final String validHexChars = "0123456789abcdef";
 
   private static BiFunction<String, Integer, Boolean> lengthCheck = (s, targetLength) -> s.length() == targetLength;
   private static Function<String, Boolean> hexCharsCheck = HexStringValidator::checkValidHexChars;
@@ -41,8 +41,8 @@ public class HexStringValidator {
   }
 
   private static Boolean checkValidHexChars(String aHexString) {
-    for (char a : aHexString.toCharArray()) {
-      if (validHexChars.toLowerCase().indexOf(a) < 0)
+    for (char a : aHexString.toLowerCase().toCharArray()) {
+      if (validHexChars.indexOf(a) < 0)
         return false;
     }
     return true;

--- a/nostr-java-util/src/main/java/nostr/util/thread/HexStringValidator.java
+++ b/nostr-java-util/src/main/java/nostr/util/thread/HexStringValidator.java
@@ -1,5 +1,7 @@
 package nostr.util.thread;
 
+import lombok.NonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -9,13 +11,13 @@ import java.util.function.Function;
 public class HexStringValidator {
   private static final String validHexChars = "0123456789abcdef";
 
-  private static BiFunction<String, Integer, Boolean> lengthCheck = (s, targetLength) -> s.length() == targetLength;
-  private static Function<String, Boolean> hexCharsCheck = HexStringValidator::checkValidHexChars;
-  private static Function<String, Boolean> upperCaseCheck = s -> s.toLowerCase().equals(s);
+  private static final BiFunction<String, Integer, Boolean> lengthCheck = (s, targetLength) -> s.length() == targetLength;
+  private static final Function<String, Boolean> hexCharsCheck = HexStringValidator::checkValidHexChars;
+  private static final Function<String, Boolean> upperCaseCheck = s -> s.toLowerCase().equals(s);
 
-  public static void validateHex(String hexString, int targetLength) {
+  public static void validateHex(@NonNull String hexString, int targetLength) {
     List<String> exceptions = new ArrayList<>();
-    Optional.ofNullable(hexString) // non-null enforcement
+    Optional.of(hexString) // non-null enforcement
         .filter(s -> {
           if (!lengthCheck.apply(s, targetLength)) {
             return exceptions.add(String.format("Invalid hex string: [%s], length: [%d], target length: [%d]", hexString, hexString.length(), targetLength));

--- a/pom.xml
+++ b/pom.xml
@@ -70,15 +70,15 @@
         <okio.version>2.8.0</okio.version>
 
         <!-- Annotation Dependency Versions -->
-        <lombok.version>1.18.32</lombok.version>
+        <lombok.version>1.18.34</lombok.version>
 
         <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
         <bcprov-jdk18on.version>1.78</bcprov-jdk18on.version>
 
-        <jackson-databind.version>2.14.1</jackson-databind.version>
+        <jackson-databind.version>2.17.2</jackson-databind.version>
 
         <!-- Test Dependency Versions -->
-        <junit.version>5.9.1</junit.version>
+        <junit.version>5.10.2</junit.version>
         <assertj.version>3.23.1</assertj.version>
 
         <!-- Maven Plugin Versions -->


### PR DESCRIPTION
hi, eric.  REQ message filter/json (plus GenericEvent & PublicKey) validations per [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md#from-client-to-relay-sending-events-and-creating-subscriptions) specification have been implemented and tested in this PR (with following synopsis for reference) and a note for you at bottom re: NIP-04.  

pls advise if any issues i've overlooked/mis-implemented per your understanding/etc.

#####  "ids": <a list of event ids>, 32-bytes lowercase hex
implementation in:  
`GenericEvent.setId(), calls HexStringValidator.validateHex()`

tested in:
`JsonParseTest.testReqMessageFilterIdLength()  `


#####  "authors": <a list of lowercase pubkeys>, 32-bytes lowercase hex
implementation in:
`PublicKey(String hexPubKey) calls NostrUtil.hexToBytes(), calls HexStringValidator.validateHex()`

tested in:
BaseKeyTest.java


#####  "kinds": <a list of a kind numbers>, integer between 0 and 65535

implementation in:
`Kind.valueOf()`
tested
`JsonParseTest.testBaseMessageDecoderKind()`

#####  "#<single-letter (a-zA-Z)>": <a list of tag values, for #e — a list of event ids, for #p — a list of pubkeys, etc.>,

implementation in:
`GenericEvent.setId() calls HexStringValidator.validateHex()`
`PublicKey(String hexPubKey) calls NostrUtil.hexToBytes(), calls HexStringValidator.validateHex()`
tested in:
`JsonParseTest.testReqMessageDecoderETag()`
`JsonParseTest.testReqMessageDecoderPTag()`

#####  "since": <an integer unix timestamp in seconds. Events must have a created_at >= to this to pass>,
implemented in:
`Filters.setSince()`
tested in:
`JsonParseTest.testReqMessageFilterSince()`


##### "until": <an integer unix timestamp in seconds. Events must have a created_at <= to this to pass>,
implemented in
`Filters.setUntil()`
tested
`JsonParseTest.testReqMessageFilterUntil()`

##### "limit": <maximum number of events relays SHOULD return in the initial query>
    no changes/tests

#####  <subscription_id> non-empty string of max length 64 chars. 
implemented in:
`ReqMessage ctor(), line 42`
tested  
`JsonParseTest.testReqMessageSubscriptionIdLength()`
  

not surprisingly, introduction of validations uncovered a few existing/minor issues related to NIP-01 hex-string length requirements.  i've fixed the few obvious ones, however, two still exist related to NIP-04, likely ideally addressed by @tcheeric's domain-expertise in this area.  

they are readily visible upon running test suite for this branch, reporting incorrect hex-string length error messages that should be a helpful starting point:  

```java
[ERROR]   ApiEventTest.testNIP04EncryptDecrypt:144 » IllegalArgument Invalid hex string: [0256adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f], length: [66], target length: [64]
[ERROR]   ApiEventTest.testNIP04SendDirectMessage:107 » IllegalArgument Invalid hex string: [0256adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f], length: [66], target length: [64]
```