### PR TITLE
Cache Identity public key and improve error handling

### DIFF
--- a/nostr-java-id/src/main/java/nostr/id/Identity.java
+++ b/nostr-java-id/src/main/java/nostr/id/Identity.java
@@ -1,8 +1,11 @@
 package nostr.id;
 
+import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +26,12 @@ public class Identity {
 
     @ToString.Exclude
     private final PrivateKey privateKey;
+
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private transient PublicKey cachedPublicKey;
 
     private Identity(@NonNull PrivateKey privateKey) {
         this.privateKey = privateKey;
@@ -54,11 +63,14 @@ public class Identity {
     }
 
     public PublicKey getPublicKey() {
-        try {
-            return new PublicKey(Schnorr.genPubKey(this.getPrivateKey().getRawData()));
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
+        if (cachedPublicKey == null) {
+            try {
+                cachedPublicKey = new PublicKey(Schnorr.genPubKey(this.getPrivateKey().getRawData()));
+            } catch (Exception ex) {
+                throw new IllegalArgumentException("Invalid private key", ex);
+            }
         }
+        return cachedPublicKey;
     }
 
 //    TODO: exceptions refactor

--- a/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
+++ b/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
@@ -1,5 +1,6 @@
 package nostr.id;
 
+import nostr.base.PrivateKey;
 import nostr.base.PublicKey;
 import nostr.event.impl.GenericEvent;
 import nostr.event.tag.DelegationTag;
@@ -33,6 +34,20 @@ public class IdentityTest {
         DelegationTag delegationTag = new DelegationTag(publicKey, null);
         identity.sign(delegationTag);
         Assertions.assertNotNull(delegationTag.getSignature());
+    }
+
+    @Test
+    public void testPublicKeyCaching() {
+        Identity identity = Identity.generateRandomIdentity();
+        PublicKey first = identity.getPublicKey();
+        PublicKey second = identity.getPublicKey();
+        Assertions.assertSame(first, second, "Public key should be cached");
+    }
+
+    @Test
+    public void testGetPublicKeyInvalidPrivateKey() {
+        Identity identity = Identity.create(new PrivateKey(new byte[32]));
+        Assertions.assertThrows(IllegalArgumentException.class, identity::getPublicKey);
     }
 
 


### PR DESCRIPTION
## Summary
- Lazily compute and cache `Identity` public keys without exposing the cache field
- Throw `IllegalArgumentException` for invalid private keys when deriving public keys
- Add unit test covering cached public key reuse and invalid key error handling

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed. Will not retry. Please see logs and check configuration)*
- `mvn -pl nostr-java-id -am test`


------
https://chatgpt.com/codex/tasks/task_b_6899139714c88331b4388947a6c0ca61