### PR TITLE
Remove Lombok EqualsAndHashCode from Identity

### DIFF
--- a/nostr-java-id/src/main/java/nostr/id/Identity.java
+++ b/nostr-java-id/src/main/java/nostr/id/Identity.java
@@ -1,7 +1,6 @@
 package nostr.id;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.ToString;
@@ -16,7 +15,6 @@ import nostr.util.NostrUtil;
 /**
  * @author squirrel
  */
-@EqualsAndHashCode
 @Data
 @Slf4j
 public class Identity {


### PR DESCRIPTION
## Summary
- remove Lombok's `@EqualsAndHashCode` annotation and import from `Identity`

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment; tests requiring Docker did not run)*


------
https://chatgpt.com/codex/tasks/task_b_6899138ad4308331b5f2de628419efc2