### PR TITLE
Add util module tests to satisfy coverage

### DIFF
--- a/nostr-java-util/src/test/java/nostr/util/NostrUtilExtendedTest.java
+++ b/nostr-java-util/src/test/java/nostr/util/NostrUtilExtendedTest.java
@@ -1,0 +1,55 @@
+package nostr.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NostrUtilExtendedTest {
+
+    @Test
+    public void testBytesFromIntAndBigInteger() {
+        int value = 0x12345678;
+        byte[] bytes = NostrUtil.bytesFromInt(value);
+        assertArrayEquals(new byte[]{0x12, 0x34, 0x56, 0x78}, bytes);
+
+        BigInteger big = new BigInteger(1, new byte[]{0x01, 0x02});
+        byte[] bigBytes = NostrUtil.bytesFromBigInteger(big);
+        assertEquals(32, bigBytes.length);
+        assertTrue(Arrays.equals(Arrays.copyOfRange(bigBytes, 30, 32), new byte[]{0x01, 0x02}));
+
+        assertEquals(big, NostrUtil.bigIntFromBytes(bigBytes));
+    }
+
+    @Test
+    public void testSha256AndXor() throws NoSuchAlgorithmException {
+        byte[] data = new byte[]{1,2,3};
+        byte[] hash = NostrUtil.sha256(data);
+        assertEquals(32, hash.length);
+
+        byte[] xored = NostrUtil.xor(data, new byte[]{3,2,1});
+        assertArrayEquals(new byte[]{2,0,2}, xored);
+
+        assertNull(NostrUtil.xor(new byte[]{1}, new byte[]{1,2}));
+    }
+
+    @Test
+    public void testJsonEscapeAndUnescape() {
+        String json = "{\"key\":\n\t'\\value'\r}";
+        String escaped = NostrUtil.escapeJsonString(json);
+        String unescaped = NostrUtil.unEscapeJsonString(escaped);
+        assertEquals(json, unescaped);
+    }
+
+    @Test
+    public void testHexLengthConversions() {
+        String hex128 = "a".repeat(128);
+        assertEquals(64, NostrUtil.hex128ToBytes(hex128).length);
+
+        String nip04 = "a".repeat(66);
+        assertEquals(33, NostrUtil.nip04PubKeyHexToBytes(nip04).length);
+    }
+}

--- a/nostr-java-util/src/test/java/nostr/util/validator/HexStringValidatorTest.java
+++ b/nostr-java-util/src/test/java/nostr/util/validator/HexStringValidatorTest.java
@@ -1,0 +1,32 @@
+package nostr.util.validator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HexStringValidatorTest {
+
+    @Test
+    public void testValidHexString() {
+        assertDoesNotThrow(() -> HexStringValidator.validateHex("deadbeef", 8));
+    }
+
+    @Test
+    public void testInvalidLength() {
+        assertThrows(IllegalArgumentException.class,
+                () -> HexStringValidator.validateHex("abc", 4));
+    }
+
+    @Test
+    public void testInvalidCharacters() {
+        assertThrows(IllegalArgumentException.class,
+                () -> HexStringValidator.validateHex("zzzz", 4));
+    }
+
+    @Test
+    public void testUpperCaseCharacters() {
+        assertThrows(IllegalArgumentException.class,
+                () -> HexStringValidator.validateHex("ABcd", 4));
+    }
+}

--- a/nostr-java-util/src/test/java/nostr/util/validator/Nip05ValidatorTest.java
+++ b/nostr-java-util/src/test/java/nostr/util/validator/Nip05ValidatorTest.java
@@ -1,0 +1,44 @@
+package nostr.util.validator;
+
+import nostr.util.NostrException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Nip05ValidatorTest {
+
+    @Test
+    public void testInvalidLocalPart() {
+        Nip05Validator validator = Nip05Validator.builder()
+                .nip05("bad!part@example.com")
+                .publicKey("pub")
+                .build();
+        assertThrows(NostrException.class, validator::validate);
+    }
+
+    @Test
+    public void testUnknownDomain() {
+        Nip05Validator validator = Nip05Validator.builder()
+                .nip05("user@http://example.com")
+                .publicKey("pub")
+                .build();
+        assertThrows(NostrException.class, validator::validate);
+    }
+
+    @Test
+    public void testGetPublicKeyViaReflection() throws Exception {
+        Nip05Validator validator = Nip05Validator.builder()
+                .nip05("user@example.com")
+                .publicKey("pub")
+                .build();
+        Method m = Nip05Validator.class.getDeclaredMethod("getPublicKey", StringBuilder.class, String.class);
+        m.setAccessible(true);
+        String json = "{\"names\":{\"alice\":\"abc\"}}";
+        String result = (String) m.invoke(validator, new StringBuilder(json), "alice");
+        assertEquals("abc", result);
+        String missing = (String) m.invoke(validator, new StringBuilder(json), "bob");
+        assertNull(missing);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for hex string validation, Nostr utilities and NIP-05 validator
- ensure validator handles invalid local parts and domains, and public key extraction
- cover additional utility methods for integer conversion, hashing, XOR and JSON escaping

## Testing
- `mvn -q verify -pl nostr-java-util`
- `mvn -q verify` *(fails: Coverage checks have not been met for module nostr-java-base)*

------
https://chatgpt.com/codex/tasks/task_b_6896bba1911483319469c33966735aee