### PR TITLE
Enable relay-dependent integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ $ git checkout <your_chosen_branch>
   <summary>integration-tested build (requires a nostr-relay for testing)</summary>
 
 valid relay(s) must **_first_** be defined in [relays.properties](nostr-java-api/src/main/resources/relays.properties) file, then
+integration tests will automatically be skipped when no relay is reachable.
 
 ###### maven
     (unix)

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiEventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiEventIT.java
@@ -42,10 +42,10 @@ import nostr.event.tag.UrlTag;
 import nostr.event.tag.VoteTag;
 import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import nostr.api.integration.BaseRelayIntegrationTest;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -66,8 +66,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringJUnitConfig(RelayConfig.class)
 @Slf4j
-@Disabled("Requires running relay at ws://localhost:5555")
-public class ApiEventIT {
+public class ApiEventIT extends BaseRelayIntegrationTest {
     @Autowired
     private Map<String, String> relays;
 

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiEventTestUsingSpringWebSocketClientIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiEventTestUsingSpringWebSocketClientIT.java
@@ -9,10 +9,10 @@ import nostr.event.impl.GenericEvent;
 import nostr.event.message.EventMessage;
 import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import nostr.api.integration.BaseRelayIntegrationTest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,8 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringJUnitConfig(RelayConfig.class)
 @ActiveProfiles("test")
-@Disabled("Requires running relays at ws://localhost:5555")
-class ApiEventTestUsingSpringWebSocketClientIT {
+class ApiEventTestUsingSpringWebSocketClientIT extends BaseRelayIntegrationTest {
     private final List<SpringWebSocketClient> springWebSocketClients;
 
     @Autowired

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
@@ -13,8 +13,8 @@ import nostr.event.tag.IdentifierTag;
 import nostr.event.tag.PubKeyTag;
 import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 import org.springframework.test.context.ActiveProfiles;
+import nostr.api.integration.BaseRelayIntegrationTest;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -24,8 +24,7 @@ import static nostr.base.IEvent.MAPPER_AFTERBURNER;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("test")
-@Disabled("Requires running relay at ws://localhost:5555")
-class ApiNIP52EventIT {
+class ApiNIP52EventIT extends BaseRelayIntegrationTest {
   private static final String RELAY_URI = "ws://localhost:5555";
   private final SpringWebSocketClient springWebSocketClient;
 

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52RequestIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52RequestIT.java
@@ -16,8 +16,8 @@ import nostr.event.tag.PubKeyTag;
 import nostr.event.tag.ReferenceTag;
 import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 import org.springframework.test.context.ActiveProfiles;
+import nostr.api.integration.BaseRelayIntegrationTest;
 
 import java.io.IOException;
 import java.net.URI;
@@ -30,8 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("test")
-@Disabled("Requires running relay at ws://localhost:5555")
-class ApiNIP52RequestIT {
+class ApiNIP52RequestIT extends BaseRelayIntegrationTest {
   private static final String PRV_KEY_VALUE = "23c011c4c02de9aa98d48c3646c70bb0e7ae30bdae1dfed4d251cbceadaeeb7b";
   private static final String RELAY_URI = "ws://localhost:5555";
   private static final String UUID_CALENDAR_TIME_BASED_EVENT_TEST = "UUID-CalendarTimeBasedEventTest";

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
@@ -17,8 +17,8 @@ import nostr.event.tag.PubKeyTag;
 import nostr.event.tag.SubjectTag;
 import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 import org.springframework.test.context.ActiveProfiles;
+import nostr.api.integration.BaseRelayIntegrationTest;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -30,8 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("test")
-@Disabled("Requires running relay at ws://localhost:5555")
-class ApiNIP99EventIT {
+class ApiNIP99EventIT extends BaseRelayIntegrationTest {
   private static final String RELAY_URI = "ws://localhost:5555";
   public static final String CLASSIFIED_LISTING_CONTENT = "classified listing content";
 

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99RequestIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99RequestIT.java
@@ -17,8 +17,8 @@ import nostr.event.tag.PubKeyTag;
 import nostr.event.tag.SubjectTag;
 import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 import org.springframework.test.context.ActiveProfiles;
+import nostr.api.integration.BaseRelayIntegrationTest;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -31,8 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("test")
-@Disabled("Requires running relay at ws://localhost:5555")
-class ApiNIP99RequestIT {
+class ApiNIP99RequestIT extends BaseRelayIntegrationTest {
   private static final String PRV_KEY_VALUE = "23c011c4c02de9aa98d48c3646c70bb0e7ae30bdae1dfed4d251cbceadaeeb7b";
   private static final String RELAY_URI = "ws://localhost:5555";
   public static final String PUBLISHED_AT_CODE = "published_at";

--- a/nostr-java-api/src/test/java/nostr/api/integration/BaseRelayIntegrationTest.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/BaseRelayIntegrationTest.java
@@ -1,0 +1,12 @@
+package nostr.api.integration;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+
+public abstract class BaseRelayIntegrationTest {
+    @BeforeAll
+    static void ensureRelayAvailable() {
+        Assumptions.assumeTrue(RelayAvailability.areRelaysAvailable(),
+                "Requires running relay defined in relays.properties");
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/integration/RelayAvailability.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/RelayAvailability.java
@@ -27,7 +27,14 @@ public class RelayAvailability {
             String host = uri.getHost();
             int port = uri.getPort();
             if (port == -1) {
-                port = "wss".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+                String scheme = uri.getScheme();
+                if ("wss".equalsIgnoreCase(scheme)) {
+                    port = 443;
+                } else if ("ws".equalsIgnoreCase(scheme)) {
+                    port = 80;
+                } else {
+                    throw new IllegalArgumentException("Unsupported URI scheme: " + scheme);
+                }
             }
             try (Socket socket = new Socket()) {
                 socket.connect(new InetSocketAddress(host, port), 1000);

--- a/nostr-java-api/src/test/java/nostr/api/integration/RelayAvailability.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/RelayAvailability.java
@@ -6,9 +6,11 @@ import java.net.URI;
 import java.util.ResourceBundle;
 
 public class RelayAvailability {
+    private static final String RESOURCE_BUNDLE_NAME = "relays";
+
     public static boolean areRelaysAvailable() {
         try {
-            ResourceBundle bundle = ResourceBundle.getBundle("relays");
+            ResourceBundle bundle = ResourceBundle.getBundle(RESOURCE_BUNDLE_NAME);
             for (String key : bundle.keySet()) {
                 String uri = bundle.getString(key);
                 if (!isRelayAvailable(uri)) {

--- a/nostr-java-api/src/test/java/nostr/api/integration/RelayAvailability.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/RelayAvailability.java
@@ -37,7 +37,7 @@ public class RelayAvailability {
                 }
             }
             try (Socket socket = new Socket()) {
-                socket.connect(new InetSocketAddress(host, port), 1000);
+                socket.connect(new InetSocketAddress(host, port), DEFAULT_TIMEOUT_MS);
             }
             return true;
         } catch (Exception e) {

--- a/nostr-java-api/src/test/java/nostr/api/integration/RelayAvailability.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/RelayAvailability.java
@@ -1,0 +1,40 @@
+package nostr.api.integration;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.util.ResourceBundle;
+
+public class RelayAvailability {
+    public static boolean areRelaysAvailable() {
+        try {
+            ResourceBundle bundle = ResourceBundle.getBundle("relays");
+            for (String key : bundle.keySet()) {
+                String uri = bundle.getString(key);
+                if (!isRelayAvailable(uri)) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public static boolean isRelayAvailable(String url) {
+        try {
+            URI uri = URI.create(url);
+            String host = uri.getHost();
+            int port = uri.getPort();
+            if (port == -1) {
+                port = "wss".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+            }
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(host, port), 1000);
+            }
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/integration/ZDoLastApiNIP09EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ZDoLastApiNIP09EventIT.java
@@ -18,10 +18,10 @@ import nostr.event.tag.GenericTag;
 import nostr.event.tag.IdentifierTag;
 import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import nostr.api.integration.BaseRelayIntegrationTest;
 
 import java.io.IOException;
 import java.util.List;
@@ -37,13 +37,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringJUnitConfig(RelayConfig.class)
 @ActiveProfiles("test")
-@Disabled("Requires running relay at ws://localhost:5555")
-public class ZDoLastApiNIP09EventIT {
+public class ZDoLastApiNIP09EventIT extends BaseRelayIntegrationTest {
     @Autowired
     private Map<String, String> relays;
 
     @Test
-    @Disabled("Requires running relay at ws://127.0.0.1:5555")
     public void deleteEvent() throws IOException {
 
         Identity identity = Identity.generateRandomIdentity();
@@ -75,7 +73,6 @@ public class ZDoLastApiNIP09EventIT {
 
 
     @Test
-    @Disabled("Requires running relay at ws://127.0.0.1:5555")
     public void deleteEventWithRef() throws IOException {
         final String RELAY_URI = "ws://localhost:5555";
         Identity identity = Identity.generateRandomIdentity();


### PR DESCRIPTION
## Summary
- run API integration tests only when configured relays are reachable
- add `RelayAvailability` helper and `BaseRelayIntegrationTest` base class
- remove static `@Disabled` annotations from integration tests
- note automatic skipping of integration tests in README

## Testing
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_b_688a83c6ff908331ae096bb4ff153224