### PR TITLE
Add logging for WebSocket client send and close operations

### DIFF
--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
@@ -29,12 +29,19 @@ public class SpringWebSocketClient {
   @NostrRetryable
   @SneakyThrows
   public List<String> send(@NonNull BaseMessage eventMessage) {
-    return webSocketClientIF.send(eventMessage.encode());
+    String payload = eventMessage.encode();
+    log.debug("Sending BaseMessage [{}] to relay {} (size: {} chars)", eventMessage.getCommand(), relayUrl, payload.length());
+    List<String> responses = webSocketClientIF.send(payload);
+    log.debug("Sent BaseMessage [{}] to relay {} (size: {} chars)", eventMessage.getCommand(), relayUrl, payload.length());
+    return responses;
   }
 
   @NostrRetryable
   public List<String> send(@NonNull String json) throws IOException {
-    return webSocketClientIF.send(json);
+    log.debug("Sending raw message to relay {} (size: {} chars)", relayUrl, json.length());
+    List<String> responses = webSocketClientIF.send(json);
+    log.debug("Sent raw message to relay {} (size: {} chars)", relayUrl, json.length());
+    return responses;
   }
 
   /**
@@ -70,7 +77,9 @@ public class SpringWebSocketClient {
   }
 
   public void closeSocket() throws IOException {
+    log.info("Closing WebSocket client for relay {}", relayUrl);
     webSocketClientIF.closeSocket();
+    log.info("WebSocket client closed for relay {}", relayUrl);
   }
 }
 


### PR DESCRIPTION
## Summary
- log relay URL and message size at start and end of send methods
- log when WebSocket client closes

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_b_68991b965bb4833181dd38ae5b57caa1