### PR TITLE
docs: document GitHub Packages usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,28 @@ $ ./mvnw clean install
 
 See [`docs/CODEBASE_OVERVIEW.md`](docs/CODEBASE_OVERVIEW.md) for details about running tests and contributing.
 
+## Using Published Artifacts
+Artifacts are published to GitHub Packages and can be consumed from Maven by adding the repository and desired dependency to your `pom.xml`:
+
+```xml
+<repositories>
+  <repository>
+    <id>github</id>
+    <url>https://maven.pkg.github.com/OWNER/REPO</url>
+  </repository>
+</repositories>
+
+<dependencies>
+  <dependency>
+    <groupId>xyz.tcheeric</groupId>
+    <artifactId>nostr-java-api</artifactId>
+    <version>${nostr-java.version}</version>
+  </dependency>
+</dependencies>
+```
+
+Authenticating to GitHub Packages is required; provide a personal access token with the appropriate scopes or `GITHUB_TOKEN` credentials. See the [GitHub Packages documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry) for more details.
+
 ## CI and Releases
 The project uses GitHub Actions defined in [ci.yml](https://github.com/tcheeric/nostr-java/actions/workflows/ci.yml).
 This workflow runs `mvn -q verify` to build the project and execute all tests on each push and pull request.


### PR DESCRIPTION
## Summary
- document how to consume artifacts from GitHub Packages with Maven

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met)*


------
https://chatgpt.com/codex/tasks/task_b_6896c2af9a4483318bba4984dd1c959b