### PR TITLE
Fix EventTag marker initialization

### DIFF
--- a/nostr-java-event/src/main/java/nostr/event/tag/EventTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/EventTag.java
@@ -42,11 +42,7 @@ public class EventTag extends BaseTag {
     private Marker marker;
 
     public EventTag(String idEvent) {
-        this.recommendedRelayUrl = null;
         this.idEvent = idEvent;
-
-        // TODO: This is a bug. The marker should not be set, or at least not like this.
-        //this.marker = this.idEvent == null ? Marker.ROOT : Marker.REPLY;
     }
 
     public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {

--- a/nostr-java-event/src/test/java/nostr/event/unit/EventTagTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/EventTagTest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EventTagTest {
@@ -34,6 +35,15 @@ class EventTagTest {
 
         assertFalse(fields.stream().anyMatch(field -> field.getName().equals("idEventXXX")));
         assertFalse(fields.stream().flatMap(field -> eventTag.getFieldValue(field).stream()).anyMatch(fieldValue -> fieldValue.equals(eventId + "x")));
+    }
+
+    @Test
+    void constructorDoesNotSetOptionalFields() {
+        String eventId = UUID.randomUUID().toString().concat(UUID.randomUUID().toString()).substring(0, 64);
+        EventTag eventTag = new EventTag(eventId);
+
+        assertNull(eventTag.getRecommendedRelayUrl());
+        assertNull(eventTag.getMarker());
     }
 
     private static void anyFieldNameMatch(List<Field> fields, Predicate<Field> predicate) {


### PR DESCRIPTION
## Summary
- clean up `EventTag` constructor so marker and relay URL remain unset
- add test verifying constructor leaves optional fields null

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed)*

------
https://chatgpt.com/codex/tasks/task_b_688bad5501c48331af2e7962e54809ef