### PR TITLE
Cache derived public key and refine Identity exceptions

### DIFF
--- a/nostr-java-id/src/main/java/nostr/id/Identity.java
+++ b/nostr-java-id/src/main/java/nostr/id/Identity.java
@@ -4,8 +4,6 @@ import lombok.Data;
 import lombok.NonNull;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import java.nio.ByteBuffer;
-import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import nostr.base.ISignable;
 import nostr.base.PrivateKey;
@@ -29,6 +27,9 @@ public class Identity {
 
     @ToString.Exclude
     private final PrivateKey privateKey;
+
+    @ToString.Exclude
+    private PublicKey cachedPublicKey;
 
     private Identity(@NonNull PrivateKey privateKey) {
         this.privateKey = privateKey;
@@ -71,15 +72,18 @@ public class Identity {
      * Derives the {@link PublicKey} associated with this identity's private key.
      *
      * @return the derived public key
-     * @throws RuntimeException if public key generation fails
+     * @throws IllegalStateException if public key generation fails
      */
     public PublicKey getPublicKey() {
-        try {
-            return new PublicKey(Schnorr.genPubKey(this.getPrivateKey().getRawData()));
-        } catch (Exception ex) {
-            log.error("Failed to derive public key", ex);
-            throw new RuntimeException(ex);
+        if (cachedPublicKey == null) {
+            try {
+                cachedPublicKey = new PublicKey(Schnorr.genPubKey(this.getPrivateKey().getRawData()));
+            } catch (Exception ex) {
+                log.error("Failed to derive public key", ex);
+                throw new IllegalStateException("Failed to derive public key", ex);
+            }
         }
+        return cachedPublicKey;
     }
 
     //    TODO: exceptions refactor
@@ -105,12 +109,10 @@ public class Identity {
             return signature;
         } catch (NoSuchAlgorithmException ex) {
             log.error("SHA-256 algorithm not available for signing", ex);
-            throw new RuntimeException("SHA-256 algorithm not available", ex);
+            throw new IllegalStateException("SHA-256 algorithm not available", ex);
         } catch (Exception ex) {
-            InvalidKeyException ike = new InvalidKeyException("Failed to sign with provided key");
-            ike.initCause(ex);
-            log.error("Signing failed", ike);
-            throw new RuntimeException("Signing failed", ike);
+            log.error("Signing failed", ex);
+            throw new IllegalArgumentException("Failed to sign with provided key", ex);
         }
     }
 

--- a/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
+++ b/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
@@ -96,5 +96,52 @@ public class IdentityTest {
         Assertions.assertTrue(verified);
     }
 
+    @Test
+    public void testPublicKeyCaching() {
+        Identity identity = Identity.generateRandomIdentity();
+        PublicKey first = identity.getPublicKey();
+        PublicKey second = identity.getPublicKey();
+        Assertions.assertSame(first, second);
+    }
+
+    @Test
+    public void testGetPublicKeyFailure() {
+        String invalidPriv = "0000000000000000000000000000000000000000000000000000000000000000";
+        Identity identity = Identity.create(invalidPriv);
+        Assertions.assertThrows(IllegalStateException.class, identity::getPublicKey);
+    }
+
+    @Test
+    public void testSignWithInvalidKeyFails() {
+        String invalidPriv = "0000000000000000000000000000000000000000000000000000000000000000";
+        Identity identity = Identity.create(invalidPriv);
+
+        ISignable signable = new ISignable() {
+            private Signature signature;
+
+            @Override
+            public Signature getSignature() {
+                return signature;
+            }
+
+            @Override
+            public void setSignature(Signature signature) {
+                this.signature = signature;
+            }
+
+            @Override
+            public Consumer<Signature> getSignatureConsumer() {
+                return this::setSignature;
+            }
+
+            @Override
+            public Supplier<ByteBuffer> getByteArraySupplier() {
+                return () -> ByteBuffer.wrap("msg".getBytes(StandardCharsets.UTF_8));
+            }
+        };
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> identity.sign(signable));
+    }
+
 
 }


### PR DESCRIPTION
## Summary
- cache the derived public key in `Identity` and compute it lazily
- replace generic runtime exceptions in `Identity` with `IllegalStateException`/`IllegalArgumentException`
- add unit tests for public key caching and failure scenarios

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

## Network Access
- No network access issues encountered

------
https://chatgpt.com/codex/tasks/task_b_68991e3003dc833194788df45d96ab50