### PR TITLE
Add missing NIP unit tests

### DIFF
--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP03Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP03Test.java
@@ -1,0 +1,29 @@
+package nostr.api.unit;
+
+import nostr.api.NIP01;
+import nostr.api.NIP03;
+import nostr.event.impl.GenericEvent;
+import nostr.event.tag.EventTag;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP03Test {
+
+    @Test
+    public void testCreateOtsEvent() {
+        Identity sender = Identity.generateRandomIdentity();
+        NIP01 nip01 = new NIP01(sender);
+        GenericEvent ref = nip01.createTextNoteEvent("test").sign().getEvent();
+
+        NIP03 nip03 = new NIP03(sender);
+        nip03.createOtsEvent(ref, "ots", "alt");
+        GenericEvent event = nip03.getEvent();
+
+        assertNotNull(event);
+        assertEquals(1040, event.getKind()); // Constants.Kind.OTS_ATTESTATION
+        assertTrue(event.getTags().stream().anyMatch(t -> t.getCode().equals("alt")));
+        assertTrue(event.getTags().stream().anyMatch(t -> t instanceof EventTag));
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP04Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP04Test.java
@@ -1,0 +1,30 @@
+package nostr.api.unit;
+
+import nostr.api.NIP04;
+import nostr.config.Constants;
+import nostr.event.impl.GenericEvent;
+import nostr.event.tag.PubKeyTag;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP04Test {
+
+    @Test
+    public void testCreateAndDecryptDirectMessage() {
+        Identity sender = Identity.generateRandomIdentity();
+        Identity recipient = Identity.generateRandomIdentity();
+        String content = "hello";
+
+        NIP04 nip04 = new NIP04(sender, recipient.getPublicKey());
+        nip04.createDirectMessageEvent(content);
+
+        GenericEvent event = nip04.getEvent();
+        assertEquals(Constants.Kind.ENCRYPTED_DIRECT_MESSAGE, event.getKind());
+        assertTrue(event.getTags().stream().anyMatch(t -> t instanceof PubKeyTag));
+
+        String decrypted = NIP04.decrypt(recipient, event);
+        assertEquals(content, decrypted);
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP05Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP05Test.java
@@ -1,0 +1,34 @@
+package nostr.api.unit;
+
+import nostr.api.NIP05;
+import nostr.event.entities.UserProfile;
+import nostr.event.impl.GenericEvent;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP05Test {
+
+    @Test
+    public void testCreateInternetIdentifierMetadataEvent() throws Exception {
+        Identity sender = Identity.generateRandomIdentity();
+        NIP05 nip05 = new NIP05(sender);
+        UserProfile profile = UserProfile.builder()
+                .name("tester")
+                .nip05("tester@example.com")
+                .publicKey(sender.getPublicKey())
+                .picture(URI.create("https://example.com/pic").toURL())
+                .about("about")
+                .build();
+
+        nip05.createInternetIdentifierMetadataEvent(profile);
+        GenericEvent event = nip05.getEvent();
+
+        assertNotNull(event);
+        assertEquals(0, event.getKind().intValue()); // Constants.Kind.USER_METADATA but 0
+        assertTrue(event.getContent().contains("tester@example.com"));
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP08Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP08Test.java
@@ -1,0 +1,31 @@
+package nostr.api.unit;
+
+import nostr.api.NIP08;
+import nostr.config.Constants;
+import nostr.event.BaseTag;
+import nostr.event.impl.GenericEvent;
+import nostr.event.tag.PubKeyTag;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP08Test {
+
+    @Test
+    public void testCreateMentionsEvent() {
+        Identity sender = Identity.generateRandomIdentity();
+        Identity recipient = Identity.generateRandomIdentity();
+        BaseTag pTag = new PubKeyTag(recipient.getPublicKey());
+
+        NIP08 nip08 = new NIP08(sender);
+        nip08.createMentionsEvent(Constants.Kind.SHORT_TEXT_NOTE, List.of(pTag), "hi");
+        GenericEvent event = nip08.getEvent();
+
+        assertEquals(Constants.Kind.SHORT_TEXT_NOTE, event.getKind());
+        assertTrue(event.getTags().contains(pTag));
+        assertEquals("hi", event.getContent());
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP09Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP09Test.java
@@ -1,0 +1,30 @@
+package nostr.api.unit;
+
+import nostr.api.NIP01;
+import nostr.api.NIP09;
+import nostr.config.Constants;
+import nostr.event.BaseTag;
+import nostr.event.impl.GenericEvent;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP09Test {
+
+    @Test
+    public void testCreateDeletionEvent() {
+        Identity sender = Identity.generateRandomIdentity();
+        NIP01 nip01 = new NIP01(sender);
+        GenericEvent note = nip01.createTextNoteEvent("del me").getEvent();
+
+        NIP09 nip09 = new NIP09(sender);
+        nip09.createDeletionEvent(List.of(note));
+        GenericEvent event = nip09.getEvent();
+
+        assertEquals(Constants.Kind.EVENT_DELETION, event.getKind());
+        assertTrue(event.getTags().stream().anyMatch(t -> t.getCode().equals("e")));
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP12Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP12Test.java
@@ -1,0 +1,31 @@
+package nostr.api.unit;
+
+import nostr.api.NIP12;
+import nostr.event.BaseTag;
+import nostr.event.tag.HashtagTag;
+import nostr.event.tag.ReferenceTag;
+import nostr.event.tag.GeohashTag;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP12Test {
+
+    @Test
+    public void testCreateTags() throws Exception {
+        BaseTag hTag = NIP12.createHashtagTag("nostr");
+        assertEquals("t", hTag.getCode());
+        assertEquals("nostr", ((HashtagTag) hTag).getHashTag());
+
+        URL url = new URL("https://example.com");
+        BaseTag rTag = NIP12.createReferenceTag(url);
+        assertEquals("r", rTag.getCode());
+        assertEquals(url.toString(), ((ReferenceTag) rTag).getUri().toString());
+
+        BaseTag gTag = NIP12.createGeohashTag("loc");
+        assertEquals("g", gTag.getCode());
+        assertEquals("loc", ((GeohashTag) gTag).getLocation());
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP14Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP14Test.java
@@ -1,0 +1,18 @@
+package nostr.api.unit;
+
+import nostr.api.NIP14;
+import nostr.event.BaseTag;
+import nostr.event.tag.SubjectTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP14Test {
+
+    @Test
+    public void testCreateSubjectTag() {
+        BaseTag tag = NIP14.createSubjectTag("subj");
+        assertEquals("subject", tag.getCode());
+        assertEquals("subj", ((SubjectTag) tag).getSubject());
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP15Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP15Test.java
@@ -1,0 +1,33 @@
+package nostr.api.unit;
+
+import nostr.api.NIP15;
+import nostr.event.entities.Product;
+import nostr.event.entities.Stall;
+import nostr.event.impl.GenericEvent;
+import nostr.id.Identity;
+import nostr.event.tag.IdentifierTag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP15Test {
+
+    @Test
+    public void testCreateProductEvent() {
+        Identity sender = Identity.generateRandomIdentity();
+        NIP15 nip15 = new NIP15(sender);
+        Product product = new Product();
+        product.setName("item");
+        product.setStall(new Stall());
+        product.setCurrency("USD");
+        product.setPrice(1f);
+        product.setQuantity(1);
+        nip15.createCreateOrUpdateProductEvent(product, List.of("tag"));
+        GenericEvent event = nip15.getEvent();
+        assertNotNull(event.getId());
+        IdentifierTag idTag = (IdentifierTag) event.getTags().get(0);
+        assertNotNull(idTag.getUuid());
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP20Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP20Test.java
@@ -1,0 +1,24 @@
+package nostr.api.unit;
+
+import nostr.api.NIP01;
+import nostr.api.NIP20;
+import nostr.event.impl.GenericEvent;
+import nostr.event.message.OkMessage;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP20Test {
+
+    @Test
+    public void testCreateOkMessage() {
+        Identity sender = Identity.generateRandomIdentity();
+        NIP01 nip01 = new NIP01(sender);
+        GenericEvent event = nip01.createTextNoteEvent("msg").getEvent();
+        OkMessage ok = NIP20.createOkMessage(event, true, "ok");
+        assertEquals(event.getId(), ok.getEventId());
+        assertTrue(ok.getFlag());
+        assertEquals("ok", ok.getMessage());
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP23Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP23Test.java
@@ -1,0 +1,29 @@
+package nostr.api.unit;
+
+import nostr.api.NIP23;
+import nostr.config.Constants;
+import nostr.event.BaseTag;
+import nostr.event.impl.GenericEvent;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP23Test {
+
+    @Test
+    public void testCreateLongFormTextNoteEvent() throws Exception {
+        Identity sender = Identity.generateRandomIdentity();
+        NIP23 nip23 = new NIP23(sender);
+        nip23.creatLongFormTextNoteEvent("long");
+        nip23.addTitleTag("title");
+        nip23.addImageTag(new URL("https://example.com"));
+        GenericEvent event = nip23.getEvent();
+
+        assertEquals(Constants.Kind.LONG_FORM_TEXT_NOTE, event.getKind());
+        assertTrue(event.getTags().stream().anyMatch(t -> t.getCode().equals("title")));
+        assertTrue(event.getTags().stream().anyMatch(t -> t.getCode().equals("image")));
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP25Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP25Test.java
@@ -1,0 +1,31 @@
+package nostr.api.unit;
+
+import nostr.api.NIP01;
+import nostr.api.NIP25;
+import nostr.event.BaseTag;
+import nostr.event.entities.Reaction;
+import nostr.event.impl.GenericEvent;
+import nostr.event.tag.EventTag;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP25Test {
+
+    @Test
+    public void testCreateReactionEvent() {
+        Identity sender = Identity.generateRandomIdentity();
+        NIP01 nip01 = new NIP01(sender);
+        GenericEvent note = nip01.createTextNoteEvent("hi").getEvent();
+
+        NIP25 nip25 = new NIP25(sender);
+        nip25.createReactionEvent(note, Reaction.LIKE, null);
+        GenericEvent event = nip25.getEvent();
+
+        assertEquals("+", event.getContent());
+        assertTrue(event.getTags().stream().anyMatch(t -> t instanceof EventTag));
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP28Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP28Test.java
@@ -1,0 +1,25 @@
+package nostr.api.unit;
+
+import nostr.api.NIP28;
+import nostr.config.Constants;
+import nostr.event.entities.ChannelProfile;
+import nostr.event.impl.GenericEvent;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP28Test {
+
+    @Test
+    public void testCreateChannelCreateEvent() throws Exception {
+        Identity sender = Identity.generateRandomIdentity();
+        NIP28 nip28 = new NIP28(sender);
+        ChannelProfile profile = new ChannelProfile("channel","about", new java.net.URL("https://example.com"));
+        nip28.createChannelCreateEvent(profile);
+        GenericEvent event = nip28.getEvent();
+
+        assertEquals(Constants.Kind.CHANNEL_CREATION, event.getKind());
+        assertTrue(event.getContent().contains("channel"));
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP30Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP30Test.java
@@ -1,0 +1,19 @@
+package nostr.api.unit;
+
+import nostr.api.NIP30;
+import nostr.event.BaseTag;
+import nostr.event.tag.EmojiTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP30Test {
+
+    @Test
+    public void testCreateEmojiTag() {
+        BaseTag tag = NIP30.createEmojiTag("smile", "https://img");
+        assertEquals("emoji", tag.getCode());
+        assertEquals("smile", ((EmojiTag) tag).getShortcode());
+        assertEquals("https://img", ((EmojiTag) tag).getUrl());
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP31Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP31Test.java
@@ -1,0 +1,18 @@
+package nostr.api.unit;
+
+import nostr.api.NIP31;
+import nostr.event.BaseTag;
+import nostr.event.tag.GenericTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP31Test {
+
+    @Test
+    public void testCreateAltTag() {
+        BaseTag tag = NIP31.createAltTag("desc");
+        assertEquals("alt", tag.getCode());
+        assertEquals("desc", ((GenericTag) tag).getAttributes().get(0).getValue());
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP32Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP32Test.java
@@ -1,0 +1,25 @@
+package nostr.api.unit;
+
+import nostr.api.NIP32;
+import nostr.event.BaseTag;
+import nostr.event.tag.GenericTag;
+import nostr.event.tag.LabelNamespaceTag;
+import nostr.event.tag.LabelTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP32Test {
+
+    @Test
+    public void testCreateTags() {
+        BaseTag ns = NIP32.createNameSpaceTag("ns");
+        assertEquals("L", ns.getCode());
+        assertEquals("ns", ((LabelNamespaceTag) ns).getNameSpace());
+
+        BaseTag label = NIP32.createLabelTag("label", "ns");
+        assertEquals("l", label.getCode());
+        assertEquals("label", ((LabelTag) label).getLabel());
+        assertEquals("ns", ((LabelTag) label).getNameSpace());
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP40Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP40Test.java
@@ -1,0 +1,18 @@
+package nostr.api.unit;
+
+import nostr.api.NIP40;
+import nostr.event.BaseTag;
+import nostr.event.tag.ExpirationTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP40Test {
+
+    @Test
+    public void testCreateExpirationTag() {
+        BaseTag tag = NIP40.createExpirationTag(10);
+        assertEquals("expiration", tag.getCode());
+        assertEquals(10, ((ExpirationTag) tag).getExpiration().intValue());
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP42Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP42Test.java
@@ -1,0 +1,24 @@
+package nostr.api.unit;
+
+import nostr.api.NIP42;
+import nostr.base.Relay;
+import nostr.event.BaseTag;
+import nostr.event.tag.GenericTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP42Test {
+
+    @Test
+    public void testCreateTags() {
+        Relay relay = new Relay("wss://relay");
+        BaseTag rTag = NIP42.createRelayTag(relay);
+        assertEquals("relay", rTag.getCode());
+        assertEquals(relay.getUri(), ((GenericTag) rTag).getAttributes().get(0).getValue());
+
+        BaseTag cTag = NIP42.createChallengeTag("abc");
+        assertEquals("challenge", cTag.getCode());
+        assertEquals("abc", ((GenericTag) cTag).getAttributes().get(0).getValue());
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP44Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP44Test.java
@@ -1,0 +1,38 @@
+package nostr.api.unit;
+
+import nostr.api.NIP44;
+import nostr.event.impl.GenericEvent;
+import nostr.event.tag.PubKeyTag;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP44Test {
+
+    @Test
+    public void testEncryptDecrypt() {
+        Identity sender = Identity.generateRandomIdentity();
+        Identity recipient = Identity.generateRandomIdentity();
+        String message = "hello";
+
+        String encrypted = NIP44.encrypt(sender, message, recipient.getPublicKey());
+        String decrypted = NIP44.decrypt(recipient, encrypted, sender.getPublicKey());
+        assertEquals(message, decrypted);
+    }
+
+    @Test
+    public void testDecryptEvent() {
+        Identity sender = Identity.generateRandomIdentity();
+        Identity recipient = Identity.generateRandomIdentity();
+
+        String content = "msg";
+        String enc = NIP44.encrypt(sender, content, recipient.getPublicKey());
+        GenericEvent event = new GenericEvent(sender.getPublicKey(), 1050, List.of(new PubKeyTag(recipient.getPublicKey())), enc);
+
+        String dec = NIP44.decrypt(recipient, event);
+        assertEquals(content, dec);
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP46Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP46Test.java
@@ -1,0 +1,38 @@
+package nostr.api.unit;
+
+import nostr.api.NIP46;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP46Test {
+
+    @Test
+    public void testRequestAndResponseSerialization() {
+        NIP46.Request req = new NIP46.Request();
+        req.setId("1");
+        req.setMethod("do");
+        req.addParam("a");
+        String json = req.toString();
+        NIP46.Request parsed = NIP46.Request.fromString(json);
+        assertEquals(req.getId(), parsed.getId());
+        assertEquals(req.getMethod(), parsed.getMethod());
+        assertTrue(parsed.getParams().contains("a"));
+
+        NIP46.Response resp = new NIP46.Response("1", null, "ok");
+        String js = resp.toString();
+        NIP46.Response parsedResp = NIP46.Response.fromString(js);
+        assertEquals("ok", parsedResp.getResult());
+    }
+
+    @Test
+    public void testCreateRequestEvent() {
+        Identity sender = Identity.generateRandomIdentity();
+        Identity signer = Identity.generateRandomIdentity();
+        NIP46 nip46 = new NIP46(sender);
+        NIP46.Request req = new NIP46.Request("1", "do", null);
+        nip46.createRequestEvent(req, signer.getPublicKey());
+        assertNotNull(nip46.getEvent());
+    }
+}

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP65Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP65Test.java
@@ -1,0 +1,26 @@
+package nostr.api.unit;
+
+import nostr.api.NIP65;
+import nostr.base.Marker;
+import nostr.base.Relay;
+import nostr.event.BaseTag;
+import nostr.event.impl.GenericEvent;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NIP65Test {
+
+    @Test
+    public void testCreateRelayListMetadataEvent() {
+        Identity sender = Identity.generateRandomIdentity();
+        NIP65 nip65 = new NIP65(sender);
+        Relay relay = new Relay("wss://relay");
+        nip65.createRelayListMetadataEvent(List.of(relay), Marker.READ);
+        GenericEvent event = nip65.getEvent();
+        assertEquals("r", event.getTags().get(0).getCode());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for remaining NIP classes in the api module
- cover creation of events and tags for many NIP implementations

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed)*

------
https://chatgpt.com/codex/tasks/task_b_688bf98e3b348331851b2272c9490331