### PR TITLE
Refactor FiltersDecoder with Map-based parsing

### DIFF
--- a/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersDecoder.java
@@ -1,5 +1,7 @@
 package nostr.event.json.codec;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.SneakyThrows;
@@ -8,6 +10,7 @@ import nostr.event.filter.Filters;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static nostr.base.IEvent.MAPPER_AFTERBURNER;
 
@@ -21,11 +24,16 @@ public class FiltersDecoder implements FDecoder<Filters> {
   public Filters decode(@NonNull String jsonFiltersList) {
     final List<Filterable> filterables = new ArrayList<>();
 
-    MAPPER_AFTERBURNER.readTree(jsonFiltersList).fields().forEachRemaining(node ->
-        filterables.addAll(
-            FilterableProvider.getFilterFunction(
-                node.getValue(),
-                node.getKey())));
+    Map<String, JsonNode> filtersMap = MAPPER_AFTERBURNER.readValue(
+        jsonFiltersList,
+        new TypeReference<Map<String, JsonNode>>() {});
+
+    for (Map.Entry<String, JsonNode> entry : filtersMap.entrySet()) {
+      filterables.addAll(
+          FilterableProvider.getFilterFunction(
+              entry.getValue(),
+              entry.getKey()));
+    }
 
     return new Filters(filterables);
   }

--- a/nostr-java-event/src/test/java/nostr/event/unit/FiltersDecoderTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/FiltersDecoderTest.java
@@ -376,6 +376,25 @@ public class FiltersDecoderTest {
   }
 
   @Test
+  public void testDecoderMultipleFilterTypes() {
+    log.info("testDecoderMultipleFilterTypes");
+
+    String eventId = "f1b419a95cb0233a11d431423b41a42734e7165fcab16081cd08ef1c90e0be75";
+    Kind kind = Kind.valueOf(1);
+    Long since = Date.from(Instant.now()).getTime();
+
+    String expected = "{\"ids\":[\"" + eventId + "\"],\"kinds\":[" + kind.toString() + "],\"since\":" + since + "}";
+    Filters decodedFilters = new FiltersDecoder().decode(expected);
+
+    assertEquals(
+        new Filters(
+            new EventFilter<>(new GenericEvent(eventId)),
+            new KindFilter<>(kind),
+            new SinceFilter(since)),
+        decodedFilters);
+  }
+
+  @Test
   public void testFailedAddressableTagMalformedSeparator() {
     log.info("testFailedAddressableTagMalformedSeparator");
 


### PR DESCRIPTION
## Summary
- refactor `FiltersDecoder` to parse filters using TypeReference Map instead of JsonNode iteration
- add a unit test for decoding a JSON with multiple filter types

## Testing
- `mvn verify -DskipTests`


------
https://chatgpt.com/codex/tasks/task_b_6889085c8350833193e92decedf6ccf5