### PR TITLE
refactor: centralize websocket retry settings

### DIFF
--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/NostrRetryable.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/NostrRetryable.java
@@ -1,0 +1,23 @@
+package nostr.client.springwebsocket;
+
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Common retry configuration for WebSocket send operations.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Retryable(value = IOException.class, maxAttempts = NostrRetryable.MAX_ATTEMPTS,
+    backoff = @Backoff(delay = NostrRetryable.DELAY, multiplier = NostrRetryable.MULTIPLIER))
+public @interface NostrRetryable {
+    int MAX_ATTEMPTS = 3;
+    long DELAY = 500L;
+    double MULTIPLIER = 2.0;
+}

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
@@ -6,9 +6,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import nostr.event.BaseMessage;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -28,15 +26,13 @@ public class SpringWebSocketClient {
     this.relayUrl = relayUrl;
   }
 
-  @Retryable(value = IOException.class, maxAttempts = 3,
-      backoff = @Backoff(delay = 500, multiplier = 2))
+  @NostrRetryable
   @SneakyThrows
   public List<String> send(@NonNull BaseMessage eventMessage) {
     return webSocketClientIF.send(eventMessage.encode());
   }
 
-  @Retryable(value = IOException.class, maxAttempts = 3,
-      backoff = @Backoff(delay = 500, multiplier = 2))
+  @NostrRetryable
   public List<String> send(@NonNull String json) throws IOException {
     return webSocketClientIF.send(json);
   }


### PR DESCRIPTION
## Summary
- add reusable `@NostrRetryable` annotation encapsulating retry configuration
- apply the annotation to `SpringWebSocketClient` send methods to remove duplicate settings

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed. Will not retry.)*


------
https://chatgpt.com/codex/tasks/task_b_688f63abc1488331be271d8ffead17bc