### PR TITLE
Add strict kind validation to event classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ I recommend having a look at these repositories/module for examples:
 - [nostr-client](https://github.com/tcheeric/nostr-client) github repository
 - [SuperConductor](https://github.com/avlo/superconductor) nostr relay
 
+### Event validation
+Every concrete event now verifies that its `kind` matches the expected value from
+the `Kind` enum. Calling `validate()` on an event with an incorrect `kind` will
+throw an `AssertionError`.
+
 
 ## Supported NIPs
 The following NIPs are supported by the API out-of-the-box:

--- a/nostr-java-event/src/main/java/nostr/event/impl/CalendarDateBasedEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CalendarDateBasedEvent.java
@@ -98,4 +98,11 @@ public class CalendarDateBasedEvent<T extends BaseTag> extends AbstractBaseCalen
 
         return calendarContent;
     }
+
+    @Override
+    public void validateKind() {
+        if (getKind() != Kind.CALENDAR_DATE_BASED_EVENT.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.CALENDAR_DATE_BASED_EVENT.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CalendarEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CalendarEvent.java
@@ -81,4 +81,11 @@ public class CalendarEvent extends AbstractBaseCalendarEvent<JsonContent> {
             throw new AssertionError("Missing `title` tag for the event title.");
         }
     }
+
+    @Override
+    public void validateKind() {
+        if (getKind() != Kind.CALENDAR_EVENT.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.CALENDAR_EVENT.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CalendarRsvpEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CalendarRsvpEvent.java
@@ -97,4 +97,11 @@ public class CalendarRsvpEvent extends AbstractBaseCalendarEvent<CalendarRsvpCon
 
         return calendarRsvpContent;
     }
+
+    @Override
+    public void validateKind() {
+        if (getKind() != Kind.CALENDAR_RSVP_EVENT.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.CALENDAR_RSVP_EVENT.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CalendarTimeBasedEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CalendarTimeBasedEvent.java
@@ -60,4 +60,11 @@ public class CalendarTimeBasedEvent<T extends BaseTag> extends CalendarDateBased
 
         return calendarContent;
     }
+
+    @Override
+    public void validateKind() {
+        if (getKind() != Kind.CALENDAR_TIME_BASED_EVENT.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.CALENDAR_TIME_BASED_EVENT.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CanonicalAuthenticationEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CanonicalAuthenticationEvent.java
@@ -54,4 +54,11 @@ public class CanonicalAuthenticationEvent extends EphemeralEvent {
             throw new AssertionError("Missing or invalid `relay` tag.");
         }
     }
+
+    @Override
+    public void validateKind() {
+        if (getKind() != Kind.CLIENT_AUTH.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.CLIENT_AUTH.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ChannelCreateEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ChannelCreateEvent.java
@@ -27,4 +27,11 @@ public class ChannelCreateEvent extends GenericEvent {
         return MAPPER_AFTERBURNER.readValue(content, ChannelProfile.class);
     }
 
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.CHANNEL_CREATE.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.CHANNEL_CREATE.getValue());
+        }
+    }
+
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ChannelMessageEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ChannelMessageEvent.java
@@ -112,4 +112,11 @@ public class ChannelMessageEvent extends GenericEvent {
         }
         this.addTag(replyEventTag);
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.CHANNEL_MESSAGE.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.CHANNEL_MESSAGE.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ChannelMetadataEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ChannelMetadataEvent.java
@@ -59,4 +59,11 @@ public class ChannelMetadataEvent extends GenericEvent {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("Missing or invalid `e` root tag."));
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.CHANNEL_METADATA.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.CHANNEL_METADATA.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ContactListEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ContactListEvent.java
@@ -33,4 +33,11 @@ public class ContactListEvent extends GenericEvent {
             throw new AssertionError("Missing `p` tag for contact list entries.");
         }
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.CONTACT_LIST.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.CONTACT_LIST.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateProductEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateProductEvent.java
@@ -4,6 +4,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import nostr.base.IEvent;
+import nostr.base.Kind;
 import nostr.base.PublicKey;
 import nostr.base.annotation.Event;
 import nostr.event.BaseTag;
@@ -29,5 +30,12 @@ public class CreateOrUpdateProductEvent extends MerchantEvent<Product> {
 
     protected Product getEntity() {
         return getProduct();
+    }
+
+    @Override
+    public void validateKind() {
+        if (getKind() != Kind.PRODUCT_CREATE_OR_UPDATE.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.PRODUCT_CREATE_OR_UPDATE.getValue());
+        }
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateStallEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateStallEvent.java
@@ -37,4 +37,11 @@ public class CreateOrUpdateStallEvent extends MerchantEvent<Stall> {
     protected Stall getEntity() {
         return getStall();
     }
+
+    @Override
+    public void validateKind() {
+        if (getKind() != Kind.STALL_CREATE_OR_UPDATE.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.STALL_CREATE_OR_UPDATE.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CustomerOrderEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CustomerOrderEvent.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import nostr.base.IEvent;
+import nostr.base.Kind;
 import nostr.base.PublicKey;
 import nostr.base.annotation.Event;
 import nostr.event.BaseTag;
@@ -34,5 +35,12 @@ public class CustomerOrderEvent extends CheckoutEvent<CustomerOrder> {
 
     protected CustomerOrder getEntity() {
         return getCustomerOrder();
+    }
+
+    @Override
+    public void validateKind() {
+        if (getKind() != Kind.ENCRYPTED_DIRECT_MESSAGE.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.ENCRYPTED_DIRECT_MESSAGE.getValue());
+        }
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/DeletionEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/DeletionEvent.java
@@ -53,4 +53,11 @@ public class DeletionEvent extends NIP09Event {
             throw new AssertionError("Invalid `tags`: Should include a `k` tag for the kind of each event being requested for deletion.");
         }
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.DELETION.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.DELETION.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/DirectMessageEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/DirectMessageEvent.java
@@ -41,4 +41,11 @@ public class DirectMessageEvent extends NIP04Event {
             throw new AssertionError("Invalid `tags`: Must include a PubKeyTag for the recipient.");
         }
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.ENCRYPTED_DIRECT_MESSAGE.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.ENCRYPTED_DIRECT_MESSAGE.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/EncryptedPayloadEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/EncryptedPayloadEvent.java
@@ -23,4 +23,11 @@ public class EncryptedPayloadEvent extends GenericEvent {
         this.setContent(content);
         this.addTag(PubKeyTag.builder().publicKey(recipient).build());
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.ENCRYPTED_PAYLOADS.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.ENCRYPTED_PAYLOADS.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/HideMessageEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/HideMessageEvent.java
@@ -41,4 +41,11 @@ public class HideMessageEvent extends GenericEvent {
             throw new AssertionError("Invalid `tags`: Must include at least one `e` tag.");
         }
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.HIDE_MESSAGE.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.HIDE_MESSAGE.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/InternetIdentifierMetadataEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/InternetIdentifierMetadataEvent.java
@@ -57,4 +57,11 @@ public final class InternetIdentifierMetadataEvent extends NIP05Event {
         // Validate the NIP-05 identifier
         // NOTE: This is now up to the client to perform this validation
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.SET_METADATA.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.SET_METADATA.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/MerchantRequestPaymentEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/MerchantRequestPaymentEvent.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import nostr.base.IEvent;
+import nostr.base.Kind;
 import nostr.base.PublicKey;
 import nostr.base.annotation.Event;
 import nostr.event.BaseTag;
@@ -31,5 +32,12 @@ public class MerchantRequestPaymentEvent extends CheckoutEvent<PaymentRequest> {
 
     protected PaymentRequest getEntity() {
         return getPaymentRequest();
+    }
+
+    @Override
+    public void validateKind() {
+        if (getKind() != Kind.ENCRYPTED_DIRECT_MESSAGE.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.ENCRYPTED_DIRECT_MESSAGE.getValue());
+        }
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/MetadataEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/MetadataEvent.java
@@ -64,6 +64,13 @@ public final class MetadataEvent extends NIP01Event {
         super.update();
     }
 
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.SET_METADATA.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.SET_METADATA.getValue());
+        }
+    }
+
     private void setContent() {
         var mapper = ENCODER_MAPPED_AFTERBURNER;
         try {

--- a/nostr-java-event/src/main/java/nostr/event/impl/MuteUserEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/MuteUserEvent.java
@@ -36,4 +36,11 @@ public class MuteUserEvent extends GenericEvent {
             throw new AssertionError("Invalid `tags`: Must include at least one valid PubKeyTag.");
         }
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.MUTE_USER.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.MUTE_USER.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/NutZapEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/NutZapEvent.java
@@ -87,6 +87,13 @@ public class NutZapEvent extends GenericEvent {
         }
     }
 
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.NUTZAP.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.NUTZAP.getValue());
+        }
+    }
+
     private CashuMint getMintFromTag(GenericTag mintTag) {
         String url = mintTag.getAttributes().get(0).getValue().toString();
         CashuMint mint = new CashuMint(url);

--- a/nostr-java-event/src/main/java/nostr/event/impl/NutZapInformationalEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/NutZapInformationalEvent.java
@@ -75,6 +75,13 @@ public class NutZapInformationalEvent extends ReplaceableEvent {
         }
     }
 
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.NUTZAP_INFORMATIONAL.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.NUTZAP_INFORMATIONAL.getValue());
+        }
+    }
+
     private Relay getRelayFromTag(@NonNull GenericTag tag) {
         String url = tag.getAttributes().get(0).getValue().toString();
         return new Relay(url);

--- a/nostr-java-event/src/main/java/nostr/event/impl/OtsEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/OtsEvent.java
@@ -21,4 +21,11 @@ public class OtsEvent extends GenericEvent {
     public OtsEvent(@NonNull PublicKey pubKey, @NonNull List<BaseTag> tags, @NonNull String content) {
         super(pubKey, Kind.OTS_EVENT, tags, content);
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.OTS_EVENT.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.OTS_EVENT.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ReactionEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ReactionEvent.java
@@ -41,4 +41,11 @@ public class ReactionEvent extends NIP25Event {
             throw new AssertionError("Invalid `tags`: Must include at least one `EventTag` (`e` tag).");
         }
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.REACTION.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.REACTION.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/TextNoteEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/TextNoteEvent.java
@@ -37,4 +37,11 @@ public class TextNoteEvent extends NIP01Event {
                 .map(PubKeyTag::getPublicKey)
                 .toList();
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.TEXT_NOTE.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.TEXT_NOTE.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/VerifyPaymentOrShippedEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/VerifyPaymentOrShippedEvent.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import nostr.base.IEvent;
+import nostr.base.Kind;
 import nostr.base.PublicKey;
 import nostr.base.annotation.Event;
 import nostr.event.BaseTag;
@@ -31,5 +32,12 @@ public class VerifyPaymentOrShippedEvent extends CheckoutEvent<PaymentShipmentSt
 
     protected PaymentShipmentStatus getEntity() {
         return getPaymentShipmentStatus();
+    }
+
+    @Override
+    public void validateKind() {
+        if (getKind() != Kind.ENCRYPTED_DIRECT_MESSAGE.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.ENCRYPTED_DIRECT_MESSAGE.getValue());
+        }
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ZapReceiptEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ZapReceiptEvent.java
@@ -99,4 +99,11 @@ public class ZapReceiptEvent extends GenericEvent {
             throw new AssertionError("Invalid `tags`: Must include a `preimage` tag for the payment preimage.");
         }
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.ZAP_RECEIPT.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.ZAP_RECEIPT.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ZapRequestEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ZapRequestEvent.java
@@ -89,4 +89,11 @@ public class ZapRequestEvent extends GenericEvent {
             throw new AssertionError("Invalid `tags`: Must include an `lnurl` tag containing the Lightning Network URL.");
         }
     }
+
+    @Override
+    protected void validateKind() {
+        if (getKind() != Kind.ZAP_REQUEST.getValue()) {
+            throw new AssertionError("Invalid kind value. Expected " + Kind.ZAP_REQUEST.getValue());
+        }
+    }
 }

--- a/nostr-java-event/src/test/java/nostr/event/unit/ValidateKindTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/ValidateKindTest.java
@@ -1,0 +1,27 @@
+package nostr.event.unit;
+
+import nostr.base.Kind;
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.impl.TextNoteEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ValidateKindTest {
+    @Test
+    public void testTextNoteInvalidKind() {
+        TextNoteEvent event = new TextNoteEvent();
+        event.setPubKey(new PublicKey("bbbd79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76984"));
+        event.setKind(Kind.DELETION.getValue());
+        event.setContent("");
+        event.setTags(new ArrayList<>());
+        event.setSignature(Signature.fromString("86f25c161fec51b9e441bdb2c09095d5f8b92fdce66cb80d9ef09fad6ce53eaa14c5e16787c42f5404905536e43ebec0e463aee819378a4acbe412c533e60546"));
+        event.setCreatedAt(0L);
+        event.setId("494001ac0c8af2a10f60f23538e5b35d3cdacb8e1cc956fe7a16dfa5cbfc4346");
+
+        assertThrows(AssertionError.class, event::validate);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce exact Kind values for concrete event implementations
- add validation tests for mismatched kind values

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_688a84fdfbb083318d79b9337c990fcb