### PR TITLE
add kind 2022 for coinjoin

### DIFF
--- a/nostr-java-event/src/main/java/nostr/event/Kind.java
+++ b/nostr-java-event/src/main/java/nostr/event/Kind.java
@@ -16,6 +16,7 @@ public enum Kind {
     TEXT_NOTE(1, "text_note"),
     OTS_EVENT(1040, "ots_event"),
     RECOMMEND_SERVER(2, "recommend_server"),
+    COINJOIN_POOL(2022, "coinjoin_pool"),
     CONTACT_LIST(3, "contact_list"),
     ENCRYPTED_DIRECT_MESSAGE(4, "encrypted_direct_message"),
     ENCRYPTED_PAYLOADS(44, "encrypted_payloads"),


### PR DESCRIPTION
I am using this library to implement [joinstr](https://github.com/nostr-protocol/nips?#event-kinds) in sparrow wallet