### PR TITLE
Use Spring Boot BOM for client dependencies

### DIFF
--- a/nostr-java-client/pom.xml
+++ b/nostr-java-client/pom.xml
@@ -13,7 +13,6 @@
     
     <properties>
         <awaitility.version>4.2.2</awaitility.version>
-        <spring-websocket.version>6.1.10</spring-websocket.version>
     </properties>
     
     <dependencies>
@@ -31,7 +30,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-websocket</artifactId>
-            <version>${spring-websocket.version}</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
@@ -58,12 +56,10 @@
         <dependency>
             <groupId>org.springframework.retry</groupId>
             <artifactId>spring-retry</artifactId>
-            <version>${spring-retry.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aspects</artifactId>
-            <version>6.2.7</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- Remove explicit Spring Framework versions from client module, letting Spring Boot 3.4.3 manage dependency versions.

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment. Please see logs and check configuration)*

## Network Access
- No external network requests were made; tests failed locally due to missing Docker environment.

------
https://chatgpt.com/codex/tasks/task_b_68991ba5b3b083319b9741963e7dee02