### PR TITLE
Add lifecycle logging to WebSocket client

### DIFF
--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
@@ -57,7 +57,11 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
   @Override
   protected void handleTextMessage(@NonNull WebSocketSession session, TextMessage message) {
     log.info("Received message: {}", message.getPayload());
-    events.add(message.getPayload());
+    String payload = message.getPayload();
+    String truncated = payload.length() > 100 ? payload.substring(0, 100) + "..." : payload;
+    String hash = hashPayload(payload);
+    log.info("Received message: [truncated] \"{}\" [SHA-256: {}]", truncated, hash);
+    events.add(payload);
     completed.setRelease(true);
   }
 

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
@@ -60,7 +60,11 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
     String payload = message.getPayload();
     String truncated = payload.length() > 100 ? payload.substring(0, 100) + "..." : payload;
     String hash = hashPayload(payload);
-    log.info("Received message: [truncated] \"{}\" [SHA-256: {}]", truncated, hash);
+    if (log.isInfoEnabled()) {
+      String truncated = payload.length() > 100 ? payload.substring(0, 100) + "..." : payload;
+      String hash = hashPayload(payload);
+      log.info("Received message: [truncated] \"{}\" [SHA-256: {}]", truncated, hash);
+    }
     events.add(payload);
     completed.setRelease(true);
   }

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
@@ -73,7 +73,7 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
   @Override
   public List<String> send(String json) throws IOException {
     try {
-      log.info("Sending message: {}", json);
+      log.info("Sending message: [hash={}, length={}]", sha256Hex(json), json.length());
       clientSession.sendMessage(new TextMessage(json));
     } catch (IOException e) {
       log.error("Error sending message", e);


### PR DESCRIPTION
## Summary
- log connection, message send/receive, and close events in `StandardWebSocketClient`
- capture send/close exceptions at error level and document logging behavior in class Javadoc

## Testing
- `mvn -q verify` *(fails: java.lang.IllegalStateException: Previous attempts to find a Docker environment failed)*

------
https://chatgpt.com/codex/tasks/task_b_68991b7652e08331bb3febf6ece63749