### PR TITLE
Add configurable relay properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ git checkout <your_chosen_branch>
 <details>
   <summary>integration-tested build (requires a nostr-relay for testing)</summary>
 
-valid relay(s) must **_first_** be defined in [relays.properties](nostr-java-api/src/main/resources/relays.properties) file, then
+valid relay(s) must **_first_** be defined using the `relays.<name>=<uri>` format in [relays.properties](nostr-java-api/src/main/resources/relays.properties) file, then
 
 ###### maven
     (unix)

--- a/nostr-java-api/src/main/java/nostr/config/RelayConfig.java
+++ b/nostr-java-api/src/main/java/nostr/config/RelayConfig.java
@@ -1,5 +1,6 @@
 package nostr.config;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
@@ -10,12 +11,21 @@ import java.util.stream.Collectors;
 
 @Configuration
 @PropertySource("classpath:relays.properties")
+@EnableConfigurationProperties(RelaysProperties.class)
 public class RelayConfig {
 
     @Bean
-    public Map<String, String> relays() {
-        ResourceBundle relaysBundle = ResourceBundle.getBundle("relays");
+    public Map<String, String> relays(RelaysProperties relaysProperties) {
+        return relaysProperties;
+    }
+
+    /**
+     * @deprecated use {@link RelaysProperties} instead
+     */
+    @Deprecated
+    private Map<String, String> legacyRelays() {
+        var relaysBundle = ResourceBundle.getBundle("relays");
         return relaysBundle.keySet().stream()
-            .collect(Collectors.toMap(key -> key, relaysBundle::getString));
+                .collect(Collectors.toMap(key -> key, relaysBundle::getString));
     }
 }

--- a/nostr-java-api/src/main/java/nostr/config/RelaysProperties.java
+++ b/nostr-java-api/src/main/java/nostr/config/RelaysProperties.java
@@ -1,0 +1,10 @@
+package nostr.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.HashMap;
+
+@ConfigurationProperties(prefix = "relays")
+public class RelaysProperties extends HashMap<String, String> {
+    private static final long serialVersionUID = 1L;
+}

--- a/nostr-java-api/src/main/resources/relays.properties
+++ b/nostr-java-api/src/main/resources/relays.properties
@@ -1,3 +1,4 @@
-nostr_rs_relay=ws://127.0.0.1:5555
-#relay_strfry=ws://localhost:3333
-#relay_badgr=wss://relay.badgr.space
+# Relay configuration in `relays.<name>=<uri>` format
+relays.nostr_rs_relay=ws://127.0.0.1:5555
+#relays.relay_strfry=ws://localhost:3333
+#relays.relay_badgr=wss://relay.badgr.space


### PR DESCRIPTION
## Summary
- introduce `RelaysProperties` to map relay names to URLs
- configure `RelayConfig` to use new `RelaysProperties`
- document the new `relays.<name>=<uri>` format
- update default `relays.properties`

## Testing
- `mvn -q verify` *(fails: output truncated, build status unclear)*

------
https://chatgpt.com/codex/tasks/task_b_688a863216188331b5e9e8e4b3c30aeb