### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+
+      - name: Build and deploy
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: ./mvnw -q -P release deploy -Dgpg.passphrase="$GPG_PASSPHRASE"
+
+      - name: Collect JAR artifacts
+        run: |
+          mkdir -p release-jars
+          find . -name "*.jar" -path "*/target/*.jar" -not -name "*sources*" -not -name "*javadoc*" -exec cp {} release-jars/ \;
+
+      - name: Create GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload JAR artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for file in release-jars/*.jar; do
+            gh release upload "${{ github.ref_name }}" "$file" --clobber
+          done


### PR DESCRIPTION
## Summary
- add release workflow triggered by tags v*
- setup JDK21, import GPG keys, deploy release profile, and publish GitHub release with JAR assets

## Testing
- `./mvnw -q verify` *(failed: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_b_68969d778b848331a3661342d22128c1