### PR TITLE
Refine WebSocket client synchronization for concurrent operations

### DIFF
--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -39,7 +39,7 @@ The project can be built with Maven or Gradle. Unit tests do not require a runni
 Integration tests start a `nostr-rs-relay` container automatically. The image used can be overridden in `src/test/resources/relay-container.properties` by setting `relay.container.image=<image>`.
 
 ## WebSocket configuration
-`StandardWebSocketClient` waits for relay responses when sending messages. The timeout and polling interval are configured with the following properties (values in milliseconds):
+`StandardWebSocketClient` waits for relay responses when sending messages. It now uses a per-send `BlockingQueue` and `CountDownLatch` to coordinate responses, allowing multiple send operations to run concurrently. The timeout and polling interval are configured with the following properties (values in milliseconds):
 ```
 nostr.websocket.await-timeout-ms=60000
 nostr.websocket.poll-interval-ms=500

--- a/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientConcurrencyTest.java
+++ b/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientConcurrencyTest.java
@@ -1,0 +1,102 @@
+package nostr.client.springwebsocket;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.socket.*;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StandardWebSocketClientConcurrencyTest {
+
+    static class StubWebSocketSession implements WebSocketSession {
+        private boolean open = true;
+
+        @Override
+        public String getId() { return "1"; }
+
+        @Override
+        public URI getUri() { return null; }
+
+        @Override
+        public HttpHeaders getHandshakeHeaders() { return new HttpHeaders(); }
+
+        @Override
+        public Map<String, Object> getAttributes() { return Collections.emptyMap(); }
+
+        @Override
+        public Principal getPrincipal() { return null; }
+
+        @Override
+        public InetSocketAddress getLocalAddress() { return null; }
+
+        @Override
+        public InetSocketAddress getRemoteAddress() { return null; }
+
+        @Override
+        public String getAcceptedProtocol() { return null; }
+
+        @Override
+        public void setTextMessageSizeLimit(int messageSizeLimit) { }
+
+        @Override
+        public int getTextMessageSizeLimit() { return 0; }
+
+        @Override
+        public void setBinaryMessageSizeLimit(int messageSizeLimit) { }
+
+        @Override
+        public int getBinaryMessageSizeLimit() { return 0; }
+
+        @Override
+        public List<WebSocketExtension> getExtensions() { return List.of(); }
+
+        @Override
+        public void sendMessage(WebSocketMessage<?> message) { }
+
+        @Override
+        public boolean isOpen() { return open; }
+
+        @Override
+        public void close() { open = false; }
+
+        @Override
+        public void close(CloseStatus status) { open = false; }
+    }
+
+    @Test
+    void concurrentSendsReceiveResponses() throws Exception {
+        StubWebSocketSession session = new StubWebSocketSession();
+        StandardWebSocketClient client = new StandardWebSocketClient(session, 1000, 10);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        Future<List<String>> f1 = executor.submit(() -> {
+            start.await();
+            return client.send("msg1");
+        });
+        Future<List<String>> f2 = executor.submit(() -> {
+            start.await();
+            return client.send("msg2");
+        });
+
+        start.countDown();
+        Thread.sleep(100);
+
+        client.handleTextMessage(session, new TextMessage("resp1"));
+        client.handleTextMessage(session, new TextMessage("resp2"));
+
+        assertEquals(List.of("resp1"), f1.get(2, TimeUnit.SECONDS));
+        assertEquals(List.of("resp2"), f2.get(2, TimeUnit.SECONDS));
+
+        executor.shutdownNow();
+    }
+}


### PR DESCRIPTION
## Summary
- synchronize StandardWebSocketClient with per-send BlockingQueue and CountDownLatch
- reset collections via clear and expose testing constructor
- verify concurrent sends and receives with a new unit test

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*


------
https://chatgpt.com/codex/tasks/task_b_689923b143c48331a4a88fcb949e450d