### PR TITLE
Improve thread safety of Spring WebSocket client

### DIFF
--- a/nostr-java-client/pom.xml
+++ b/nostr-java-client/pom.xml
@@ -56,6 +56,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.retry</groupId>
             <artifactId>spring-retry</artifactId>
             <version>${spring-retry.version}</version>

--- a/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientConcurrencyTest.java
+++ b/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientConcurrencyTest.java
@@ -1,0 +1,50 @@
+package nostr.client.springwebsocket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+public class StandardWebSocketClientConcurrencyTest {
+
+    @Test
+    void concurrentSendsReceiveDistinctResponses() throws Exception {
+        WebSocketSession session = Mockito.mock(WebSocketSession.class);
+        StandardWebSocketClient client = new StandardWebSocketClient(session);
+        int threads = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        List<Future<List<String>>> futures = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            futures.add(executor.submit(() -> client.send("msg")));
+        }
+        Field field = StandardWebSocketClient.class.getDeclaredField("contexts");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        java.util.concurrent.ConcurrentLinkedQueue<?> contexts =
+                (java.util.concurrent.ConcurrentLinkedQueue<?>) field.get(client);
+        while (contexts.size() < threads) {
+            TimeUnit.MILLISECONDS.sleep(10);
+        }
+        for (int i = 0; i < threads; i++) {
+            client.handleTextMessage(session, new TextMessage("resp" + i));
+        }
+        Set<String> results = new HashSet<>();
+        for (Future<List<String>> future : futures) {
+            results.addAll(future.get(1, TimeUnit.SECONDS));
+        }
+        assertEquals(threads, results.size());
+        executor.shutdownNow();
+    }
+}


### PR DESCRIPTION
## Summary
- Refactor StandardWebSocketClient to use per-send queues and CountDownLatch synchronization
- Add Mockito-based concurrency test for concurrent send/receive handling
- Include Mockito as a test dependency

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment for integration tests)*


------
https://chatgpt.com/codex/tasks/task_b_68991b7e465483319e3b660fc00fe8a1