### PR TITLE
refactor: improve conversion error handling

### DIFF
--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP01Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP01Test.java
@@ -11,6 +11,7 @@ import nostr.event.tag.EventTag;
 import nostr.event.tag.GenericTag;
 import nostr.event.tag.IdentifierTag;
 import nostr.event.tag.PubKeyTag;
+import nostr.util.NostrException;
 import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 public class NIP01Test {
 
     @Test
-    public void testGenerateSignValidateAndConvertTextNote() {
+    public void testGenerateSignValidateAndConvertTextNote() throws NostrException {
         // Step 1: Prepare
         Identity sender = Identity.generateRandomIdentity();
         NIP01 nip01 = new NIP01(sender);
@@ -47,7 +48,7 @@ public class NIP01Test {
     }
 
     @Test
-    public void testGenerateSignValidateAndConvertTextNoteWithRecipient() {
+    public void testGenerateSignValidateAndConvertTextNoteWithRecipient() throws NostrException {
         // Step 1: Prepare
         Identity sender = Identity.generateRandomIdentity();
         Identity recipient = Identity.generateRandomIdentity();
@@ -73,7 +74,7 @@ public class NIP01Test {
     }
 
     @Test
-    public void testCreateTextNoteEventWithRecipientListParameter() {
+    public void testCreateTextNoteEventWithRecipientListParameter() throws NostrException {
         Identity sender = Identity.generateRandomIdentity();
         Identity recipient = Identity.generateRandomIdentity();
         NIP01 nip01 = new NIP01(sender);
@@ -88,7 +89,7 @@ public class NIP01Test {
     }
 
     @Test
-    public void testGenerateSignValidateAndConvertMetadataEvent() throws MalformedURLException {
+    public void testGenerateSignValidateAndConvertMetadataEvent() throws MalformedURLException, NostrException {
         // Step 1: Prepare
         Identity sender = Identity.generateRandomIdentity();
         NIP01 nip01 = new NIP01(sender);

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP57ImplTest.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP57ImplTest.java
@@ -6,6 +6,7 @@ import nostr.base.PublicKey;
 import nostr.event.BaseTag;
 import nostr.event.impl.GenericEvent;
 import nostr.event.impl.ZapRequestEvent;
+import nostr.util.NostrException;
 import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class NIP57ImplTest {
 
     @Test
-    void testNIP57CreateZapRequestEventFactory() {
+    void testNIP57CreateZapRequestEventFactory() throws NostrException {
         log.info("testNIP57CreateZapRequestEventFactories");
 
         Identity sender = Identity.generateRandomIdentity();

--- a/nostr-java-api/src/test/java/nostr/api/util/CommonTestObjectsFactory.java
+++ b/nostr-java-api/src/test/java/nostr/api/util/CommonTestObjectsFactory.java
@@ -11,6 +11,7 @@ import nostr.event.BaseTag;
 import nostr.event.entities.ClassifiedListing;
 import nostr.event.impl.GenericEvent;
 import nostr.event.impl.TextNoteEvent;
+import nostr.util.NostrException;
 import nostr.event.tag.EventTag;
 import nostr.event.tag.GeohashTag;
 import nostr.event.tag.HashtagTag;
@@ -26,7 +27,7 @@ public class CommonTestObjectsFactory {
     return Identity.generateRandomIdentity();
   }
 
-  public static <T extends GenericEvent> T createTextNoteEvent(Identity identity, List<BaseTag> tags, String content) {
+  public static <T extends GenericEvent> T createTextNoteEvent(Identity identity, List<BaseTag> tags, String content) throws NostrException {
     NIP01 nip01 = new NIP01(identity);
     GenericEvent genericEvent = nip01.createTextNoteEvent(tags, content).getEvent();
     TextNoteEvent textNoteEvent = GenericEvent.convert(genericEvent, TextNoteEvent.class);

--- a/nostr-java-event/src/main/java/nostr/event/BaseTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/BaseTag.java
@@ -33,6 +33,7 @@ import nostr.event.tag.RelaysTag;
 import nostr.event.tag.SubjectTag;
 import nostr.event.tag.UrlTag;
 import nostr.event.tag.VoteTag;
+import nostr.util.NostrException;
 import org.apache.commons.lang3.stream.Streams;
 
 import java.beans.IntrospectionException;
@@ -120,30 +121,33 @@ public abstract class BaseTag implements ITag {
                                 new ElementAttribute("param".concat(String.valueOf(i)), params.get(i)))
                         .toList());
 
-        return switch (code) {
-            case "a" -> convert(genericTag, AddressTag.class);
-            case "d" -> convert(genericTag, IdentifierTag.class);
-            case "e" -> convert(genericTag, EventTag.class);
-            case "g" -> convert(genericTag, GeohashTag.class);
-            case "l" -> convert(genericTag, LabelTag.class);
-            case "L" -> convert(genericTag, LabelNamespaceTag.class);
-            case "p" -> convert(genericTag, PubKeyTag.class);
-            case "r" -> convert(genericTag, ReferenceTag.class);
-            case "t" -> convert(genericTag, HashtagTag.class);
-            case "u" -> convert(genericTag, UrlTag.class);
-            case "v" -> convert(genericTag, VoteTag.class);
-            case "emoji" -> convert(genericTag, EmojiTag.class);
-            case "expiration" -> convert(genericTag, ExpirationTag.class);
-            case "nonce" -> convert(genericTag, NonceTag.class);
-            case "price" -> convert(genericTag, PriceTag.class);
-            case "relays" -> convert(genericTag, RelaysTag.class);
-            case "subject" -> convert(genericTag, SubjectTag.class);
-            default -> genericTag;
-        };
+        try {
+            return switch (code) {
+                case "a" -> convert(genericTag, AddressTag.class);
+                case "d" -> convert(genericTag, IdentifierTag.class);
+                case "e" -> convert(genericTag, EventTag.class);
+                case "g" -> convert(genericTag, GeohashTag.class);
+                case "l" -> convert(genericTag, LabelTag.class);
+                case "L" -> convert(genericTag, LabelNamespaceTag.class);
+                case "p" -> convert(genericTag, PubKeyTag.class);
+                case "r" -> convert(genericTag, ReferenceTag.class);
+                case "t" -> convert(genericTag, HashtagTag.class);
+                case "u" -> convert(genericTag, UrlTag.class);
+                case "v" -> convert(genericTag, VoteTag.class);
+                case "emoji" -> convert(genericTag, EmojiTag.class);
+                case "expiration" -> convert(genericTag, ExpirationTag.class);
+                case "nonce" -> convert(genericTag, NonceTag.class);
+                case "price" -> convert(genericTag, PriceTag.class);
+                case "relays" -> convert(genericTag, RelaysTag.class);
+                case "subject" -> convert(genericTag, SubjectTag.class);
+                default -> genericTag;
+            };
+        } catch (NostrException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    public static <T extends BaseTag> T convert(@NonNull GenericTag genericTag, @NonNull Class<T> clazz) {
-
+    public static <T extends BaseTag> T convert(@NonNull GenericTag genericTag, @NonNull Class<T> clazz) throws NostrException {
         try {
             T tag = clazz.getConstructor().newInstance();
             if (genericTag.getParent() != null) {
@@ -155,7 +159,7 @@ public abstract class BaseTag implements ITag {
 
         } catch (InstantiationException | NoSuchMethodException | InvocationTargetException |
                  IllegalAccessException e) {
-            throw new RuntimeException(e);
+            throw new NostrException("Failed to convert tag", e);
         }
     }
 

--- a/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
@@ -32,6 +32,7 @@ import java.beans.Transient;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
+import java.lang.reflect.InvocationTargetException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -373,7 +374,7 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
     }
 
 
-    public static <T extends GenericEvent> T convert(@NonNull GenericEvent genericEvent, @NonNull Class<T> clazz) {
+    public static <T extends GenericEvent> T convert(@NonNull GenericEvent genericEvent, @NonNull Class<T> clazz) throws NostrException {
         try {
             T event = clazz.getConstructor().newInstance();
             event.setContent(genericEvent.getContent());
@@ -386,8 +387,8 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
             event.setSignature(genericEvent.getSignature());
             event.setCreatedAt(genericEvent.getCreatedAt());
             return event;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new NostrException("Failed to convert GenericEvent", e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- catch specific reflection exceptions in GenericEvent.convert and BaseTag.convert
- wrap conversion failures with NostrException for clearer context
- update tests to accommodate new checked exception

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met)*


------
https://chatgpt.com/codex/tasks/task_b_6898e46443608331b707fb48e3bee296