### PR TITLE
Protect event tags from external mutation

### DIFF
--- a/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -127,12 +128,12 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
                         @NonNull String content) {
         this.pubKey = pubKey;
         this.kind = Kind.valueOf(kind).getValue();
-        this.tags = tags;
+        this.tags = new ArrayList<>(tags);
         this.content = content;
         this.attributes = new ArrayList<>();
 
         // Update parents
-        updateTagsParents(tags);
+        updateTagsParents(this.tags);
     }
 
     public void setId(String id) {
@@ -154,12 +155,15 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
     }
 
     public void setTags(List<BaseTag> tags) {
+        this.tags = new ArrayList<>(tags);
 
-        this.tags = tags;
-
-        for (BaseTag tag : tags) {
+        for (BaseTag tag : this.tags) {
             tag.setParent(this);
         }
+    }
+
+    public List<BaseTag> getTags() {
+        return Collections.unmodifiableList(this.tags);
     }
 
     @Transient

--- a/nostr-java-event/src/test/java/nostr/event/impl/ZapRequestEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/ZapRequestEventValidateTest.java
@@ -54,14 +54,18 @@ public class ZapRequestEventValidateTest {
     @Test
     public void testValidateMissingAmountTag() {
         ZapRequestEvent event = createValidEvent();
-        event.getTags().removeIf(t -> "amount".equals(t.getCode()));
+        List<BaseTag> tags = new ArrayList<>(event.getTags());
+        tags.removeIf(t -> "amount".equals(t.getCode()));
+        event.setTags(tags);
         assertThrows(AssertionError.class, event::validate);
     }
 
     @Test
     public void testValidateMissingLnurlTag() {
         ZapRequestEvent event = createValidEvent();
-        event.getTags().removeIf(t -> "lnurl".equals(t.getCode()));
+        List<BaseTag> tags = new ArrayList<>(event.getTags());
+        tags.removeIf(t -> "lnurl".equals(t.getCode()));
+        event.setTags(tags);
         assertThrows(AssertionError.class, event::validate);
     }
 


### PR DESCRIPTION
## Summary
- Defensively copy tag lists in `GenericEvent` constructors and `setTags`
- Expose tags through an unmodifiable view
- Update zap request validation tests to operate on tag copies

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met for nostr-java-encryption)*
- `mvn -q -pl nostr-java-event -am test`


------
https://chatgpt.com/codex/tasks/task_b_6898e475555c833192749c48a74b0281