### PR TITLE
docs: add javadoc for identity methods

### DIFF
--- a/nostr-java-id/src/main/java/nostr/id/Identity.java
+++ b/nostr-java-id/src/main/java/nostr/id/Identity.java
@@ -14,6 +14,12 @@ import nostr.crypto.schnorr.Schnorr;
 import nostr.util.NostrUtil;
 
 /**
+ * Represents a Nostr identity backed by a private key.
+ * <p>
+ * Instances of this class can derive the associated public key and
+ * sign arbitrary {@link ISignable} objects.
+ * </p>
+ *
  * @author squirrel
  */
 @EqualsAndHashCode
@@ -33,6 +39,13 @@ public class Identity {
         return new Identity(privateKey);
     }
 
+    /**
+     * Creates a new identity from an existing {@link PrivateKey}.
+     *
+     * @param privateKey the private key that will back the identity
+     * @return a new identity using the provided key
+     * @throws NullPointerException if {@code privateKey} is {@code null}
+     */
     public static Identity create(@NonNull PrivateKey privateKey) {
         return new Identity(privateKey);
     }
@@ -42,17 +55,34 @@ public class Identity {
         return new Identity(new PrivateKey(privateKey));
     }
 
+    /**
+     * Creates a new identity from a hex-encoded private key.
+     *
+     * @param privateKey the private key represented as a hex string
+     * @return a new identity using the provided key
+     * @throws IllegalArgumentException if the key cannot be parsed
+     * @throws NullPointerException     if {@code privateKey} is {@code null}
+     */
     public static Identity create(@NonNull String privateKey) {
         return new Identity(new PrivateKey(privateKey));
     }
 
     /**
-     * @return A strong pseudo random identity
+     * Generates a strong pseudo-random identity.
+     *
+     * @return a new identity backed by a cryptographically secure random
+     * private key
      */
     public static Identity generateRandomIdentity() {
         return new Identity(PrivateKey.generateRandomPrivKey());
     }
 
+    /**
+     * Derives the {@link PublicKey} associated with this identity's private key.
+     *
+     * @return the derived public key
+     * @throws RuntimeException if public key generation fails
+     */
     public PublicKey getPublicKey() {
         try {
             return new PublicKey(Schnorr.genPubKey(this.getPrivateKey().getRawData()));
@@ -61,7 +91,16 @@ public class Identity {
         }
     }
 
-//    TODO: exceptions refactor
+    //    TODO: exceptions refactor
+    /**
+     * Signs the supplied {@link ISignable} using this identity's private key.
+     * The resulting {@link Signature} is returned and also provided to the
+     * signable's signature consumer.
+     *
+     * @param signable the entity to sign
+     * @return the generated signature
+     * @throws Exception if the signature cannot be created
+     */
     @SneakyThrows
     public Signature sign(@NonNull ISignable signable) {
         final Signature signature = new Signature();


### PR DESCRIPTION
## Summary
- add class and method documentation for Identity

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_b_689913b679008331a0f544ab0af006e0