### PR TITLE
Upstream develop merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Nostr-java is a library for generating, signing, and publishing nostr events to 
     </repository>
 </repositories>
 ```
+<<<<<<< HEAD
 #### Option 2 - Check out and build project directly from source  
+=======
+#### Option 2 - Check out and build project directly from source
+>>>>>>> develop
 
 ```bash
 $ cd <your_git_home_dir>

--- a/README.md
+++ b/README.md
@@ -27,11 +27,7 @@ Nostr-java is a library for generating, signing, and publishing nostr events to 
     </repository>
 </repositories>
 ```
-<<<<<<< HEAD
 #### Option 2 - Check out and build project directly from source  
-=======
-#### Option 2 - Check out and build project directly from source
->>>>>>> develop
 
 ```bash
 $ cd <your_git_home_dir>

--- a/nostr-java-api/src/test/java/nostr/api/unit/JsonParseTest.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/JsonParseTest.java
@@ -1,6 +1,7 @@
 package nostr.api.unit;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Optional;
 import lombok.extern.java.Log;
 import nostr.api.NIP01;
 import nostr.api.util.JsonComparator;
@@ -91,6 +92,25 @@ public class JsonParseTest {
     assertEquals(new ReferencedPublicKeyFilter<>(new PubKeyTag(new PublicKey("fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712"))), referencedPublicKeyfilter.getFirst());
   }
 
