### PR TITLE
Refactor TagSerializer to extend abstract base

### DIFF
--- a/nostr-java-event/src/main/java/nostr/event/json/serializer/TagSerializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/serializer/TagSerializer.java
@@ -1,27 +1,18 @@
 package nostr.event.json.serializer;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import lombok.extern.slf4j.Slf4j;
-import nostr.base.ElementAttribute;
 import nostr.event.BaseTag;
 import nostr.event.tag.GenericTag;
 
-import java.io.IOException;
 import java.io.Serial;
-import java.lang.reflect.Field;
-import java.util.List;
 
-import static nostr.event.json.codec.BaseTagEncoder.BASETAG_ENCODER_MAPPED_AFTERBURNER;
 
 /**
  * @author guilhermegps
  */
 @Slf4j
-public class TagSerializer extends StdSerializer<BaseTag> {
+public class TagSerializer extends AbstractTagSerializer<BaseTag> {
 
     @Serial
     private static final long serialVersionUID = -3877972991082754068L;
@@ -31,43 +22,12 @@ public class TagSerializer extends StdSerializer<BaseTag> {
     }
 
     @Override
-    public void serialize(BaseTag value, JsonGenerator gen, SerializerProvider serializers) {
-        try {
-            // -- Create the node
-            final ObjectNode node = BASETAG_ENCODER_MAPPED_AFTERBURNER.getNodeFactory().objectNode();
-
-            if (value instanceof GenericTag && value.getClass() != GenericTag.class) {
-                // value is a subclass of GenericTag
-                List<Field> fields = value.getSupportedFields();
-
-                // Populate the node with the fields data
-                fields.forEach((Field f) -> {
-                    node.put(f.getName(), value.getFieldValue(f).orElse(null));
-                });
-            } else {
-                // value is not a subclass of GenericTag
-                // Populate the node with the attributes data
-                GenericTag genericTag = (GenericTag) value;
-                List<ElementAttribute> attrs = genericTag.getAttributes();
-                attrs.forEach(a -> node.put(a.getName(), a.getValue().toString()));
-            }
-
-            // Extract the property values from the node and serialize them as an array
-            if (node.isObject()) {
-                ArrayNode arrayNode = node.objectNode().putArray("values");
-
-                // Add the tag code as the first element
-                arrayNode.add(value.getCode());
-                node.fields().forEachRemaining(entry -> arrayNode.add(entry.getValue().asText()));
-
-                gen.writePOJO(arrayNode);
-            } else {
-                throw new AssertionError("node.isObject()", new RuntimeException());
-            }
-
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+    protected void applyCustomAttributes(ObjectNode node, BaseTag value) {
+        if (value instanceof GenericTag genericTag) {
+            genericTag.getAttributes()
+                    .forEach(a -> node.put(a.getName(), a.getValue().toString()));
         }
     }
+
 
 }


### PR DESCRIPTION
## Summary
- simplify `TagSerializer` by extending `AbstractTagSerializer`
- move GenericTag attribute handling to `applyCustomAttributes`

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_6889084e88688331b29861ca86c185d7