### PR TITLE
Rename getByteArraySupplier method

### DIFF
--- a/nostr-java-base/src/main/java/nostr/base/ISignable.java
+++ b/nostr-java-base/src/main/java/nostr/base/ISignable.java
@@ -13,5 +13,5 @@ public interface ISignable {
     Signature getSignature();
     void setSignature(Signature signature);
     Consumer<Signature> getSignatureConsumer();
-    Supplier<ByteBuffer> getByeArraySupplier();
+    Supplier<ByteBuffer> getByteArraySupplier();
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
@@ -291,7 +291,7 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
 
     @Transient
     @Override
-    public Supplier<ByteBuffer> getByeArraySupplier() {
+    public Supplier<ByteBuffer> getByteArraySupplier() {
         this.update();
         log.debug("Serialized event: {}", new String(this.get_serializedEvent()));
         return () -> ByteBuffer.wrap(this.get_serializedEvent());

--- a/nostr-java-event/src/main/java/nostr/event/tag/DelegationTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/DelegationTag.java
@@ -58,7 +58,7 @@ public class DelegationTag extends BaseTag implements ISignable {
     }
 
     @Override
-    public Supplier<ByteBuffer> getByeArraySupplier() {
+    public Supplier<ByteBuffer> getByteArraySupplier() {
         return () -> ByteBuffer.wrap(this.getToken().getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/nostr-java-id/src/main/java/nostr/id/Identity.java
+++ b/nostr-java-id/src/main/java/nostr/id/Identity.java
@@ -67,7 +67,7 @@ public class Identity {
         final Signature signature = new Signature();
         signature.setRawData(
                 Schnorr.sign(
-                        NostrUtil.sha256(signable.getByeArraySupplier().get().array()),
+                        NostrUtil.sha256(signable.getByteArraySupplier().get().array()),
                         this.getPrivateKey().getRawData(),
                         generateAuxRand()));
         signature.setPubKey(getPublicKey());


### PR DESCRIPTION
## Summary
- Rename `getByeArraySupplier` to `getByteArraySupplier` in `ISignable`.
- Update `GenericEvent`, `DelegationTag`, and `Identity` to use the new method name.

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met for module `nostr-java-encryption`)*

------
https://chatgpt.com/codex/tasks/task_b_6898e4510eb08331bba5ad017e738287