### PR TITLE
Initialize SpringWebSocketClient in setup

### DIFF
--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
@@ -12,6 +12,7 @@ import nostr.event.message.EventMessage;
 import nostr.event.tag.IdentifierTag;
 import nostr.event.tag.PubKeyTag;
 import nostr.id.Identity;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 import nostr.api.integration.BaseRelayIntegrationTest;
@@ -25,11 +26,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("test")
 class ApiNIP52EventIT extends BaseRelayIntegrationTest {
-  private static final String RELAY_URI = "ws://localhost:5555";
-  private final SpringWebSocketClient springWebSocketClient;
+  private SpringWebSocketClient springWebSocketClient;
 
-  public ApiNIP52EventIT() {
-    springWebSocketClient = new SpringWebSocketClient(RELAY_URI);
+  @BeforeEach
+  void setUp() {
+    springWebSocketClient = new SpringWebSocketClient(getRelayUri());
   }
 
   @Test

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
@@ -16,6 +16,8 @@ import nostr.event.tag.PriceTag;
 import nostr.event.tag.PubKeyTag;
 import nostr.event.tag.SubjectTag;
 import nostr.id.Identity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 import nostr.api.integration.BaseRelayIntegrationTest;
@@ -31,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("test")
 class ApiNIP99EventIT extends BaseRelayIntegrationTest {
-  private static final String RELAY_URI = "ws://localhost:5555";
   public static final String CLASSIFIED_LISTING_CONTENT = "classified listing content";
 
   public static final String PTAG_HEX = "2bed79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76985";
@@ -55,10 +56,11 @@ class ApiNIP99EventIT extends BaseRelayIntegrationTest {
   public static final String SUMMARY_CODE = "summary";
   public static final String PUBLISHED_AT_CODE = "published_at";
   public static final String LOCATION_CODE = "location";
-  private final SpringWebSocketClient springWebSocketClient;
+  private SpringWebSocketClient springWebSocketClient;
 
-  public ApiNIP99EventIT() {
-    springWebSocketClient = new SpringWebSocketClient(RELAY_URI);
+  @BeforeEach
+  void setUp() {
+    springWebSocketClient = new SpringWebSocketClient(getRelayUri());
   }
 
   @Test

--- a/nostr-java-api/src/test/java/nostr/api/integration/BaseRelayIntegrationTest.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/BaseRelayIntegrationTest.java
@@ -2,11 +2,17 @@ package nostr.api.integration;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
+import java.util.ResourceBundle;
 
 public abstract class BaseRelayIntegrationTest {
     @BeforeAll
     static void ensureRelayAvailable() {
         Assumptions.assumeTrue(RelayAvailability.areRelaysAvailable(),
                 "Requires running relay defined in relays.properties");
+    }
+
+    protected String getRelayUri() {
+        ResourceBundle bundle = ResourceBundle.getBundle("relays");
+        return bundle.getString(bundle.keySet().iterator().next());
     }
 }


### PR DESCRIPTION
## Summary
- refactor `ApiNIP52EventIT` and `ApiNIP99EventIT` to initialize the WebSocket client in a `@BeforeEach` method
- add `getRelayUri` helper in `BaseRelayIntegrationTest`

## Testing
- `mvn -q verify && echo SUCCESS`


------
https://chatgpt.com/codex/tasks/task_b_688ab884e4b08331a37f8e1b414dbcf6