### PR TITLE
Configure GitHub Packages deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'maven'
+          server-id: github
+          server-username: ${{ github.actor }}
+          server-password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Import GPG key
         env:
@@ -30,6 +33,13 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: ./mvnw -q -P release deploy -Dgpg.passphrase="$GPG_PASSPHRASE"
+
+      - name: Deploy to GitHub Packages
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          ./mvnw -q -P release deploy -Dgpg.passphrase="$GPG_PASSPHRASE" \
+            -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/tcheeric/nostr-java
 
       - name: Collect JAR artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,12 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           ./mvnw -q -P release deploy -Dgpg.passphrase="$GPG_PASSPHRASE" \
-            -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/tcheeric/nostr-java
+        run: $MVN_DEPLOY_CMD
+
+      - name: Deploy to GitHub Packages
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: $MVN_DEPLOY_CMD -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/tcheeric/nostr-java
 
       - name: Collect JAR artifacts
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,10 @@
     </scm>
 
     <distributionManagement>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/tcheeric/nostr-java</url>
+        </repository>
         <snapshotRepository>
             <id>ossrh</id>
             <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>


### PR DESCRIPTION
## Summary
- publish releases to GitHub Packages via distributionManagement
- release workflow authenticates to GitHub Packages and deploys artifacts

## Testing
- `./mvnw -q verify` *(fails: java.net.SocketException: Network is unreachable)*

## Network Access
- `repo.maven.apache.org` – network is unreachable


------
https://chatgpt.com/codex/tasks/task_b_6896c2a8ef908331a8f42dcaec869f57