+  @Test
+  public void testAbsentFilter() throws JsonProcessingException {
+      final String parseTarget =
+          "[\"REQ\", " +
+              "\"npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh\", " +
+              "{\"kinds\": [1], " +
+              "\"#p\": [\"fc7f200c5bed175702bd06c7ca5dba90d3497e827350b42fc99c3a4fa276a712\"]}]";
+
+      final var message = new BaseMessageDecoder<>().decode(parseTarget);
+
+      assertEquals(Command.REQ.toString(), message.getCommand());
+      assertEquals("npub17x6pn22ukq3n5yw5x9prksdyyu6ww9jle2ckpqwdprh3ey8qhe6stnpujh", ((ReqMessage) message).getSubscriptionId());
+      assertEquals(1, ((ReqMessage) message).getFiltersList().size());
+
+      Filters filters = ((ReqMessage) message).getFiltersList().getFirst();
+      
+      assertTrue(filters.getFilterByType(AuthorFilter.FILTER_KEY).isEmpty());
+  }
+  
   @Test
   public void testBaseMessageDecoderKindsAuthorsReferencedPublicKey() throws JsonProcessingException {
     log.info("testBaseMessageDecoderKindsAuthorsReferencedPublicKey");

--- a/nostr-java-event/src/main/java/nostr/event/BaseMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/BaseMessage.java
@@ -1,8 +1,6 @@
 package nostr.event;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import lombok.Getter;
 import nostr.base.IElement;
 
@@ -12,7 +10,6 @@ import nostr.base.IElement;
  */
 @Getter
 public abstract class BaseMessage implements IElement {
-    private final ArrayNode arrayNode = JsonNodeFactory.instance.arrayNode();
     private final String command;
 
     protected BaseMessage(String command) {

--- a/nostr-java-event/src/main/java/nostr/event/filter/Filters.java
+++ b/nostr-java-event/src/main/java/nostr/event/filter/Filters.java
@@ -1,55 +1,54 @@
 package nostr.event.filter;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
-
-import java.util.List;
-import java.util.Map;
-
 import static java.util.stream.Collectors.groupingBy;
 
 @Getter
 @EqualsAndHashCode
 public class Filters {
-  public static final int DEFAULT_FILTERS_LIMIT = 10;
-  private final Map<String, List<Filterable>> filtersMap;
+    public static final int DEFAULT_FILTERS_LIMIT = 10;
+    private final Map<String, List<Filterable>> filtersMap;
 
-  @Setter
-  private Integer limit = DEFAULT_FILTERS_LIMIT;
+    @Setter
+    private Integer limit = DEFAULT_FILTERS_LIMIT;
 
-  public Filters(@NonNull Filterable... filterablesByDefaultType) {
-    this(List.of(filterablesByDefaultType));
-  }
-
-  public Filters(@NonNull List<Filterable> filterablesByDefaultType) {
-    this(filterablesByDefaultType.stream().collect(groupingBy(Filterable::getFilterKey)));
-  }
-
-  private Filters(@NonNull Map<String, List<Filterable>> filterablesByCustomType) {
-    validateFiltersMap(filterablesByCustomType);
-    this.filtersMap = filterablesByCustomType;
-  }
-
-  public List<Filterable> getFilterByType(@NonNull String type) {
-    return filtersMap.get(type);
-  }
-
-  private static void validateFiltersMap(Map<String, List<Filterable>> filtersMap) throws IllegalArgumentException {
-    if (filtersMap.isEmpty()) {
-      throw new IllegalArgumentException("Filters cannot be empty.");
+    public Filters(@NonNull Filterable... filterablesByDefaultType) {
+        this(List.of(filterablesByDefaultType));
     }
 
-    filtersMap.values().forEach(filterables -> {
-      if (filterables.isEmpty()) {
-        throw new IllegalArgumentException("Filters cannot be empty.");
-      }
-    });
+    public Filters(@NonNull List<Filterable> filterablesByDefaultType) {
+        this(filterablesByDefaultType.stream().collect(groupingBy(Filterable::getFilterKey)));
+    }
 
-    filtersMap.forEach((key, value) -> {
-      if (key.isEmpty())
-        throw new IllegalArgumentException(String.format("Filter key for filterable [%s] is not defined", value.getFirst().getFilterKey()));
-    });
-  }
+    private Filters(@NonNull Map<String, List<Filterable>> filterablesByCustomType) {
+        validateFiltersMap(filterablesByCustomType);
+        this.filtersMap = filterablesByCustomType;
+    }
+
+    public List<Filterable> getFilterByType(@NonNull String type) {
+        return Objects.nonNull(filtersMap.get(type)) ?  filtersMap.get(type) : List.of();
+    }
+
+    private static void validateFiltersMap(Map<String, List<Filterable>> filtersMap) throws IllegalArgumentException {
+        if (filtersMap.isEmpty()) {
+            throw new IllegalArgumentException("Filters cannot be empty.");
+        }
+
+        filtersMap.values().forEach(filterables -> {
+            if (filterables.isEmpty()) {
+                throw new IllegalArgumentException("Filters cannot be empty.");
+            }
+        });
+
+        filtersMap.forEach((key, value) -> {
+            if (key.isEmpty())
+                throw new IllegalArgumentException(String.format("Filter key for filterable [%s] is not defined", value.getFirst().getFilterKey()));
+        });
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/GenericMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/GenericMessage.java
@@ -2,6 +2,7 @@ package nostr.event.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -62,9 +63,10 @@ public class GenericMessage extends BaseMessage implements IGenericElement, IEle
 
     @Override
     public String encode() throws JsonProcessingException {
-        getArrayNode().add(getCommand());
-        getAttributes().stream().map(ElementAttribute::getValue).forEach(v -> getArrayNode().add(v.toString()));
-        return ENCODER_MAPPED_AFTERBURNER.writeValueAsString(getArrayNode());
+        var encoderArrayNode = JsonNodeFactory.instance.arrayNode();
+        encoderArrayNode.add(getCommand());
+        getAttributes().stream().map(ElementAttribute::getValue).forEach(v -> encoderArrayNode.add(v.toString()));
+        return ENCODER_MAPPED_AFTERBURNER.writeValueAsString(encoderArrayNode);
     }
 
 //    public static <T extends BaseMessage> T decode(@NonNull String jsonString) {

--- a/nostr-java-event/src/main/java/nostr/event/message/CloseMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/CloseMessage.java
@@ -2,6 +2,7 @@ package nostr.event.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -33,7 +34,7 @@ public class CloseMessage extends BaseMessage {
     @Override
     public String encode() throws JsonProcessingException {
         return ENCODER_MAPPED_AFTERBURNER.writeValueAsString(
-            getArrayNode()
+            JsonNodeFactory.instance.arrayNode()
                 .add(getCommand())
                 .add(getSubscriptionId()));
     }

--- a/nostr-java-event/src/main/java/nostr/event/message/EoseMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/EoseMessage.java
@@ -2,6 +2,7 @@ package nostr.event.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -32,7 +33,7 @@ public class EoseMessage extends BaseMessage {
     @Override
     public String encode() throws JsonProcessingException {
         return ENCODER_MAPPED_AFTERBURNER.writeValueAsString(
-            getArrayNode()
+            JsonNodeFactory.instance.arrayNode()
                 .add(getCommand())
                 .add(getSubscriptionId()));
     }

--- a/nostr-java-event/src/main/java/nostr/event/message/EventMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/EventMessage.java
@@ -3,6 +3,7 @@ package nostr.event.message;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -44,7 +45,7 @@ public class EventMessage extends BaseMessage {
 
     @Override
     public String encode() throws JsonProcessingException {
-        var arrayNode = getArrayNode().add(getCommand());
+        var arrayNode = JsonNodeFactory.instance.arrayNode().add(getCommand());
         Optional.ofNullable(getSubscriptionId())
             .ifPresent(arrayNode::add);
         arrayNode.add(ENCODER_MAPPED_AFTERBURNER.readTree(

--- a/nostr-java-event/src/main/java/nostr/event/message/NoticeMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/NoticeMessage.java
@@ -2,6 +2,7 @@ package nostr.event.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -29,7 +30,7 @@ public class NoticeMessage extends BaseMessage {
     @Override
     public String encode() throws JsonProcessingException {
         return ENCODER_MAPPED_AFTERBURNER.writeValueAsString(
-            getArrayNode()
+            JsonNodeFactory.instance.arrayNode()
                 .add(getCommand())
                 .add(getMessage()));
     }

--- a/nostr-java-event/src/main/java/nostr/event/message/OkMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/OkMessage.java
@@ -2,6 +2,7 @@ package nostr.event.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -33,7 +34,7 @@ public class OkMessage extends BaseMessage {
     @Override
     public String encode() throws JsonProcessingException {
         return ENCODER_MAPPED_AFTERBURNER.writeValueAsString(
-            getArrayNode()
+            JsonNodeFactory.instance.arrayNode()
                 .add(getCommand())
                 .add(getEventId())
                 .add(getFlag())

--- a/nostr-java-event/src/main/java/nostr/event/message/RelayAuthenticationMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/RelayAuthenticationMessage.java
@@ -2,6 +2,7 @@ package nostr.event.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -29,7 +30,7 @@ public class RelayAuthenticationMessage extends BaseAuthMessage {
     @Override
     public String encode() throws JsonProcessingException {
         return ENCODER_MAPPED_AFTERBURNER.writeValueAsString(
-            getArrayNode()
+            JsonNodeFactory.instance.arrayNode()
                 .add(getCommand())
                 .add(getChallenge()));
     }

--- a/nostr-java-event/src/main/java/nostr/event/message/ReqMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/ReqMessage.java
@@ -3,6 +3,7 @@ package nostr.event.message;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
@@ -47,7 +48,8 @@ public class ReqMessage extends BaseMessage {
 
     @Override
     public String encode() throws JsonProcessingException {
-        getArrayNode()
+        var encoderArrayNode = JsonNodeFactory.instance.arrayNode();
+        encoderArrayNode
           .add(getCommand())
           .add(getSubscriptionId());
 
@@ -55,9 +57,9 @@ public class ReqMessage extends BaseMessage {
           .map(FiltersEncoder::new)
           .map(FiltersEncoder::encode)
           .map(ReqMessage::createJsonNode)
-          .forEach(jsonNode -> getArrayNode().add(jsonNode));
+          .forEach(encoderArrayNode::add);
 
-        return ENCODER_MAPPED_AFTERBURNER.writeValueAsString(getArrayNode());
+        return ENCODER_MAPPED_AFTERBURNER.writeValueAsString(encoderArrayNode);
     }
 
     public static <T extends BaseMessage> T decode(@NonNull Object subscriptionId, @NonNull String jsonString) throws JsonProcessingException {


### PR DESCRIPTION
supplemental:

- since multiple calls to a single <XYZ>Message's encoder() method pollutes its underlying JSON, all encoder() methods updated to create JsonNodeFactory.instance.arrayNode() per encode() call
- Filters.getFilterByType() now returns empty list instead of null
- new and updated unit tests for above