### PR TITLE
Fix websocket completion flag

### DIFF
--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
@@ -35,7 +35,7 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
   @Override
   protected void handleTextMessage(@NonNull WebSocketSession session, TextMessage message) {
     events.add(message.getPayload());
-    completed.setRelease(true);
+    completed.set(true);
   }
 
   @Override
@@ -51,7 +51,7 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
         .untilTrue(completed);
     List<String> eventList = List.copyOf(events);
     events = new ArrayList<>();
-    completed.setRelease(false);
+    completed.set(false);
     return eventList;
   }
 


### PR DESCRIPTION
## Summary
- fix `StandardWebSocketClient` to use `AtomicBoolean#set` instead of nonexistent `setRelease`
- build the project to ensure compilation

## Testing
- `mvn -q -DskipTests=true install`

------
https://chatgpt.com/codex/tasks/task_b_6887ff289a388331856d7c03e3d505c2