### PR TITLE
Add generics to event factories

### DIFF
--- a/nostr-java-api/src/main/java/nostr/api/NIP01.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP01.java
@@ -60,13 +60,13 @@ public class NIP01 extends EventNostr {
     }
 
     public NIP01 createTextNoteEvent(Identity sender, String content, List<PubKeyTag> recipients) {
-        GenericEvent genericEvent = new GenericEventFactory(sender, Constants.Kind.SHORT_TEXT_NOTE, (List<BaseTag>) (List<?>) recipients, content).create();
+        GenericEvent genericEvent = new GenericEventFactory<PubKeyTag>(sender, Constants.Kind.SHORT_TEXT_NOTE, recipients, content).create();
         this.updateEvent(genericEvent);
         return this;
     }
 
     public NIP01 createTextNoteEvent(String content, List<PubKeyTag> recipients) {
-        GenericEvent genericEvent = new GenericEventFactory(getSender(), Constants.Kind.SHORT_TEXT_NOTE, (List<BaseTag>) (List<?>) recipients, content).create();
+        GenericEvent genericEvent = new GenericEventFactory<PubKeyTag>(getSender(), Constants.Kind.SHORT_TEXT_NOTE, recipients, content).create();
         this.updateEvent(genericEvent);
         return this;
     }
