### PR TITLE
Remove deprecated Identity.getInstance methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The project uses GitHub Actions defined in [ci.yml](https://github.com/tcheeric/
 This workflow runs `mvn -q verify` to build the project and execute all tests on each push and pull request.
 Releases are published using the [release.yml](https://github.com/tcheeric/nostr-java/actions/workflows/release.yml) workflow.
 
+## Migration Notes
+- The `Identity.getInstance` factory methods have been removed. Use `Identity.create` instead.
+
 ## Examples
 Example usages are located in the [`nostr-java-examples`](./nostr-java-examples) module. Additional demonstrations can be found in [nostr-client](https://github.com/tcheeric/nostr-client) and [SuperConductor](https://github.com/avlo/superconductor).
 

--- a/nostr-java-id/src/main/java/nostr/id/Identity.java
+++ b/nostr-java-id/src/main/java/nostr/id/Identity.java
@@ -28,18 +28,8 @@ public class Identity {
         this.privateKey = privateKey;
     }
 
-    @Deprecated(forRemoval = true)
-    public static Identity getInstance(@NonNull PrivateKey privateKey) {
-        return new Identity(privateKey);
-    }
-
     public static Identity create(@NonNull PrivateKey privateKey) {
         return new Identity(privateKey);
-    }
-
-    @Deprecated(forRemoval = true)
-    public static Identity getInstance(@NonNull String privateKey) {
-        return new Identity(new PrivateKey(privateKey));
     }
 
     public static Identity create(@NonNull String privateKey) {


### PR DESCRIPTION
## Summary
- remove deprecated `getInstance` overloads from `Identity`
- document transition to `Identity.create` in README

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*


------
https://chatgpt.com/codex/tasks/task_b_689913b3697883318b8b0428fd6667fb