### PR TITLE
Add validation tests for key event types

### DIFF
--- a/nostr-java-event/src/test/java/nostr/event/impl/ContactListEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/ContactListEventValidateTest.java
@@ -1,0 +1,59 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import nostr.event.tag.PubKeyTag;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ContactListEventValidateTest {
+    private static final String HEX_64_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String HEX_64_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String SIG_HEX = "c".repeat(128);
+
+    private ContactListEvent createValidEvent() {
+        PublicKey pubKey = new PublicKey(HEX_64_A);
+        List<BaseTag> tags = new ArrayList<>();
+        tags.add(new PubKeyTag(new PublicKey(HEX_64_B)));
+        ContactListEvent event = new ContactListEvent(pubKey, tags);
+        event.setId(HEX_64_A);
+        event.setSignature(Signature.fromString(SIG_HEX));
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        return event;
+    }
+
+    @Test
+    public void testValidateSuccess() {
+        ContactListEvent event = createValidEvent();
+        assertDoesNotThrow(event::validate);
+    }
+
+    @Test
+    public void testValidateMissingPTag() {
+        ContactListEvent event = createValidEvent();
+        event.setTags(new ArrayList<>());
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    @Test
+    public void testValidateWrongKind() {
+        ContactListEvent event = createValidEvent();
+        event.setKind(-1);
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    @Test
+    public void testValidateInvalidContent() {
+        ContactListEvent event = createValidEvent();
+        event.setContent(null);
+        assertThrows(AssertionError.class, event::validate);
+    }
+}

--- a/nostr-java-event/src/test/java/nostr/event/impl/TextNoteEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/TextNoteEventValidateTest.java
@@ -1,0 +1,70 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import nostr.event.tag.PubKeyTag;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TextNoteEventValidateTest {
+    private static final String HEX_64_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String HEX_64_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String SIG_HEX = "e".repeat(128);
+
+    private TextNoteEvent createValidEvent() {
+        PublicKey pubKey = new PublicKey(HEX_64_A);
+        List<BaseTag> tags = new ArrayList<>();
+        tags.add(new PubKeyTag(new PublicKey(HEX_64_B)));
+        TextNoteEvent event = new TextNoteEvent(pubKey, tags, "note content");
+        event.setId(HEX_64_A);
+        event.setSignature(Signature.fromString(SIG_HEX));
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        return event;
+    }
+
+    private void clearTags(TextNoteEvent event) {
+        try {
+            Field f = GenericEvent.class.getDeclaredField("tags");
+            f.setAccessible(true);
+            f.set(event, null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testValidateSuccess() {
+        TextNoteEvent event = createValidEvent();
+        assertDoesNotThrow(event::validate);
+    }
+
+    @Test
+    public void testValidateMissingTags() {
+        TextNoteEvent event = createValidEvent();
+        clearTags(event);
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    @Test
+    public void testValidateWrongKind() {
+        TextNoteEvent event = createValidEvent();
+        event.setKind(-1);
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    @Test
+    public void testValidateInvalidContent() {
+        TextNoteEvent event = createValidEvent();
+        event.setContent(null);
+        assertThrows(AssertionError.class, event::validate);
+    }
+}

--- a/nostr-java-event/src/test/java/nostr/event/impl/ZapRequestEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/ZapRequestEventValidateTest.java
@@ -1,0 +1,81 @@
+package nostr.event.impl;
+
+import nostr.base.ElementAttribute;
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import nostr.event.tag.PubKeyTag;
+import nostr.event.tag.GenericTag;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ZapRequestEventValidateTest {
+    private static final String HEX_64_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String HEX_64_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String SIG_HEX = "d".repeat(128);
+
+    private ZapRequestEvent createValidEvent() {
+        PublicKey pubKey = new PublicKey(HEX_64_A);
+        List<BaseTag> tags = new ArrayList<>();
+        tags.add(new PubKeyTag(new PublicKey(HEX_64_B)));
+        GenericTag amountTag = new GenericTag("amount");
+        amountTag.addAttribute(new ElementAttribute("amount", "1000"));
+        tags.add(amountTag);
+        GenericTag lnurlTag = new GenericTag("lnurl");
+        lnurlTag.addAttribute(new ElementAttribute("lnurl", "lnurl-value"));
+        tags.add(lnurlTag);
+        ZapRequestEvent event = new ZapRequestEvent(pubKey, tags, "content");
+        event.setId(HEX_64_A);
+        event.setSignature(Signature.fromString(SIG_HEX));
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        return event;
+    }
+
+    @Test
+    public void testValidateSuccess() {
+        ZapRequestEvent event = createValidEvent();
+        assertDoesNotThrow(event::validate);
+    }
+
+    @Test
+    public void testValidateMissingPTag() {
+        ZapRequestEvent event = createValidEvent();
+        event.setTags(event.getTags().subList(1, event.getTags().size()));
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    @Test
+    public void testValidateMissingAmountTag() {
+        ZapRequestEvent event = createValidEvent();
+        event.getTags().removeIf(t -> "amount".equals(t.getCode()));
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    @Test
+    public void testValidateMissingLnurlTag() {
+        ZapRequestEvent event = createValidEvent();
+        event.getTags().removeIf(t -> "lnurl".equals(t.getCode()));
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    @Test
+    public void testValidateWrongKind() {
+        ZapRequestEvent event = createValidEvent();
+        event.setKind(-1);
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    @Test
+    public void testValidateInvalidContent() {
+        ZapRequestEvent event = createValidEvent();
+        event.setContent(null);
+        assertThrows(AssertionError.class, event::validate);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests under `impl` to exercise `validate()` on `ContactListEvent`, `ZapRequestEvent`, and `TextNoteEvent`
- cover positive cases and missing tag, wrong kind, and invalid content scenarios

## Testing
- `mvn -q verify`
- Results show all new tests pass:
  - `ContactListEventValidateTest`: Tests run: 4, Failures: 0
  - `ZapRequestEventValidateTest`: Tests run: 6, Failures: 0
  - `TextNoteEventValidateTest`: Tests run: 4, Failures: 0

------
https://chatgpt.com/codex/tasks/task_b_688a850853888331a9229ebce247afe0