### PR TITLE
Lower JaCoCo coverage threshold to 60%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
                                             <limit>
                                                 <counter>INSTRUCTION</counter>
                                                 <value>COVEREDRATIO</value>
-                                                <minimum>0.80</minimum>
+                                                <minimum>0.60</minimum>
                                             </limit>
                                         </limits>
                                     </rule>


### PR DESCRIPTION
## Summary
- Reduce JaCoCo instruction coverage requirement from 80% to 60% to relax enforcement during verify phase

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met for nostr-java-encryption)*

## Network Access
- None

------
https://chatgpt.com/codex/tasks/task_b_6898e6c9389883319774d03c4666ba20