### PR TITLE
Add tag helper methods and refactor events

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![](https://jitpack.io/v/xyz.tcheeric/nostr-java.svg)](https://jitpack.io/#xyz.tcheeric/nostr-java)
 
 Nostr-java is a library for generating, signing, and publishing nostr events to relays.
+It provides helper methods such as `requireTag` and `requireTagInstance` on `GenericEvent` to assert required tags are present.
 
 ## Requirements
 - Maven

--- a/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
@@ -343,6 +343,36 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
                 .toList();
     }
 
+    /**
+     * Ensure that a tag with the provided code exists.
+     *
+     * @param code the tag code to search for
+     * @return the first matching tag
+     * @throws AssertionError if no tag with the given code is present
+     */
+    protected BaseTag requireTag(@NonNull String code) {
+        return getTags().stream()
+                .filter(tag -> code.equals(tag.getCode()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing required `" + code + "` tag."));
+    }
+
+    /**
+     * Ensure that at least one tag instance of the provided class exists.
+     *
+     * @param clazz the tag class to search for
+     * @param <T>   tag type
+     * @return the first matching tag instance
+     * @throws AssertionError if no matching tag is present
+     */
+    protected <T extends BaseTag> T requireTagInstance(@NonNull Class<T> clazz) {
+        return getTags().stream()
+                .filter(clazz::isInstance)
+                .map(clazz::cast)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing required `" + clazz.getSimpleName() + "` tag."));
+    }
+
 
     public static <T extends GenericEvent> T convert(@NonNull GenericEvent genericEvent, @NonNull Class<T> clazz) {
         try {

--- a/nostr-java-event/src/main/java/nostr/event/impl/MuteUserEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/MuteUserEvent.java
@@ -22,18 +22,13 @@ public class MuteUserEvent extends GenericEvent {
     }
 
     public PublicKey getMutedUser() {
-        return ((PubKeyTag) getTags().get(0)).getPublicKey();
+        return requireTagInstance(PubKeyTag.class).getPublicKey();
     }
 
     @Override
     protected void validateTags() {
         super.validateTags();
 
-        // Validate `tags` field for at least one PubKeyTag
-        boolean hasValidPubKeyTag = this.getTags().stream()
-                .anyMatch(tag -> tag instanceof PubKeyTag);
-        if (!hasValidPubKeyTag) {
-            throw new AssertionError("Invalid `tags`: Must include at least one valid PubKeyTag.");
-        }
+        requireTagInstance(PubKeyTag.class);
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ReactionEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ReactionEvent.java
@@ -23,22 +23,13 @@ public class ReactionEvent extends NIP25Event {
     }
 
     public String getReactedEventId() {
-        return this.getTags().stream()
-                .filter(tag -> tag instanceof EventTag)
-                .map(tag -> ((EventTag) tag).getIdEvent())
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("Invalid `tags`: Must include at least one `EventTag` (`e` tag)."));
+        return requireTagInstance(EventTag.class).getIdEvent();
     }
 
     @Override
     protected void validateTags() {
         super.validateTags();
 
-        // Validate `tags` field for at least one `EventTag` (`e` tag)
-        boolean hasEventTag = this.getTags().stream()
-                .anyMatch(tag -> tag instanceof EventTag);
-        if (!hasEventTag) {
-            throw new AssertionError("Invalid `tags`: Must include at least one `EventTag` (`e` tag).");
-        }
+        requireTagInstance(EventTag.class);
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ZapReceiptEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ZapReceiptEvent.java
@@ -24,9 +24,9 @@ public class ZapReceiptEvent extends GenericEvent {
     }
 
     public ZapReceipt getZapReceipt() {
-        BaseTag preimageTag = getTag("preimage");
-        BaseTag descriptionTag = getTag("description");
-        BaseTag bolt11Tag = getTag("bolt11");
+        BaseTag preimageTag = requireTag("preimage");
+        BaseTag descriptionTag = requireTag("description");
+        BaseTag bolt11Tag = requireTag("bolt11");
 
         return new ZapReceipt(
                 ((GenericTag) bolt11Tag).getAttributes().get(0).getValue().toString(),
@@ -51,8 +51,7 @@ public class ZapReceiptEvent extends GenericEvent {
     }
 
     public PublicKey getRecipient() {
-        BaseTag recipientTag = getTag("p");
-        PubKeyTag recipientPubKeyTag = (PubKeyTag) recipientTag;
+        PubKeyTag recipientPubKeyTag = (PubKeyTag) requireTag("p");
         return recipientPubKeyTag.getPublicKey();
     }
 
@@ -79,24 +78,9 @@ public class ZapReceiptEvent extends GenericEvent {
 
         // Validate `tags` field
         // Check for required tags
-        boolean hasRecipientTag = this.getTags().stream().anyMatch(tag -> "p".equals(tag.getCode()));
-        if (!hasRecipientTag) {
-            throw new AssertionError("Invalid `tags`: Must include a `p` tag for the recipient's public key.");
-        }
-
-        boolean hasBolt11Tag = this.getTags().stream().anyMatch(tag -> "bolt11".equals(tag.getCode()));
-        if (!hasBolt11Tag) {
-            throw new AssertionError("Invalid `tags`: Must include a `bolt11` tag for the Lightning invoice.");
-        }
-
-        boolean hasDescriptionTag = this.getTags().stream().anyMatch(tag -> "description".equals(tag.getCode()));
-        if (!hasDescriptionTag) {
-            throw new AssertionError("Invalid `tags`: Must include a `description` tag for the description hash.");
-        }
-
-        boolean hasPreimageTag = this.getTags().stream().anyMatch(tag -> "preimage".equals(tag.getCode()));
-        if (!hasPreimageTag) {
-            throw new AssertionError("Invalid `tags`: Must include a `preimage` tag for the payment preimage.");
-        }
+        requireTag("p");
+        requireTag("bolt11");
+        requireTag("description");
+        requireTag("preimage");
     }
 }

--- a/nostr-java-id/src/test/java/nostr/id/ReactionEventTest.java
+++ b/nostr-java-id/src/test/java/nostr/id/ReactionEventTest.java
@@ -1,0 +1,32 @@
+package nostr.id;
+
+import nostr.base.PublicKey;
+import nostr.event.entities.Reaction;
+import nostr.event.impl.GenericEvent;
+import nostr.event.impl.ReactionEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ReactionEventTest {
+
+    @Test
+    void testGetReactedEventId() {
+        PublicKey pk = Identity.generateRandomIdentity().getPublicKey();
+        GenericEvent original = EntityFactory.Events.createTextNoteEvent(pk);
+        original.update();
+        ReactionEvent reaction = EntityFactory.Events.createReactionEvent(pk, original);
+        reaction.update();
+        assertEquals(original.getId(), reaction.getReactedEventId());
+    }
+
+    @Test
+    void testMissingEventTag() {
+        PublicKey pk = Identity.generateRandomIdentity().getPublicKey();
+        ReactionEvent reaction = new ReactionEvent(pk, new ArrayList<>(), Reaction.LIKE.getEmoji());
+        assertThrows(AssertionError.class, reaction::getReactedEventId);
+    }
+}


### PR DESCRIPTION
## Summary
- add `requireTag` and `requireTagInstance` helpers
- use new helpers in `ReactionEvent`, `ZapReceiptEvent`, and `MuteUserEvent`
- add unit test for `ReactionEvent`
- document tag helper methods in README

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_688a8500df4c833192e7879aea6d2535