### PR TITLE
Handle null consumer in Identity signing

### DIFF
--- a/nostr-java-id/src/main/java/nostr/id/Identity.java
+++ b/nostr-java-id/src/main/java/nostr/id/Identity.java
@@ -4,9 +4,9 @@ import lombok.Data;
 import lombok.NonNull;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.function.Consumer;
 import nostr.base.ISignable;
 import nostr.base.PrivateKey;
 import nostr.base.PublicKey;
@@ -101,7 +101,10 @@ public class Identity {
                             this.getPrivateKey().getRawData(),
                             generateAuxRand()));
             signature.setPubKey(getPublicKey());
-            signable.getSignatureConsumer().accept(signature);
+            Consumer<Signature> consumer = signable.getSignatureConsumer();
+            if (consumer != null) {
+                consumer.accept(signature);
+            }
             return signature;
         } catch (NoSuchAlgorithmException ex) {
             log.error("SHA-256 algorithm not available for signing", ex);

--- a/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
+++ b/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
@@ -96,5 +96,31 @@ public class IdentityTest {
         Assertions.assertTrue(verified);
     }
 
+    @Test
+    public void testSignWithNullConsumer() {
+        Identity identity = Identity.generateRandomIdentity();
+        ISignable signable = new ISignable() {
+            @Override
+            public Signature getSignature() {
+                return null;
+            }
 
+            @Override
+            public void setSignature(Signature signature) {
+            }
+
+            @Override
+            public Consumer<Signature> getSignatureConsumer() {
+                return null;
+            }
+
+            @Override
+            public Supplier<ByteBuffer> getByteArraySupplier() {
+                return () -> ByteBuffer.wrap("payload".getBytes(StandardCharsets.UTF_8));
+            }
+        };
+        Signature signature = Assertions.assertDoesNotThrow(() -> identity.sign(signable));
+        Assertions.assertNotNull(signature);
+        Assertions.assertNull(signable.getSignature());
+    }
 }


### PR DESCRIPTION
## Summary
- Avoid NullPointerException when signable has no signature consumer
- Test signing with a null signature consumer

## Testing
- `PATH=/bin:/usr/bin:$PATH ./mvnw -q verify` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68991defe10c8331839b85e4e887c18d