### PR TITLE
Make WebSocket send timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,16 @@ valid relay(s) must **_first_** be defined using the `relays.<name>=<uri>` forma
 </dependencies>
 ```
 
+### Configuring WebSocket client
+`StandardWebSocketClient` awaits responses from the relay when sending messages.
+The wait duration and polling interval can be customized using the following
+properties (values in milliseconds):
 
+```
+nostr.websocket.await-timeout-ms=60000
+nostr.websocket.poll-interval-ms=500
+```
+By default the client waits up to 60 seconds with a poll interval of 500&nbsp;ms.
 
 ## Examples
 I recommend having a look at these repositories/module for examples:


### PR DESCRIPTION
## Summary
- use configurable await timeout and poll interval for WebSocket client
- document new properties in the README

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_688ab88836808331b1d73dc049b8c7e3