### PR TITLE
feat: add tag registry

### DIFF
--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -67,4 +67,7 @@ The examples module shows how to create built-in and custom events. Below is an 
     }
 ```
 ## Creating custom events and tags
- TODO
+Custom tag types can be introduced without modifying existing core code by
+registering them with the `TagRegistry`. The registry maps tag codes to factory
+functions responsible for creating concrete `BaseTag` implementations from a
+`GenericTag` representation.

--- a/nostr-java-api/src/main/java/nostr/api/NIP04.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP04.java
@@ -97,7 +97,7 @@ public class NIP04 extends EventNostr {
                 .findFirst()
                 .orElseThrow(() -> new NoSuchElementException("No matching p-tag found."));
 
-        PubKeyTag pubKeyTag = GenericTag.convert(recipient, PubKeyTag.class);
+        PubKeyTag pubKeyTag = PubKeyTag.updateFields(recipient);
         PublicKey rcptPublicKey = pubKeyTag.getPublicKey();
         MessageCipher cipher = new MessageCipher04(senderId.getPrivateKey().getRawData(), rcptPublicKey.getRawData());
         var encryptedContent = cipher.encrypt(directMessageEvent.getContent());

--- a/nostr-java-event/src/main/java/nostr/event/BaseTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/BaseTag.java
@@ -15,31 +15,14 @@ import nostr.base.annotation.Key;
 import nostr.base.annotation.Tag;
 import nostr.event.json.deserializer.TagDeserializer;
 import nostr.event.json.serializer.BaseTagSerializer;
-import nostr.event.tag.AddressTag;
-import nostr.event.tag.EmojiTag;
-import nostr.event.tag.EventTag;
-import nostr.event.tag.ExpirationTag;
 import nostr.event.tag.GenericTag;
-import nostr.event.tag.GeohashTag;
-import nostr.event.tag.HashtagTag;
-import nostr.event.tag.IdentifierTag;
-import nostr.event.tag.LabelNamespaceTag;
-import nostr.event.tag.LabelTag;
-import nostr.event.tag.NonceTag;
-import nostr.event.tag.PriceTag;
-import nostr.event.tag.PubKeyTag;
-import nostr.event.tag.ReferenceTag;
-import nostr.event.tag.RelaysTag;
-import nostr.event.tag.SubjectTag;
-import nostr.event.tag.UrlTag;
-import nostr.event.tag.VoteTag;
+import nostr.event.tag.TagRegistry;
 import org.apache.commons.lang3.stream.Streams;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -120,43 +103,9 @@ public abstract class BaseTag implements ITag {
                                 new ElementAttribute("param".concat(String.valueOf(i)), params.get(i)))
                         .toList());
 
-        return switch (code) {
-            case "a" -> convert(genericTag, AddressTag.class);
-            case "d" -> convert(genericTag, IdentifierTag.class);
-            case "e" -> convert(genericTag, EventTag.class);
-            case "g" -> convert(genericTag, GeohashTag.class);
-            case "l" -> convert(genericTag, LabelTag.class);
-            case "L" -> convert(genericTag, LabelNamespaceTag.class);
-            case "p" -> convert(genericTag, PubKeyTag.class);
-            case "r" -> convert(genericTag, ReferenceTag.class);
-            case "t" -> convert(genericTag, HashtagTag.class);
-            case "u" -> convert(genericTag, UrlTag.class);
-            case "v" -> convert(genericTag, VoteTag.class);
-            case "emoji" -> convert(genericTag, EmojiTag.class);
-            case "expiration" -> convert(genericTag, ExpirationTag.class);
-            case "nonce" -> convert(genericTag, NonceTag.class);
-            case "price" -> convert(genericTag, PriceTag.class);
-            case "relays" -> convert(genericTag, RelaysTag.class);
-            case "subject" -> convert(genericTag, SubjectTag.class);
-            default -> genericTag;
-        };
-    }
-
-    public static <T extends BaseTag> T convert(@NonNull GenericTag genericTag, @NonNull Class<T> clazz) {
-
-        try {
-            T tag = clazz.getConstructor().newInstance();
-            if (genericTag.getParent() != null) {
-                tag.setParent(genericTag.getParent());
-            }
-
-            Method staticUpdateFields = clazz.getMethod("updateFields", GenericTag.class);
-            return (T) staticUpdateFields.invoke(null, genericTag);
-
-        } catch (InstantiationException | NoSuchMethodException | InvocationTargetException |
-                 IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+        return Optional.ofNullable(TagRegistry.get(code))
+                .map(f -> (BaseTag) f.apply(genericTag))
+                .orElse(genericTag);
     }
 
     protected static <T extends BaseTag> void setOptionalField(JsonNode node, BiConsumer<JsonNode, T> con, T tag) {

--- a/nostr-java-event/src/main/java/nostr/event/tag/TagRegistry.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/TagRegistry.java
@@ -1,0 +1,60 @@
+package nostr.event.tag;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import nostr.event.BaseTag;
+
+/**
+ * Registry of tag factory functions keyed by tag code. Allows new tag types
+ * to be registered without modifying {@link BaseTag}.
+ */
+public final class TagRegistry {
+
+    private static final Map<String, Function<GenericTag, ? extends BaseTag>> REGISTRY = new ConcurrentHashMap<>();
+
+    static {
+        register("a", AddressTag::updateFields);
+        register("d", IdentifierTag::updateFields);
+        register("e", EventTag::updateFields);
+        register("g", GeohashTag::updateFields);
+        register("l", LabelTag::updateFields);
+        register("L", LabelNamespaceTag::updateFields);
+        register("p", PubKeyTag::updateFields);
+        register("r", ReferenceTag::updateFields);
+        register("t", HashtagTag::updateFields);
+        register("u", UrlTag::updateFields);
+        register("v", VoteTag::updateFields);
+        register("emoji", EmojiTag::updateFields);
+        register("expiration", ExpirationTag::updateFields);
+        register("nonce", NonceTag::updateFields);
+        register("price", PriceTag::updateFields);
+        register("relays", RelaysTag::updateFields);
+        register("subject", SubjectTag::updateFields);
+    }
+
+    private TagRegistry() {
+    }
+
+    /**
+     * Register a factory function for the supplied tag code.
+     *
+     * @param code    the tag code
+     * @param factory factory that creates a {@link BaseTag} from a {@link GenericTag}
+     */
+    public static void register(String code, Function<GenericTag, ? extends BaseTag> factory) {
+        REGISTRY.put(code, factory);
+    }
+
+    /**
+     * Retrieve the factory function for the given tag code.
+     *
+     * @param code tag code
+     * @return registered factory or {@code null} if none exists
+     */
+    public static Function<GenericTag, ? extends BaseTag> get(String code) {
+        return REGISTRY.get(code);
+    }
+}
+

--- a/nostr-java-event/src/test/java/nostr/event/unit/TagRegistryTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/TagRegistryTest.java
@@ -1,0 +1,37 @@
+package nostr.event.unit;
+
+import nostr.event.BaseTag;
+import nostr.event.tag.GenericTag;
+import nostr.event.tag.TagRegistry;
+import nostr.base.annotation.Key;
+import nostr.base.annotation.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for dynamic tag registration.
+ */
+class TagRegistryTest {
+
+    @Tag(code = "x")
+    static class CustomTag extends BaseTag {
+        @Key
+        private String value;
+
+        static CustomTag updateFields(GenericTag genericTag) {
+            CustomTag tag = new CustomTag();
+            tag.value = genericTag.getAttributes().get(0).getValue().toString();
+            return tag;
+        }
+    }
+
+    @Test
+    void registerCustomTag() {
+        TagRegistry.register("x", CustomTag::updateFields);
+        BaseTag created = BaseTag.create("x", "hello");
+        assertInstanceOf(CustomTag.class, created);
+        assertEquals("hello", ((CustomTag) created).value);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add TagRegistry for registering tag factories
- refactor BaseTag to use registry instead of switch
- remove reflective tag conversion and add test for custom tag registration

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met in nostr-java-encryption)*

------
https://chatgpt.com/codex/tasks/task_b_6898e49fa6108331965ee2756e74bfe4