### PR TITLE
feat: support AutoCloseable for websocket clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Example usages are located in the [`nostr-java-examples`](./nostr-java-examples)
 ## Retry Support
 `SpringWebSocketClient` leverages Spring Retry so that failed WebSocket send operations are attempted up to three times with exponential backoff.
 
+Both `StandardWebSocketClient` and `SpringWebSocketClient` implement `AutoCloseable`, so they can be used with Java's try-with-resources for automatic cleanup.
+
 ## Supported NIPs
 The API currently implements the following [NIPs](https://github.com/nostr-protocol/nips):
 - [NIP-1](https://github.com/nostr-protocol/nips/blob/master/01.md)

--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -48,6 +48,8 @@ nostr.websocket.poll-interval-ms=500
 ## Retry behavior
 `SpringWebSocketClient` leverages Spring Retry so that failed send operations are retried up to three times with an exponential backoff starting at 500 ms.
 
+Both `StandardWebSocketClient` and `SpringWebSocketClient` implement `AutoCloseable`, allowing try-with-resources for automatic session cleanup.
+
 ## Creating and sending events
 The examples module shows how to create built-in and custom events. Below is an excerpt from the examples illustrating the creation of a `TextNoteEvent`:
 ```java

--- a/nostr-java-api/src/main/java/nostr/api/WebSocketClientHandler.java
+++ b/nostr-java-api/src/main/java/nostr/api/WebSocketClientHandler.java
@@ -52,9 +52,9 @@ public class WebSocketClientHandler {
     }
 
     public void close() throws IOException {
-        eventClient.closeSocket();
+        eventClient.close();
         for (SpringWebSocketClient client : requestClientMap.values()) {
-            client.closeSocket();
+            client.close();
         }
     }
 }

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
@@ -13,7 +13,6 @@ import nostr.event.message.EventMessage;
 import nostr.event.tag.IdentifierTag;
 import nostr.event.tag.PubKeyTag;
 import nostr.id.Identity;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -26,12 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("test")
 class ApiNIP52EventIT extends BaseRelayIntegrationTest {
-  private SpringWebSocketClient springWebSocketClient;
-
-  @BeforeEach
-    void setup() {
-      springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
-    }
+  
 
   @Test
   void testNIP52CalendarTimeBasedEventEventUsingSpringWebSocketClient() throws IOException {
@@ -51,6 +45,7 @@ class ApiNIP52EventIT extends BaseRelayIntegrationTest {
     EventMessage message = new EventMessage(event);
 
     var expectedJson = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId()));
+    try (SpringWebSocketClient springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri())) {
     var actualJson = MAPPER_AFTERBURNER.readTree(springWebSocketClient.send(message).stream().findFirst().orElseThrow());
 
     // Compare only first 3 elements of the JSON arrays
@@ -65,7 +60,7 @@ class ApiNIP52EventIT extends BaseRelayIntegrationTest {
                 .add(actualJson.get(1))
                 .add(actualJson.get(2))));
 
-    springWebSocketClient.closeSocket();
+    }
   }
 
   private String expectedResponseJson(String sha256) {

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52RequestIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52RequestIT.java
@@ -109,7 +109,7 @@ class ApiNIP52RequestIT extends BaseRelayIntegrationTest {
     eventPubKey = event.getPubKey().toString();
     EventMessage eventMessage = new EventMessage(event);
 
-      SpringWebSocketClient springWebSocketEventClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
+    try (SpringWebSocketClient springWebSocketEventClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri())) {
     String eventResponse = springWebSocketEventClient.send(eventMessage).stream().findFirst().orElseThrow();
 
     // Extract and compare only first 3 elements of the JSON array
@@ -125,12 +125,12 @@ class ApiNIP52RequestIT extends BaseRelayIntegrationTest {
       assertEquals(expectedSubscriptionId, actualSubscriptionId, "Subscription ID should match");
     //assertTrue(expectedSuccess == actualSuccess, "Success flag should match"); -- This test is not required. The relay will always return false because we resending the same event, causing duplicates.
 
-    springWebSocketEventClient.closeSocket();
+    }
 
 
     // TODO - This assertion fails with superdonductor and nostr-rs-relay
 
-      SpringWebSocketClient springWebSocketRequestClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
+      try (SpringWebSocketClient springWebSocketRequestClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri())) {
     String subscriberId = UUID.randomUUID().toString();
     String reqJson = createReqJson(subscriberId, eventId);
     String reqResponse = springWebSocketRequestClient.send(reqJson).stream().findFirst().orElseThrow();
@@ -144,7 +144,7 @@ class ApiNIP52RequestIT extends BaseRelayIntegrationTest {
             MAPPER_AFTERBURNER.readTree(reqResponse)));
 */
 
-    springWebSocketRequestClient.closeSocket();
+    }
   }
 
   private String expectedEventResponseJson(String subscriptionId) {

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
@@ -3,12 +3,12 @@ package nostr.api.integration;
 import nostr.api.NIP99;
 import nostr.base.PrivateKey;
 import nostr.base.PublicKey;
-import nostr.client.springwebsocket.SpringWebSocketClient;
-import nostr.client.springwebsocket.StandardWebSocketClient;
 import nostr.event.BaseTag;
 import nostr.event.entities.ClassifiedListing;
 import nostr.event.impl.GenericEvent;
 import nostr.event.message.EventMessage;
+import nostr.client.springwebsocket.SpringWebSocketClient;
+import nostr.client.springwebsocket.StandardWebSocketClient;
 import nostr.event.tag.EventTag;
 import nostr.event.tag.GeohashTag;
 import nostr.event.tag.HashtagTag;
@@ -16,7 +16,6 @@ import nostr.event.tag.PriceTag;
 import nostr.event.tag.PubKeyTag;
 import nostr.event.tag.SubjectTag;
 import nostr.id.Identity;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -53,12 +52,7 @@ class ApiNIP99EventIT extends BaseRelayIntegrationTest {
   public static final String SUMMARY_CODE = "summary";
   public static final String PUBLISHED_AT_CODE = "published_at";
   public static final String LOCATION_CODE = "location";
-  private SpringWebSocketClient springWebSocketClient;
-
-  @BeforeEach
-    void setup() {
-      springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
-    }
+  
 
   @Test
   void testNIP99ClassifiedListingEvent() throws IOException {
@@ -92,6 +86,7 @@ class ApiNIP99EventIT extends BaseRelayIntegrationTest {
     var expectedSubscriptionId = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(1).asText();
     var expectedSuccess = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(2).asBoolean();
 
+    try (SpringWebSocketClient springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri())) {
     String eventResponse = springWebSocketClient.send(message).stream().findFirst().get();
     var actualArray = MAPPER_AFTERBURNER.readTree(eventResponse).get(0).asText();
     var actualSubscriptionId = MAPPER_AFTERBURNER.readTree(eventResponse).get(1).asText();
@@ -101,7 +96,7 @@ class ApiNIP99EventIT extends BaseRelayIntegrationTest {
       assertEquals(expectedSubscriptionId, actualSubscriptionId, "Subscription ID should match");
       assertEquals(expectedSuccess, actualSuccess, "Success flag should match");
 
-    springWebSocketClient.closeSocket();
+    }
   }
 
   private String expectedResponseJson(String sha256) {

--- a/nostr-java-api/src/test/java/nostr/api/integration/ZDoLastApiNIP09EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ZDoLastApiNIP09EventIT.java
@@ -19,15 +19,12 @@ import nostr.event.tag.AddressTag;
 import nostr.event.tag.EventTag;
 import nostr.event.tag.IdentifierTag;
 import nostr.id.Identity;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,15 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @SpringJUnitConfig(RelayConfig.class)
 @ActiveProfiles("test")
 public class ZDoLastApiNIP09EventIT extends BaseRelayIntegrationTest {
-    @Autowired
-    private Map<String, String> relays;
-
-    private SpringWebSocketClient springWebSocketClient;
-
-    @BeforeEach
-    void setup() {
-        springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
-    }
+    
 
     @Test
     public void deleteEvent() throws IOException {
@@ -56,6 +45,7 @@ public class ZDoLastApiNIP09EventIT extends BaseRelayIntegrationTest {
         NIP09 nip09 = new NIP09(identity);
         NIP01 nip01 = new NIP01(identity);
 
+        try (SpringWebSocketClient springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri())) {
         GenericEvent event = nip01.createTextNoteEvent("Delete me!").sign().getEvent();
         EventMessage message = new EventMessage(event);
         springWebSocketClient.send(message);
@@ -77,6 +67,7 @@ public class ZDoLastApiNIP09EventIT extends BaseRelayIntegrationTest {
 
         assertFalse(result.isEmpty());
         assertEquals(1, result.size());
+        }
 
         nip01.close();
         nip09.close();
@@ -91,6 +82,7 @@ public class ZDoLastApiNIP09EventIT extends BaseRelayIntegrationTest {
         NIP01 nip011 = new NIP01(identity);
         GenericEvent replaceableEvent = nip011.createReplaceableEvent(10_001, "replaceable event").sign().getEvent();
         EventMessage replaceableEventMessage = new EventMessage(replaceableEvent);
+        try (SpringWebSocketClient springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri())) {
         List<String> jsonReplaceableMessageList = springWebSocketClient.send(replaceableEventMessage);
 
         BaseMessageDecoder<OkMessage> decoder = new BaseMessageDecoder<>();
@@ -155,5 +147,6 @@ public class ZDoLastApiNIP09EventIT extends BaseRelayIntegrationTest {
         nip01.close();
         nip011.close();
         nip09.close();
+        }
     }
 }

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @Component
 @Slf4j
-public class SpringWebSocketClient {
+public class SpringWebSocketClient implements AutoCloseable {
   private final WebSocketClientIF webSocketClientIF;
 
   @Getter
@@ -69,8 +69,14 @@ public class SpringWebSocketClient {
     throw ex;
   }
 
+  @Override
+  public void close() throws IOException {
+    webSocketClientIF.close();
+  }
+
+  @Deprecated(forRemoval = true)
   public void closeSocket() throws IOException {
-    webSocketClientIF.closeSocket();
+    close();
   }
 }
 

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
@@ -69,7 +69,14 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
   }
 
   @Override
+  public void close() throws IOException {
+    if (clientSession.isOpen()) {
+      clientSession.close();
+    }
+  }
+
+  @Deprecated(forRemoval = true)
   public void closeSocket() throws IOException {
-    clientSession.close();
+    close();
   }
 }

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/WebSocketClientIF.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/WebSocketClientIF.java
@@ -5,8 +5,10 @@ import nostr.event.BaseMessage;
 import java.io.IOException;
 import java.util.List;
 
-public interface WebSocketClientIF {
+public interface WebSocketClientIF extends AutoCloseable {
   <T extends BaseMessage> List<String> send(T eventMessage) throws IOException;
   List<String> send(String json) throws IOException;
-  void closeSocket() throws IOException;
+
+  @Override
+  void close() throws IOException;
 }

--- a/nostr-java-client/src/test/java/nostr/client/springwebsocket/SpringWebSocketClientTest.java
+++ b/nostr-java-client/src/test/java/nostr/client/springwebsocket/SpringWebSocketClientTest.java
@@ -51,7 +51,7 @@ class SpringWebSocketClientTest {
         }
 
         @Override
-        public void closeSocket() {
+        public void close() {
         }
     }
 


### PR DESCRIPTION
## Summary
- implement `AutoCloseable` for `SpringWebSocketClient` and `StandardWebSocketClient`
- replace `closeSocket` with `close` and guard session closure
- leverage try-with-resources in integration tests

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_b_68991ba9f65c8331b18e67a8095174eb