### PR TITLE
Replace SneakyThrows with explicit throws

### DIFF
--- a/nostr-java-api/src/main/java/nostr/api/WebSocketClientHandler.java
+++ b/nostr-java-api/src/main/java/nostr/api/WebSocketClientHandler.java
@@ -11,11 +11,10 @@ import nostr.event.message.EventMessage;
 import nostr.event.message.ReqMessage;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 
 public class WebSocketClientHandler {
     private final SpringWebSocketClient eventClient;
@@ -26,7 +25,8 @@ public class WebSocketClientHandler {
     @Getter
     private String relayUri;
 
-    protected WebSocketClientHandler(@NonNull String relayName, @NonNull String relayUri) {
+    protected WebSocketClientHandler(@NonNull String relayName, @NonNull String relayUri)
+        throws ExecutionException, InterruptedException {
         this.relayName = relayName;
         this.relayUri = relayUri;
         this.eventClient = new SpringWebSocketClient(new StandardWebSocketClient(relayUri), relayUri);
@@ -34,21 +34,30 @@ public class WebSocketClientHandler {
 
     public List<String> sendEvent(@NonNull IEvent event) {
         ((GenericEvent) event).validate();
-        return eventClient.send(new EventMessage(event)).stream().toList();
+        try {
+            return eventClient.send(new EventMessage(event)).stream().toList();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to send event", e);
+        }
     }
 
     protected List<String> sendRequest(@NonNull Filters filters, @NonNull String subscriptionId) {
-        return Optional
-                .ofNullable(
-                        requestClientMap.get(subscriptionId))
-                .map(client ->
-                        client.send(new ReqMessage(subscriptionId, filters))).or(() -> {
-                      requestClientMap.put(subscriptionId, new SpringWebSocketClient(new StandardWebSocketClient(relayUri), relayUri));
-                    return Optional.ofNullable(
-                            requestClientMap.get(subscriptionId).send(
-                                    new ReqMessage(subscriptionId, filters)));
-                })
-                .orElse(new ArrayList<>());
+        try {
+            SpringWebSocketClient client = requestClientMap.get(subscriptionId);
+            if (client == null) {
+                try {
+                    requestClientMap.put(
+                        subscriptionId,
+                        new SpringWebSocketClient(new StandardWebSocketClient(relayUri), relayUri));
+                    client = requestClientMap.get(subscriptionId);
+                } catch (ExecutionException | InterruptedException e) {
+                    throw new RuntimeException("Failed to initialize request client", e);
+                }
+            }
+            return client.send(new ReqMessage(subscriptionId, filters));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to send request", e);
+        }
     }
 
     public void close() throws IOException {

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiEventTestUsingSpringWebSocketClientIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiEventTestUsingSpringWebSocketClientIT.java
@@ -31,7 +31,13 @@ class ApiEventTestUsingSpringWebSocketClientIT extends BaseRelayIntegrationTest 
     @Autowired
     public ApiEventTestUsingSpringWebSocketClientIT(Map<String, String> relays) {
         this.springWebSocketClients = relays.values().stream()
-            .map(uri -> new SpringWebSocketClient(new StandardWebSocketClient(uri), uri))
+            .map(uri -> {
+                try {
+                    return new SpringWebSocketClient(new StandardWebSocketClient(uri), uri);
+                } catch (java.util.concurrent.ExecutionException | InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            })
             .toList();
     }
 

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
@@ -29,7 +29,7 @@ class ApiNIP52EventIT extends BaseRelayIntegrationTest {
   private SpringWebSocketClient springWebSocketClient;
 
   @BeforeEach
-    void setup() {
+    void setup() throws Exception {
       springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
     }
 

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52RequestIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52RequestIT.java
@@ -18,7 +18,6 @@ import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +74,7 @@ class ApiNIP52RequestIT extends BaseRelayIntegrationTest {
   public String signature;
 
   @Test
-  void testNIP99CalendarContentPreRequest() throws IOException {
+  void testNIP99CalendarContentPreRequest() throws Exception {
     System.out.println("testNIP52CalendarContentEvent");
 
     List<BaseTag> tags = new ArrayList<>();

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
@@ -56,7 +56,7 @@ class ApiNIP99EventIT extends BaseRelayIntegrationTest {
   private SpringWebSocketClient springWebSocketClient;
 
   @BeforeEach
-    void setup() {
+    void setup() throws Exception {
       springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
     }
 

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99RequestIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99RequestIT.java
@@ -19,7 +19,6 @@ import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,7 +65,7 @@ class ApiNIP99RequestIT extends BaseRelayIntegrationTest {
   public String signature;
 
   @Test
-  void testNIP99ClassifiedListingPreRequest() throws IOException {
+  void testNIP99ClassifiedListingPreRequest() throws Exception {
     System.out.println("testNIP99ClassifiedListingEvent");
 
     List<BaseTag> tags = new ArrayList<>();

--- a/nostr-java-api/src/test/java/nostr/api/integration/ZDoLastApiNIP09EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ZDoLastApiNIP09EventIT.java
@@ -44,7 +44,7 @@ public class ZDoLastApiNIP09EventIT extends BaseRelayIntegrationTest {
     private SpringWebSocketClient springWebSocketClient;
 
     @BeforeEach
-    void setup() {
+    void setup() throws Exception {
         springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
     }
 

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
@@ -2,7 +2,6 @@ package nostr.client.springwebsocket;
 
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import nostr.event.BaseMessage;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,8 +26,14 @@ public class SpringWebSocketClient {
   }
 
   @NostrRetryable
-  @SneakyThrows
-  public List<String> send(@NonNull BaseMessage eventMessage) {
+  /**
+   * Sends the provided {@link BaseMessage} over the WebSocket connection.
+   *
+   * @param eventMessage the message to send
+   * @return the list of responses from the relay
+   * @throws IOException if an I/O error occurs while sending the message
+   */
+  public List<String> send(@NonNull BaseMessage eventMessage) throws IOException {
     return webSocketClientIF.send(eventMessage.encode());
   }
 

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
@@ -1,7 +1,6 @@
 package nostr.client.springwebsocket;
 
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import nostr.event.BaseMessage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -37,9 +36,21 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
   private List<String> events = new ArrayList<>();
   private final AtomicBoolean completed = new AtomicBoolean(false);
 
-  @SneakyThrows
-  public StandardWebSocketClient(@Value("${nostr.relay.uri}") String relayUri) {
-    this.clientSession = new org.springframework.web.socket.client.standard.StandardWebSocketClient().execute(this, new WebSocketHttpHeaders(), URI.create(relayUri)).get();
+  /**
+   * Creates a new {@code StandardWebSocketClient} connected to the provided relay URI.
+   *
+   * @param relayUri the URI of the relay to connect to
+   * @throws java.util.concurrent.ExecutionException   if the WebSocket session fails to
+   *     establish
+   * @throws InterruptedException if the current thread is interrupted while waiting
+   *     for the WebSocket handshake to complete
+   */
+  public StandardWebSocketClient(@Value("${nostr.relay.uri}") String relayUri)
+      throws java.util.concurrent.ExecutionException, InterruptedException {
+    this.clientSession =
+        new org.springframework.web.socket.client.standard.StandardWebSocketClient()
+            .execute(this, new WebSocketHttpHeaders(), URI.create(relayUri))
+            .get();
   }
 
   @Override


### PR DESCRIPTION
## Summary
- replace Lombok `@SneakyThrows` in the WebSocket client constructor and send method with explicit checked exceptions
- adjust handler and client logic to propagate or wrap new exceptions
- update integration tests to account for constructor exceptions

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

## Network Access
- no external network access needed; Docker environment unavailable

------
https://chatgpt.com/codex/tasks/task_b_68991b8f246c833183979960cb4f37e0