### PR TITLE
Add JSON validation for channel and merchant events

### DIFF
--- a/nostr-java-event/src/main/java/nostr/event/impl/ChannelCreateEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ChannelCreateEvent.java
@@ -27,4 +27,28 @@ public class ChannelCreateEvent extends GenericEvent {
         return MAPPER_AFTERBURNER.readValue(content, ChannelProfile.class);
     }
 
+    @Override
+    protected void validateContent() {
+        super.validateContent();
+
+        try {
+            ChannelProfile profile = getChannelProfile();
+
+            if (profile.getName() == null || profile.getName().isEmpty()) {
+                throw new AssertionError("Invalid `content`: `name` field is required.");
+            }
+
+            if (profile.getAbout() == null || profile.getAbout().isEmpty()) {
+                throw new AssertionError("Invalid `content`: `about` field is required.");
+            }
+
+            if (profile.getPicture() == null) {
+                throw new AssertionError("Invalid `content`: `picture` field is required.");
+            }
+
+        } catch (Exception e) {
+            throw new AssertionError("Invalid `content`: Must be a valid ChannelProfile JSON object.", e);
+        }
+    }
+
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ChannelMetadataEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ChannelMetadataEvent.java
@@ -30,6 +30,29 @@ public class ChannelMetadataEvent extends GenericEvent {
         return MAPPER_AFTERBURNER.readValue(content, ChannelProfile.class);
     }
 
+    @Override
+    protected void validateContent() {
+        super.validateContent();
+
+        try {
+            ChannelProfile profile = getChannelProfile();
+
+            if (profile.getName() == null || profile.getName().isEmpty()) {
+                throw new AssertionError("Invalid `content`: `name` field is required.");
+            }
+
+            if (profile.getAbout() == null || profile.getAbout().isEmpty()) {
+                throw new AssertionError("Invalid `content`: `about` field is required.");
+            }
+
+            if (profile.getPicture() == null) {
+                throw new AssertionError("Invalid `content`: `picture` field is required.");
+            }
+        } catch (Exception e) {
+            throw new AssertionError("Invalid `content`: Must be a valid ChannelProfile JSON object.", e);
+        }
+    }
+
     public String getChannelCreateEventId() {
         return getTags().stream()
                 .filter(tag -> "e".equals(tag.getCode()))

--- a/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateProductEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateProductEvent.java
@@ -30,4 +30,29 @@ public class CreateOrUpdateProductEvent extends MerchantEvent<Product> {
     protected Product getEntity() {
         return getProduct();
     }
+
+    @Override
+    protected void validateContent() {
+        super.validateContent();
+
+        try {
+            Product product = getProduct();
+
+            if (product.getName() == null || product.getName().isEmpty()) {
+                throw new AssertionError("Invalid `content`: `name` field is required.");
+            }
+
+            if (product.getCurrency() == null || product.getCurrency().isEmpty()) {
+                throw new AssertionError("Invalid `content`: `currency` field is required.");
+            }
+
+            if (product.getPrice() == null) {
+                throw new AssertionError("Invalid `content`: `price` field is required.");
+            }
+        } catch (AssertionError e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AssertionError("Invalid `content`: Must be a valid Product JSON object.", e);
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateStallEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateStallEvent.java
@@ -37,4 +37,25 @@ public class CreateOrUpdateStallEvent extends MerchantEvent<Stall> {
     protected Stall getEntity() {
         return getStall();
     }
+
+    @Override
+    protected void validateContent() {
+        super.validateContent();
+
+        try {
+            Stall stall = getStall();
+
+            if (stall.getName() == null || stall.getName().isEmpty()) {
+                throw new AssertionError("Invalid `content`: `name` field is required.");
+            }
+
+            if (stall.getCurrency() == null || stall.getCurrency().isEmpty()) {
+                throw new AssertionError("Invalid `content`: `currency` field is required.");
+            }
+        } catch (AssertionError e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AssertionError("Invalid `content`: Must be a valid Stall JSON object.", e);
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/MerchantEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/MerchantEvent.java
@@ -42,4 +42,24 @@ public abstract class MerchantEvent<T extends NIP15Content.MerchantContent> exte
             throw new AssertionError("The d-tag value MUST be the same as the stall id.");
         }
     }
+
+    @Override
+    protected void validateContent() {
+        super.validateContent();
+
+        try {
+            T entity = getEntity();
+            if (entity == null) {
+                throw new AssertionError("Invalid `content`: Unable to parse merchant entity.");
+            }
+
+            if (entity.getId() == null || entity.getId().isEmpty()) {
+                throw new AssertionError("Invalid `content`: `id` field is required.");
+            }
+        } catch (AssertionError e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AssertionError("Invalid `content`: Must be a valid JSON object.", e);
+        }
+    }
 }

--- a/nostr-java-event/src/test/java/nostr/event/unit/JsonContentValidationTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/JsonContentValidationTest.java
@@ -1,0 +1,51 @@
+package nostr.event.unit;
+
+import nostr.base.PublicKey;
+import nostr.event.impl.ChannelCreateEvent;
+import nostr.event.impl.CreateOrUpdateProductEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JsonContentValidationTest {
+
+    private static final PublicKey PUBKEY = new PublicKey("56adf01ca1aa9d6f1c35953833bbe6d99a0c85b73af222e6bd305b51f2749f6f");
+
+    private static class TestChannelCreateEvent extends ChannelCreateEvent {
+        public TestChannelCreateEvent(PublicKey pk, String content) { super(pk, content); }
+        public void callValidateContent() { super.validateContent(); }
+    }
+
+    private static class TestProductEvent extends CreateOrUpdateProductEvent {
+        public TestProductEvent(PublicKey pk, List<nostr.event.BaseTag> tags, String content) { super(pk, tags, content); }
+        public void callValidateContent() { super.validateContent(); }
+    }
+
+    @Test
+    void channelCreateInvalidJson() {
+        TestChannelCreateEvent event = new TestChannelCreateEvent(PUBKEY, "{invalid");
+        assertThrows(AssertionError.class, event::callValidateContent);
+    }
+
+    @Test
+    void channelCreateMissingFields() {
+        String json = "{\"name\":\"test\"}"; // missing about and picture
+        TestChannelCreateEvent event = new TestChannelCreateEvent(PUBKEY, json);
+        assertThrows(AssertionError.class, event::callValidateContent);
+    }
+
+    @Test
+    void productEventInvalidJson() {
+        TestProductEvent event = new TestProductEvent(PUBKEY, List.of(), "{invalid");
+        assertThrows(AssertionError.class, event::callValidateContent);
+    }
+
+    @Test
+    void productEventMissingFields() {
+        String json = "{\"id\":\"123\",\"currency\":\"USD\",\"price\":10}"; // missing name
+        TestProductEvent event = new TestProductEvent(PUBKEY, List.of(), json);
+        assertThrows(AssertionError.class, event::callValidateContent);
+    }
+}


### PR DESCRIPTION
## Summary
- validate JSON contents for ChannelCreateEvent and ChannelMetadataEvent
- validate MerchantEvent content and check required fields for product and stall events
- add unit tests covering invalid or incomplete JSON

## Testing
- `mvn -q verify`
- `mvn -DskipTests install`

------
https://chatgpt.com/codex/tasks/task_b_688a8503ca2c83319e47e1b7c88d7c8e