### PR TITLE
feat: add retry to websocket client

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ See [`docs/CODEBASE_OVERVIEW.md`](docs/CODEBASE_OVERVIEW.md) for details about r
 ## Examples
 Example usages are located in the [`nostr-java-examples`](./nostr-java-examples) module. Additional demonstrations can be found in [nostr-client](https://github.com/tcheeric/nostr-client) and [SuperConductor](https://github.com/avlo/superconductor).
 
+## Retry Support
+`SpringWebSocketClient` leverages Spring Retry so that failed WebSocket send operations are attempted up to three times with exponential backoff.
+
 ## Supported NIPs
 The API currently implements the following [NIPs](https://github.com/nostr-protocol/nips):
 - [NIP-1](https://github.com/nostr-protocol/nips/blob/master/01.md)

--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -45,6 +45,9 @@ nostr.websocket.await-timeout-ms=60000
 nostr.websocket.poll-interval-ms=500
 ```
 
+## Retry behavior
+`SpringWebSocketClient` leverages Spring Retry so that failed send operations are retried up to three times with an exponential backoff starting at 500 ms.
+
 ## Creating and sending events
 The examples module shows how to create built-in and custom events. Below is an excerpt from the examples illustrating the creation of a `TextNoteEvent`:
 ```java

--- a/nostr-java-api/src/main/java/nostr/api/WebSocketClientHandler.java
+++ b/nostr-java-api/src/main/java/nostr/api/WebSocketClientHandler.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import nostr.base.IEvent;
 import nostr.client.springwebsocket.SpringWebSocketClient;
+import nostr.client.springwebsocket.StandardWebSocketClient;
 import nostr.event.filter.Filters;
 import nostr.event.impl.GenericEvent;
 import nostr.event.message.EventMessage;
@@ -28,7 +29,7 @@ public class WebSocketClientHandler {
     protected WebSocketClientHandler(@NonNull String relayName, @NonNull String relayUri) {
         this.relayName = relayName;
         this.relayUri = relayUri;
-        this.eventClient = new SpringWebSocketClient(relayUri);
+        this.eventClient = new SpringWebSocketClient(new StandardWebSocketClient(relayUri), relayUri);
     }
 
     public List<String> sendEvent(@NonNull IEvent event) {
@@ -42,7 +43,7 @@ public class WebSocketClientHandler {
                         requestClientMap.get(subscriptionId))
                 .map(client ->
                         client.send(new ReqMessage(subscriptionId, filters))).or(() -> {
-                    requestClientMap.put(subscriptionId, new SpringWebSocketClient(relayUri));
+                      requestClientMap.put(subscriptionId, new SpringWebSocketClient(new StandardWebSocketClient(relayUri), relayUri));
                     return Optional.ofNullable(
                             requestClientMap.get(subscriptionId).send(
                                     new ReqMessage(subscriptionId, filters)));

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiEventTestUsingSpringWebSocketClientIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiEventTestUsingSpringWebSocketClientIT.java
@@ -4,6 +4,7 @@ import lombok.SneakyThrows;
 import nostr.api.NIP15;
 import nostr.base.PrivateKey;
 import nostr.client.springwebsocket.SpringWebSocketClient;
+import nostr.client.springwebsocket.StandardWebSocketClient;
 import nostr.config.RelayConfig;
 import nostr.event.impl.GenericEvent;
 import nostr.event.message.EventMessage;
@@ -29,7 +30,9 @@ class ApiEventTestUsingSpringWebSocketClientIT extends BaseRelayIntegrationTest 
 
     @Autowired
     public ApiEventTestUsingSpringWebSocketClientIT(Map<String, String> relays) {
-        this.springWebSocketClients = relays.values().stream().map(SpringWebSocketClient::new).toList();
+        this.springWebSocketClients = relays.values().stream()
+            .map(uri -> new SpringWebSocketClient(new StandardWebSocketClient(uri), uri))
+            .toList();
     }
 
     @Test

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
@@ -5,6 +5,7 @@ import nostr.api.util.JsonComparator;
 import nostr.base.PrivateKey;
 import nostr.base.PublicKey;
 import nostr.client.springwebsocket.SpringWebSocketClient;
+import nostr.client.springwebsocket.StandardWebSocketClient;
 import nostr.event.BaseTag;
 import nostr.event.entities.CalendarContent;
 import nostr.event.impl.GenericEvent;
@@ -28,9 +29,9 @@ class ApiNIP52EventIT extends BaseRelayIntegrationTest {
   private SpringWebSocketClient springWebSocketClient;
 
   @BeforeEach
-  void setup() {
-    springWebSocketClient = new SpringWebSocketClient(getRelayUri());
-  }
+    void setup() {
+      springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
+    }
 
   @Test
   void testNIP52CalendarTimeBasedEventEventUsingSpringWebSocketClient() throws IOException {

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52RequestIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52RequestIT.java
@@ -3,6 +3,7 @@ package nostr.api.integration;
 import nostr.api.NIP52;
 import nostr.base.PublicKey;
 import nostr.client.springwebsocket.SpringWebSocketClient;
+import nostr.client.springwebsocket.StandardWebSocketClient;
 import nostr.event.BaseTag;
 import nostr.event.entities.CalendarContent;
 import nostr.event.impl.GenericEvent;
@@ -108,7 +109,7 @@ class ApiNIP52RequestIT extends BaseRelayIntegrationTest {
     eventPubKey = event.getPubKey().toString();
     EventMessage eventMessage = new EventMessage(event);
 
-    SpringWebSocketClient springWebSocketEventClient = new SpringWebSocketClient(getRelayUri());
+      SpringWebSocketClient springWebSocketEventClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
     String eventResponse = springWebSocketEventClient.send(eventMessage).stream().findFirst().orElseThrow();
 
     // Extract and compare only first 3 elements of the JSON array
@@ -129,7 +130,7 @@ class ApiNIP52RequestIT extends BaseRelayIntegrationTest {
 
     // TODO - This assertion fails with superdonductor and nostr-rs-relay
 
-    SpringWebSocketClient springWebSocketRequestClient = new SpringWebSocketClient(getRelayUri());
+      SpringWebSocketClient springWebSocketRequestClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
     String subscriberId = UUID.randomUUID().toString();
     String reqJson = createReqJson(subscriberId, eventId);
     String reqResponse = springWebSocketRequestClient.send(reqJson).stream().findFirst().orElseThrow();

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
@@ -4,6 +4,7 @@ import nostr.api.NIP99;
 import nostr.base.PrivateKey;
 import nostr.base.PublicKey;
 import nostr.client.springwebsocket.SpringWebSocketClient;
+import nostr.client.springwebsocket.StandardWebSocketClient;
 import nostr.event.BaseTag;
 import nostr.event.entities.ClassifiedListing;
 import nostr.event.impl.GenericEvent;
@@ -55,9 +56,9 @@ class ApiNIP99EventIT extends BaseRelayIntegrationTest {
   private SpringWebSocketClient springWebSocketClient;
 
   @BeforeEach
-  void setup() {
-    springWebSocketClient = new SpringWebSocketClient(getRelayUri());
-  }
+    void setup() {
+      springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
+    }
 
   @Test
   void testNIP99ClassifiedListingEvent() throws IOException {

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99RequestIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99RequestIT.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import nostr.api.NIP99;
 import nostr.base.PublicKey;
 import nostr.client.springwebsocket.SpringWebSocketClient;
+import nostr.client.springwebsocket.StandardWebSocketClient;
 import nostr.event.BaseTag;
 import nostr.event.entities.ClassifiedListing;
 import nostr.event.impl.GenericEvent;
@@ -96,7 +97,7 @@ class ApiNIP99RequestIT extends BaseRelayIntegrationTest {
     eventPubKey = event.getPubKey().toString();
     EventMessage eventMessage = new EventMessage(event);
 
-    SpringWebSocketClient springWebSocketEventClient = new SpringWebSocketClient(getRelayUri());
+      SpringWebSocketClient springWebSocketEventClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
     List<String> eventResponses = springWebSocketEventClient.send(eventMessage);
 
 	  assertEquals(1, eventResponses.size(), "Expected 1 event response, but got " + eventResponses.size());
@@ -118,7 +119,7 @@ class ApiNIP99RequestIT extends BaseRelayIntegrationTest {
 
     // TODO - Investigate why EOSE, instead of EVENT, is returned from nostr-rs-relay, and not superconductor
 
-    SpringWebSocketClient springWebSocketRequestClient = new SpringWebSocketClient(getRelayUri());
+      SpringWebSocketClient springWebSocketRequestClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
     String reqJson = createReqJson(UUID.randomUUID().toString(), eventId);
     List<String> reqResponses = springWebSocketRequestClient.send(reqJson).stream().toList();
     springWebSocketRequestClient.closeSocket();

--- a/nostr-java-api/src/test/java/nostr/api/integration/ZDoLastApiNIP09EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ZDoLastApiNIP09EventIT.java
@@ -5,6 +5,7 @@ import nostr.api.NIP09;
 import nostr.base.Kind;
 import nostr.base.Relay;
 import nostr.client.springwebsocket.SpringWebSocketClient;
+import nostr.client.springwebsocket.StandardWebSocketClient;
 import nostr.config.RelayConfig;
 import nostr.event.BaseTag;
 import nostr.event.filter.AuthorFilter;
@@ -44,7 +45,7 @@ public class ZDoLastApiNIP09EventIT extends BaseRelayIntegrationTest {
 
     @BeforeEach
     void setup() {
-        springWebSocketClient = new SpringWebSocketClient(getRelayUri());
+        springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
     }
 
     @Test

--- a/nostr-java-client/pom.xml
+++ b/nostr-java-client/pom.xml
@@ -50,5 +50,18 @@
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/RetryConfig.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/RetryConfig.java
@@ -1,0 +1,9 @@
+package nostr.client.springwebsocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
@@ -3,29 +3,55 @@ package nostr.client.springwebsocket;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import nostr.event.BaseMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.List;
 
+@Component
+@Slf4j
 public class SpringWebSocketClient {
   private final WebSocketClientIF webSocketClientIF;
 
   @Getter
   private final String relayUrl;
 
-  public SpringWebSocketClient(@NonNull String relayUrl) {
-    webSocketClientIF = new StandardWebSocketClient(relayUrl);
+  public SpringWebSocketClient(@NonNull WebSocketClientIF webSocketClientIF,
+      @Value("${nostr.relay.uri}") String relayUrl) {
+    this.webSocketClientIF = webSocketClientIF;
     this.relayUrl = relayUrl;
   }
 
+  @Retryable(value = IOException.class, maxAttempts = 3,
+      backoff = @Backoff(delay = 500, multiplier = 2))
   @SneakyThrows
   public List<String> send(@NonNull BaseMessage eventMessage) {
     return webSocketClientIF.send(eventMessage.encode());
   }
 
+  @Retryable(value = IOException.class, maxAttempts = 3,
+      backoff = @Backoff(delay = 500, multiplier = 2))
   public List<String> send(@NonNull String json) throws IOException {
     return webSocketClientIF.send(json);
+  }
+
+  @Recover
+  public List<String> recover(IOException ex, String json) throws IOException {
+    log.error("Failed to send message after retries: {}", json, ex);
+    throw ex;
+  }
+
+  @Recover
+  @SneakyThrows
+  public List<String> recover(IOException ex, BaseMessage eventMessage) {
+    log.error("Failed to send message after retries: {}", eventMessage, ex);
+    throw ex;
   }
 
   public void closeSocket() throws IOException {

--- a/nostr-java-client/src/test/java/nostr/client/springwebsocket/SpringWebSocketClientTest.java
+++ b/nostr-java-client/src/test/java/nostr/client/springwebsocket/SpringWebSocketClientTest.java
@@ -1,0 +1,84 @@
+package nostr.client.springwebsocket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+import nostr.event.BaseMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(classes = {RetryConfig.class, SpringWebSocketClient.class, SpringWebSocketClientTest.TestConfig.class})
+@TestPropertySource(properties = "nostr.relay.uri=wss://test")
+class SpringWebSocketClientTest {
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        TestWebSocketClient webSocketClientIF() {
+            return new TestWebSocketClient();
+        }
+    }
+
+    static class TestWebSocketClient implements WebSocketClientIF {
+        @Getter
+        @Setter
+        private int attempts;
+        @Setter
+        private int failuresBeforeSuccess;
+
+        @Override
+        public <T extends BaseMessage> List<String> send(T eventMessage) throws IOException {
+            return send(eventMessage.encode());
+        }
+
+        @Override
+        public List<String> send(String json) throws IOException {
+            attempts++;
+            if (attempts <= failuresBeforeSuccess) {
+                throw new IOException("fail");
+            }
+            return List.of("ok");
+        }
+
+        @Override
+        public void closeSocket() {
+        }
+    }
+
+    @Autowired
+    private SpringWebSocketClient client;
+
+    @Autowired
+    private TestWebSocketClient webSocketClientIF;
+
+    @BeforeEach
+    void setup() {
+        webSocketClientIF.setFailuresBeforeSuccess(0);
+        webSocketClientIF.setAttempts(0);
+    }
+
+    @Test
+    void retriesUntilSuccess() throws IOException {
+        webSocketClientIF.setFailuresBeforeSuccess(2);
+        List<String> result = client.send("payload");
+        assertEquals(List.of("ok"), result);
+        assertEquals(3, webSocketClientIF.getAttempts());
+    }
+
+    @Test
+    void recoverAfterMaxAttempts() {
+        webSocketClientIF.setFailuresBeforeSuccess(5);
+        assertThrows(IOException.class, () -> client.send("payload"));
+        assertEquals(3, webSocketClientIF.getAttempts());
+    }
+}


### PR DESCRIPTION
## Summary
- enable Spring Retry on the client module and expose retry configuration
- convert SpringWebSocketClient to a Spring component with retryable send operations
- document and test WebSocket retry behaviour

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

## Network Access
- `https://www.slf4j.org/codes.html#noProviders`

------
https://chatgpt.com/codex/tasks/task_b_688f585beab48331b2a0bf186f6ad4ad