### PR TITLE
Enforce JaCoCo instruction coverage threshold

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,8 +221,34 @@
                         <execution>
                             <goals>
                                 <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <phase>verify</phase>
+                            <goals>
                                 <goal>report</goal>
                             </goals>
+                        </execution>
+                        <execution>
+                            <id>check</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <rule>
+                                        <limits>
+                                            <limit>
+                                                <counter>INSTRUCTION</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.80</minimum>
+                                            </limit>
+                                        </limits>
+                                    </rule>
+                                </rules>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>


### PR DESCRIPTION
## Summary
- enforce an 80% instruction coverage requirement via JaCoCo

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met for nostr-java-util)*

------
https://chatgpt.com/codex/tasks/task_b_6896b6cbc36083318402b55753b9c2a1