@@ -162,7 +162,7 @@ public class NIP01 extends EventNostr {
      * @return
      */
     public NIP01 createAddressableEvent(@NonNull List<GenericTag> tags, @NonNull Integer kind, String content) {
-        GenericEvent genericEvent = new GenericEventFactory(getSender(), kind, (List<BaseTag>) (List<?>) tags, content).create();
+        GenericEvent genericEvent = new GenericEventFactory<GenericTag>(getSender(), kind, tags, content).create();
         this.updateEvent(genericEvent);
         return this;
     }

--- a/nostr-java-api/src/main/java/nostr/api/factory/EventFactory.java
+++ b/nostr-java-api/src/main/java/nostr/api/factory/EventFactory.java
@@ -18,11 +18,11 @@ import java.util.List;
  * @author eric
  */
 @Data
-public abstract class EventFactory {
+public abstract class EventFactory<E extends GenericEvent, T extends BaseTag> {
 
     private final Identity identity;
     private final String content;
-    private final List<BaseTag> tags;
+    private final List<T> tags;
 
     public EventFactory(Identity identity) {
         this(identity, new ArrayList<>(), "");
@@ -38,15 +38,15 @@ public abstract class EventFactory {
         this(sender, new ArrayList<>(), content);
     }
 
-    public EventFactory(Identity sender, List<BaseTag> tags, String content) {
+    public EventFactory(Identity sender, List<T> tags, String content) {
         this.content = content;
         this.tags = tags;
         this.identity = sender;
     }
 
-    public abstract GenericEvent create();
-    
-    protected void addTag(BaseTag tag) {
+    public abstract E create();
+
+    protected void addTag(T tag) {
         this.tags.add(tag);
     }
 

--- a/nostr-java-api/src/main/java/nostr/api/factory/impl/GenericEventFactory.java
+++ b/nostr-java-api/src/main/java/nostr/api/factory/impl/GenericEventFactory.java
@@ -43,7 +43,7 @@ public class GenericEventFactory<T extends BaseTag> extends EventFactory<Generic
     }
 
     public GenericEvent create() {
-        return new GenericEvent(getIdentity().getPublicKey(), getKind(), new ArrayList<BaseTag>(getTags()), getContent());
+        return new GenericEvent(getIdentity().getPublicKey(), getKind(), getTags(), getContent());
     }
 
 }

--- a/nostr-java-api/src/main/java/nostr/api/factory/impl/GenericEventFactory.java
+++ b/nostr-java-api/src/main/java/nostr/api/factory/impl/GenericEventFactory.java
@@ -8,11 +8,12 @@ import nostr.event.BaseTag;
 import nostr.event.impl.GenericEvent;
 import nostr.id.Identity;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class GenericEventFactory extends EventFactory {
+public class GenericEventFactory<T extends BaseTag> extends EventFactory<GenericEvent, T> {
 
     private Integer kind;
 
@@ -36,13 +37,13 @@ public class GenericEventFactory extends EventFactory {
         this.kind = kind;
     }
 
-    public GenericEventFactory(Identity sender, @NonNull Integer kind, List<BaseTag> tags, @NonNull String content) {
+    public GenericEventFactory(Identity sender, @NonNull Integer kind, List<T> tags, @NonNull String content) {
         super(sender, tags, content);
         this.kind = kind;
     }
 
     public GenericEvent create() {
-        return new GenericEvent(getIdentity().getPublicKey(), getKind(), getTags(), getContent());
+        return new GenericEvent(getIdentity().getPublicKey(), getKind(), new ArrayList<BaseTag>(getTags()), getContent());
     }
 
 }

--- a/nostr-java-api/src/main/java/nostr/api/factory/impl/GenericEventFactory.java
+++ b/nostr-java-api/src/main/java/nostr/api/factory/impl/GenericEventFactory.java
@@ -43,7 +43,7 @@ public class GenericEventFactory<T extends BaseTag> extends EventFactory<Generic
     }
 
     public GenericEvent create() {
-        return new GenericEvent(getIdentity().getPublicKey(), getKind(), getTags(), getContent());
+        return new GenericEvent(getIdentity().getPublicKey(), getKind(), new ArrayList<BaseTag>(getTags()), getContent());
     }
 
 }

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP01Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP01Test.java
@@ -73,6 +73,21 @@ public class NIP01Test {
     }
 
     @Test
+    public void testCreateTextNoteEventWithRecipientListParameter() {
+        Identity sender = Identity.generateRandomIdentity();
+        Identity recipient = Identity.generateRandomIdentity();
+        NIP01 nip01 = new NIP01(sender);
+
+        PubKeyTag recipientTag = new PubKeyTag(recipient.getPublicKey());
+        GenericEvent genericEvent = nip01.createTextNoteEvent("Generic", List.of(recipientTag)).sign().getEvent();
+
+        TextNoteEvent textNoteEvent = GenericEvent.convert(genericEvent, TextNoteEvent.class);
+
+        assertEquals(1, textNoteEvent.getRecipients().size());
+        assertEquals(recipient.getPublicKey(), textNoteEvent.getRecipients().get(0));
+    }
+
+    @Test
     public void testGenerateSignValidateAndConvertMetadataEvent() throws MalformedURLException {
         // Step 1: Prepare
         Identity sender = Identity.generateRandomIdentity();
@@ -154,6 +169,18 @@ public class NIP01Test {
         assertEquals(kind, genericEvent.getKind(), "The kind of the parameterized replaceable event should match the specified kind.");
         assertEquals(content, genericEvent.getContent(), "The content of the parameterized replaceable event should match the original content.");
         assertEquals(sender.getPublicKey(), genericEvent.getPubKey(), "The public key of the parameterized replaceable event should match the sender's public key.");
+    }
+
+    @Test
+    public void testCreateAddressableEventWithTagList() {
+        Identity sender = Identity.generateRandomIdentity();
+        NIP01 nip01 = new NIP01(sender);
+
+        GenericTag tag = new GenericTag("test");
+        GenericEvent event = nip01.createAddressableEvent(List.of(tag), 30001, "addr").sign().getEvent();
+
+        assertEquals(1, event.getTags().size());
+        assertEquals("addr", event.getContent());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- make `EventFactory` and `GenericEventFactory` generic
- use typed `GenericEventFactory` in `NIP01`
- add unit tests for the new generic methods
- run `mvn -q verify`

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_688a863639c48331803c6366cc2bd9d6