### PR TITLE
chore: remove deprecated attributes from GenericEvent

### DIFF
--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -67,4 +67,7 @@ The examples module shows how to create built-in and custom events. Below is an 
     }
 ```
 ## Creating custom events and tags
- TODO
+`GenericEvent` provides a flexible way to create custom event kinds. Metadata should be expressed through tags or the `content` field.
+
+> **Note**
+> Prior versions of the library exposed an `attributes` collection on `GenericEvent`. This field and the related helper methods have been removed. Use tags for any additional metadata.

--- a/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
@@ -9,8 +9,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import nostr.base.ElementAttribute;
-import nostr.base.IGenericElement;
 import nostr.base.ISignable;
 import nostr.base.ITag;
 import nostr.base.Kind;
@@ -47,7 +45,7 @@ import static nostr.base.Encoder.ENCODER_MAPPED_AFTERBURNER;
 @Slf4j
 @Data
 @EqualsAndHashCode(callSuper = false)
-public class GenericEvent extends BaseEvent implements ISignable, IGenericElement, Deleteable {
+public class GenericEvent extends BaseEvent implements ISignable, Deleteable {
 
     @Key
     @EqualsAndHashCode.Include
@@ -91,13 +89,7 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
     @EqualsAndHashCode.Exclude
     private Integer nip;
 
-    @JsonIgnore
-    @EqualsAndHashCode.Exclude
-    @Deprecated
-    private final List<ElementAttribute> attributes;
-
     public GenericEvent() {
-        this.attributes = new ArrayList<>();
         this.tags = new ArrayList<>();
     }
 
@@ -129,7 +121,6 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
         this.kind = Kind.valueOf(kind).getValue();
         this.tags = tags;
         this.content = content;
-        this.attributes = new ArrayList<>();
 
         // Update parents
         updateTagsParents(tags);
@@ -212,18 +203,6 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
         return this.signature != null;
     }
 
-    @Deprecated
-    @Override
-    public void addAttribute(ElementAttribute... attribute) {
-        addAttributes(List.of(attribute));
-    }
-
-    @Deprecated
-    @Override
-    public void addAttributes(List<ElementAttribute> attributes) {
-        this.attributes.addAll(attributes);
-    }
-
     public void validate() {
 
         // Validate `id` field
@@ -295,14 +274,6 @@ public class GenericEvent extends BaseEvent implements ISignable, IGenericElemen
         this.update();
         log.debug("Serialized event: {}", new String(this.get_serializedEvent()));
         return () -> ByteBuffer.wrap(this.get_serializedEvent());
-    }
-
-    @Deprecated
-    public ElementAttribute getAttribute(@NonNull String name) {
-        return this.attributes.stream()
-                .filter(a -> a.getName().equalsIgnoreCase(name))
-                .findFirst()
-                .orElse(null);
     }
 
     protected final void updateTagsParents(List<? extends BaseTag> tagList) {


### PR DESCRIPTION
## Summary
- drop deprecated `attributes` field and helper methods from `GenericEvent`
- document that custom metadata should be expressed with tags

## Testing
- `mvn -q verify` *(fails: Coverage checks have not been met for nostr-java-encryption)*
- `mvn -q -pl nostr-java-event -am test`

## Network Access
- No network access was required

------
https://chatgpt.com/codex/tasks/task_b_6898e4ee10dc8331ac30ac89fe320515