### PR TITLE
Remove unused logger annotation from Identity

### DIFF
--- a/nostr-java-id/src/main/java/nostr/id/Identity.java
+++ b/nostr-java-id/src/main/java/nostr/id/Identity.java
@@ -5,7 +5,6 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 import nostr.base.ISignable;
 import nostr.base.PrivateKey;
 import nostr.base.PublicKey;
@@ -18,7 +17,6 @@ import nostr.util.NostrUtil;
  */
 @EqualsAndHashCode
 @Data
-@Slf4j
 public class Identity {
 
     @ToString.Exclude


### PR DESCRIPTION
## Summary
- remove unused `@Slf4j` annotation and import from `Identity`

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*
- `mvn -pl nostr-java-id -am verify`

## Network Access
- No network requests were made

------
https://chatgpt.com/codex/tasks/task_b_689913ccfc3c83319765c97ea66a5231