### PR TITLE
Validate event fields with null checks

### DIFF
--- a/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/GenericEvent.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.Objects;
 
 import static nostr.base.Encoder.ENCODER_MAPPED_AFTERBURNER;
 
@@ -209,14 +210,16 @@ public class GenericEvent extends BaseEvent implements ISignable, Deleteable {
     }
 
     public void validate() {
-
         // Validate `id` field
+        Objects.requireNonNull(this.id, "Missing required `id` field.");
         HexStringValidator.validateHex(this.id, 64);
 
         // Validate `pubkey` field
+        Objects.requireNonNull(this.pubKey, "Missing required `pubkey` field.");
         HexStringValidator.validateHex(this.pubKey.toString(), 64);
 
         // Validate `sig` field
+        Objects.requireNonNull(this.signature, "Missing required `sig` field.");
         HexStringValidator.validateHex(this.signature.toString(), 128);
 
         // Validate `created_at` field

--- a/nostr-java-event/src/test/java/nostr/event/impl/GenericEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/GenericEventValidateTest.java
@@ -1,0 +1,49 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class GenericEventValidateTest {
+
+    private static final String HEX_64_A = "a".repeat(64);
+    private static final String HEX_64_B = "b".repeat(64);
+    private static final String SIG_HEX = "c".repeat(128);
+
+    @Test
+    public void testValidateMissingId() {
+        GenericEvent event = new GenericEvent(new PublicKey(HEX_64_A), 1);
+        event.setSignature(Signature.fromString(SIG_HEX));
+        event.setCreatedAt(Instant.now().getEpochSecond());
+
+        NullPointerException ex = assertThrows(NullPointerException.class, event::validate);
+        assertEquals("Missing required `id` field.", ex.getMessage());
+    }
+
+    @Test
+    public void testValidateMissingPubKey() {
+        GenericEvent event = new GenericEvent();
+        event.setId(HEX_64_A);
+        event.setSignature(Signature.fromString(SIG_HEX));
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        event.setKind(1);
+
+        NullPointerException ex = assertThrows(NullPointerException.class, event::validate);
+        assertEquals("Missing required `pubkey` field.", ex.getMessage());
+    }
+
+    @Test
+    public void testValidateMissingSignature() {
+        GenericEvent event = new GenericEvent(new PublicKey(HEX_64_A), 1);
+        event.setId(HEX_64_B);
+        event.setCreatedAt(Instant.now().getEpochSecond());
+
+        NullPointerException ex = assertThrows(NullPointerException.class, event::validate);
+        assertEquals("Missing required `sig` field.", ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- enforce non-null checks for `id`, `pubkey`, and `sig` before hex validation
- add unit tests confirming informative exceptions for missing fields

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment for Testcontainers)*

## Network Access
- No network requests were made; test failures were due to missing local Docker environment.

------
https://chatgpt.com/codex/tasks/task_b_68991201d8cc8331b16003a23cabde2b