### PR TITLE
Add identity randomness and signature tests

### DIFF
--- a/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
+++ b/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
@@ -1,10 +1,19 @@
 package nostr.id;
 
 import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.base.ISignable;
+import nostr.crypto.schnorr.Schnorr;
 import nostr.event.impl.GenericEvent;
 import nostr.event.tag.DelegationTag;
+import nostr.util.NostrUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  *
@@ -33,6 +42,58 @@ public class IdentityTest {
         DelegationTag delegationTag = new DelegationTag(publicKey, null);
         identity.sign(delegationTag);
         Assertions.assertNotNull(delegationTag.getSignature());
+    }
+
+    @Test
+    public void testGenerateRandomIdentityProducesUniqueKeys() {
+        Identity id1 = Identity.generateRandomIdentity();
+        Identity id2 = Identity.generateRandomIdentity();
+        Assertions.assertNotEquals(id1.getPrivateKey(), id2.getPrivateKey());
+    }
+
+    @Test
+    public void testGetPublicKeyDerivation() {
+        String privHex = "0000000000000000000000000000000000000000000000000000000000000001";
+        Identity identity = Identity.create(privHex);
+        PublicKey expected = new PublicKey("79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798");
+        Assertions.assertEquals(expected, identity.getPublicKey());
+    }
+
+    @Test
+    public void testSignProducesValidSignature() throws Exception {
+        String privHex = "0000000000000000000000000000000000000000000000000000000000000001";
+        Identity identity = Identity.create(privHex);
+        final byte[] message = "hello".getBytes(StandardCharsets.UTF_8);
+
+        ISignable signable = new ISignable() {
+            private Signature signature;
+
+            @Override
+            public Signature getSignature() {
+                return signature;
+            }
+
+            @Override
+            public void setSignature(Signature signature) {
+                this.signature = signature;
+            }
+
+            @Override
+            public Consumer<Signature> getSignatureConsumer() {
+                return this::setSignature;
+            }
+
+            @Override
+            public Supplier<ByteBuffer> getByteArraySupplier() {
+                return () -> ByteBuffer.wrap(message);
+            }
+        };
+
+        identity.sign(signable);
+
+        byte[] msgHash = NostrUtil.sha256(message);
+        boolean verified = Schnorr.verify(msgHash, identity.getPublicKey().getRawData(), signable.getSignature().getRawData());
+        Assertions.assertTrue(verified);
     }
 
 


### PR DESCRIPTION
## Summary
- verify randomly generated identities produce distinct private keys
- check public key derivation from a known private key
- ensure signing produces Schnorr-valid signatures for a known message

## Testing
- `mvn -q verify -pl nostr-java-id -am && echo "BUILD SUCCESS"`


------
https://chatgpt.com/codex/tasks/task_b_689913ab4dfc8331bbb1b596dfd2b6e3