### PR TITLE
Implement AutoCloseable for websocket clients

### DIFF
--- a/nostr-java-api/src/main/java/nostr/api/WebSocketClientHandler.java
+++ b/nostr-java-api/src/main/java/nostr/api/WebSocketClientHandler.java
@@ -61,9 +61,9 @@ public class WebSocketClientHandler {
     }
 
     public void close() throws IOException {
-        eventClient.closeSocket();
+        eventClient.close();
         for (SpringWebSocketClient client : requestClientMap.values()) {
-            client.closeSocket();
+            client.close();
         }
     }
 }

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiEventTestUsingSpringWebSocketClientIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiEventTestUsingSpringWebSocketClientIT.java
@@ -60,22 +60,22 @@ class ApiEventTestUsingSpringWebSocketClientIT extends BaseRelayIntegrationTest 
         GenericEvent event = nip15.createCreateOrUpdateProductEvent(product, categories).sign().getEvent();
         EventMessage message = new EventMessage(event);
 
-        String eventResponse = springWebSocketClient.send(message).stream().findFirst().orElseThrow();
+        try (SpringWebSocketClient client = springWebSocketClient) {
+            String eventResponse = client.send(message).stream().findFirst().orElseThrow();
 
-        // Extract and compare only first 3 elements of the JSON array
-        var expectedArray = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(0).asText();
-        var expectedSubscriptionId = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(1).asText();
-        var expectedSuccess = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(2).asBoolean();
+            // Extract and compare only first 3 elements of the JSON array
+            var expectedArray = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(0).asText();
+            var expectedSubscriptionId = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(1).asText();
+            var expectedSuccess = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(2).asBoolean();
 
-        var actualArray = MAPPER_AFTERBURNER.readTree(eventResponse).get(0).asText();
-        var actualSubscriptionId = MAPPER_AFTERBURNER.readTree(eventResponse).get(1).asText();
-        var actualSuccess = MAPPER_AFTERBURNER.readTree(eventResponse).get(2).asBoolean();
+            var actualArray = MAPPER_AFTERBURNER.readTree(eventResponse).get(0).asText();
+            var actualSubscriptionId = MAPPER_AFTERBURNER.readTree(eventResponse).get(1).asText();
+            var actualSuccess = MAPPER_AFTERBURNER.readTree(eventResponse).get(2).asBoolean();
 
-        assertEquals(expectedArray, actualArray, "First element should match");
-        assertEquals(expectedSubscriptionId, actualSubscriptionId, "Subscription ID should match");
-        assertEquals(expectedSuccess, actualSuccess, "Success flag should match");
-
-        springWebSocketClient.closeSocket();
+            assertEquals(expectedArray, actualArray, "First element should match");
+            assertEquals(expectedSubscriptionId, actualSubscriptionId, "Subscription ID should match");
+            assertEquals(expectedSuccess, actualSuccess, "Success flag should match");
+        }
     }
 
     private String expectedResponseJson(String sha256) {

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
@@ -92,16 +92,16 @@ class ApiNIP99EventIT extends BaseRelayIntegrationTest {
     var expectedSubscriptionId = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(1).asText();
     var expectedSuccess = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(2).asBoolean();
 
-    String eventResponse = springWebSocketClient.send(message).stream().findFirst().get();
-    var actualArray = MAPPER_AFTERBURNER.readTree(eventResponse).get(0).asText();
-    var actualSubscriptionId = MAPPER_AFTERBURNER.readTree(eventResponse).get(1).asText();
-    var actualSuccess = MAPPER_AFTERBURNER.readTree(eventResponse).get(2).asBoolean();
+    try (SpringWebSocketClient client = springWebSocketClient) {
+      String eventResponse = client.send(message).stream().findFirst().get();
+      var actualArray = MAPPER_AFTERBURNER.readTree(eventResponse).get(0).asText();
+      var actualSubscriptionId = MAPPER_AFTERBURNER.readTree(eventResponse).get(1).asText();
+      var actualSuccess = MAPPER_AFTERBURNER.readTree(eventResponse).get(2).asBoolean();
 
       assertEquals(expectedArray, actualArray, "First element should match");
       assertEquals(expectedSubscriptionId, actualSubscriptionId, "Subscription ID should match");
       assertEquals(expectedSuccess, actualSuccess, "Success flag should match");
-
-    springWebSocketClient.closeSocket();
+    }
   }
 
   private String expectedResponseJson(String sha256) {

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99RequestIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99RequestIT.java
@@ -96,49 +96,50 @@ class ApiNIP99RequestIT extends BaseRelayIntegrationTest {
     eventPubKey = event.getPubKey().toString();
     EventMessage eventMessage = new EventMessage(event);
 
-      SpringWebSocketClient springWebSocketEventClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
-    List<String> eventResponses = springWebSocketEventClient.send(eventMessage);
+    try (SpringWebSocketClient springWebSocketEventClient =
+             new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri())) {
+      List<String> eventResponses = springWebSocketEventClient.send(eventMessage);
 
-	  assertEquals(1, eventResponses.size(), "Expected 1 event response, but got " + eventResponses.size());
+      assertEquals(1, eventResponses.size(), "Expected 1 event response, but got " + eventResponses.size());
 
-    // Extract and compare only first 3 elements of the JSON array
-    var expectedArray = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(0).asText();
-    var expectedSubscriptionId = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(1).asText();
-    var expectedSuccess = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(2).asBoolean();
+      // Extract and compare only first 3 elements of the JSON array
+      var expectedArray = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(0).asText();
+      var expectedSubscriptionId = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(1).asText();
+      var expectedSuccess = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(2).asBoolean();
 
-    var actualArray = MAPPER_AFTERBURNER.readTree(eventResponses.getFirst()).get(0).asText();
-    var actualSubscriptionId = MAPPER_AFTERBURNER.readTree(eventResponses.getFirst()).get(1).asText();
-    var actualSuccess = MAPPER_AFTERBURNER.readTree(eventResponses.getFirst()).get(2).asBoolean();
+      var actualArray = MAPPER_AFTERBURNER.readTree(eventResponses.getFirst()).get(0).asText();
+      var actualSubscriptionId = MAPPER_AFTERBURNER.readTree(eventResponses.getFirst()).get(1).asText();
+      var actualSuccess = MAPPER_AFTERBURNER.readTree(eventResponses.getFirst()).get(2).asBoolean();
 
-	  assertEquals(expectedArray, actualArray, "First element should match");
-	  assertEquals(expectedSubscriptionId, actualSubscriptionId, "Subscription ID should match");
-	  assertEquals(expectedSuccess, actualSuccess, "Success flag should match");
-
-    springWebSocketEventClient.closeSocket();
+      assertEquals(expectedArray, actualArray, "First element should match");
+      assertEquals(expectedSubscriptionId, actualSubscriptionId, "Subscription ID should match");
+      assertEquals(expectedSuccess, actualSuccess, "Success flag should match");
+    }
 
     // TODO - Investigate why EOSE, instead of EVENT, is returned from nostr-rs-relay, and not superconductor
 
-      SpringWebSocketClient springWebSocketRequestClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
-    String reqJson = createReqJson(UUID.randomUUID().toString(), eventId);
-    List<String> reqResponses = springWebSocketRequestClient.send(reqJson).stream().toList();
-    springWebSocketRequestClient.closeSocket();
+    try (SpringWebSocketClient springWebSocketRequestClient =
+             new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri())) {
+      String reqJson = createReqJson(UUID.randomUUID().toString(), eventId);
+      List<String> reqResponses = springWebSocketRequestClient.send(reqJson).stream().toList();
 
-    var actualJson = MAPPER_AFTERBURNER.readTree(reqResponses.getFirst());
-    var expectedJson = MAPPER_AFTERBURNER.readTree(expectedRequestResponseJson());
+      var actualJson = MAPPER_AFTERBURNER.readTree(reqResponses.getFirst());
+      var expectedJson = MAPPER_AFTERBURNER.readTree(expectedRequestResponseJson());
 
-    // Verify you receive the event
-	  assertEquals("EVENT", actualJson.get(0).asText(), "Event should be received, and not " + actualJson.get(0).asText());
+      // Verify you receive the event
+      assertEquals("EVENT", actualJson.get(0).asText(), "Event should be received, and not " + actualJson.get(0).asText());
 
-    // Verify only required fields
-	  assertEquals(3, actualJson.size(), "Expected 3 elements in the array, but got " + actualJson.size());
+      // Verify only required fields
+      assertEquals(3, actualJson.size(), "Expected 3 elements in the array, but got " + actualJson.size());
       assertEquals(actualJson.get(2).get("id").asText(), expectedJson.get(2).get("id").asText(), "ID should match");
       assertEquals(actualJson.get(2).get("kind").asInt(), expectedJson.get(2).get("kind").asInt(), "Kind should match");
 
-    // Verify required tags
-    var actualTags = actualJson.get(2).get("tags");
-    assertTrue(hasRequiredTag(actualTags, "price", NUMBER.toString()), "Price tag should be present");
-    assertTrue(hasRequiredTag(actualTags, "title", TITLE), "Title tag should be present");
-    assertTrue(hasRequiredTag(actualTags, "summary", SUMMARY), "Summary tag should be present");
+      // Verify required tags
+      var actualTags = actualJson.get(2).get("tags");
+      assertTrue(hasRequiredTag(actualTags, "price", NUMBER.toString()), "Price tag should be present");
+      assertTrue(hasRequiredTag(actualTags, "title", TITLE), "Title tag should be present");
+      assertTrue(hasRequiredTag(actualTags, "summary", SUMMARY), "Summary tag should be present");
+    }
 //*/
   }
 

--- a/nostr-java-api/src/test/java/nostr/api/integration/ZDoLastApiNIP09EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ZDoLastApiNIP09EventIT.java
@@ -19,15 +19,12 @@ import nostr.event.tag.AddressTag;
 import nostr.event.tag.EventTag;
 import nostr.event.tag.IdentifierTag;
 import nostr.id.Identity;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,45 +35,40 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @SpringJUnitConfig(RelayConfig.class)
 @ActiveProfiles("test")
 public class ZDoLastApiNIP09EventIT extends BaseRelayIntegrationTest {
-    @Autowired
-    private Map<String, String> relays;
 
-    private SpringWebSocketClient springWebSocketClient;
-
-    @BeforeEach
-    void setup() throws Exception {
-        springWebSocketClient = new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri());
-    }
 
     @Test
-    public void deleteEvent() throws IOException {
+    public void deleteEvent() throws Exception {
 
         Identity identity = Identity.generateRandomIdentity();
 
         NIP09 nip09 = new NIP09(identity);
         NIP01 nip01 = new NIP01(identity);
 
-        GenericEvent event = nip01.createTextNoteEvent("Delete me!").sign().getEvent();
-        EventMessage message = new EventMessage(event);
-        springWebSocketClient.send(message);
+        try (SpringWebSocketClient springWebSocketClient =
+                 new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri())) {
+            GenericEvent event = nip01.createTextNoteEvent("Delete me!").sign().getEvent();
+            EventMessage message = new EventMessage(event);
+            springWebSocketClient.send(message);
 
-        Filters filters = new Filters(
-            new KindFilter<>(Kind.TEXT_NOTE),
-            new AuthorFilter<>(identity.getPublicKey()));
+            Filters filters = new Filters(
+                new KindFilter<>(Kind.TEXT_NOTE),
+                new AuthorFilter<>(identity.getPublicKey()));
 
-        List<String> result = NIP01.sendRequest(springWebSocketClient, filters, UUID.randomUUID().toString());
+            List<String> result = NIP01.sendRequest(springWebSocketClient, filters, UUID.randomUUID().toString());
 
-        assertFalse(result.isEmpty());
-        assertEquals(2, result.size());
+            assertFalse(result.isEmpty());
+            assertEquals(2, result.size());
 
-        var nip09Event = nip09.createDeletionEvent(nip01.getEvent()).sign().getEvent();
-        EventMessage nip09Message = new EventMessage(nip09Event);
-        springWebSocketClient.send(nip09Message);
+            var nip09Event = nip09.createDeletionEvent(nip01.getEvent()).sign().getEvent();
+            EventMessage nip09Message = new EventMessage(nip09Event);
+            springWebSocketClient.send(nip09Message);
 
-        result = NIP01.sendRequest(springWebSocketClient, filters, UUID.randomUUID().toString());
+            result = NIP01.sendRequest(springWebSocketClient, filters, UUID.randomUUID().toString());
 
-        assertFalse(result.isEmpty());
-        assertEquals(1, result.size());
+            assertFalse(result.isEmpty());
+            assertEquals(1, result.size());
+        }
 
         nip01.close();
         nip09.close();
@@ -84,76 +76,80 @@ public class ZDoLastApiNIP09EventIT extends BaseRelayIntegrationTest {
 
 
     @Test
-    public void deleteEventWithRef() throws IOException {
+    public void deleteEventWithRef() throws Exception {
         final String RELAY_URI = getRelayUri();
         Identity identity = Identity.generateRandomIdentity();
 
         NIP01 nip011 = new NIP01(identity);
         GenericEvent replaceableEvent = nip011.createReplaceableEvent(10_001, "replaceable event").sign().getEvent();
         EventMessage replaceableEventMessage = new EventMessage(replaceableEvent);
-        List<String> jsonReplaceableMessageList = springWebSocketClient.send(replaceableEventMessage);
 
-        BaseMessageDecoder<OkMessage> decoder = new BaseMessageDecoder<>();
-        OkMessage okMessage = decoder.decode(jsonReplaceableMessageList.get(0));
+        try (SpringWebSocketClient springWebSocketClient =
+                 new SpringWebSocketClient(new StandardWebSocketClient(getRelayUri()), getRelayUri())) {
+            List<String> jsonReplaceableMessageList = springWebSocketClient.send(replaceableEventMessage);
 
-        assertNotNull(jsonReplaceableMessageList);
-        assertInstanceOf(OkMessage.class, okMessage);
+            BaseMessageDecoder<OkMessage> decoder = new BaseMessageDecoder<>();
+            OkMessage okMessage = decoder.decode(jsonReplaceableMessageList.get(0));
 
-        IdentifierTag identifierTag = new IdentifierTag(replaceableEvent.getId());
+            assertNotNull(jsonReplaceableMessageList);
+            assertInstanceOf(OkMessage.class, okMessage);
 
-        NIP01 nip01 = new NIP01(identity);
-        nip01
-            .createTextNoteEvent("Reference me!")
-            .getEvent()
-            .addTag(NIP01.createAddressTag(10_001, identity.getPublicKey(), identifierTag, new Relay(RELAY_URI)));
+            IdentifierTag identifierTag = new IdentifierTag(replaceableEvent.getId());
 
-        GenericEvent nip01Event = nip01.sign().getEvent();
-        EventMessage eventMessage = new EventMessage(nip01Event);
-        List<String> jsonMessageList = springWebSocketClient.send(eventMessage);
+            NIP01 nip01 = new NIP01(identity);
+            nip01
+                .createTextNoteEvent("Reference me!")
+                .getEvent()
+                .addTag(NIP01.createAddressTag(10_001, identity.getPublicKey(), identifierTag, new Relay(RELAY_URI)));
 
-        decoder = new BaseMessageDecoder<>();
-        okMessage = decoder.decode(jsonReplaceableMessageList.get(0));
+            GenericEvent nip01Event = nip01.sign().getEvent();
+            EventMessage eventMessage = new EventMessage(nip01Event);
+            List<String> jsonMessageList = springWebSocketClient.send(eventMessage);
 
-        assertNotNull(jsonMessageList);
-        assertInstanceOf(OkMessage.class, okMessage);
+            decoder = new BaseMessageDecoder<>();
+            okMessage = decoder.decode(jsonReplaceableMessageList.get(0));
+
+            assertNotNull(jsonMessageList);
+            assertInstanceOf(OkMessage.class, okMessage);
 
 
-        NIP09 nip09 = new NIP09(identity);
-        GenericEvent deletedEvent = nip09.createDeletionEvent(nip01Event).getEvent();
+            NIP09 nip09 = new NIP09(identity);
+            GenericEvent deletedEvent = nip09.createDeletionEvent(nip01Event).getEvent();
 
-        assertEquals(4, deletedEvent.getTags().size());
+            assertEquals(4, deletedEvent.getTags().size());
 
-        List<BaseTag> eventTags = deletedEvent.getTags()
-            .stream()
-            .filter(t -> "e".equals(t.getCode()))
-            .toList();
+            List<BaseTag> eventTags = deletedEvent.getTags()
+                .stream()
+                .filter(t -> "e".equals(t.getCode()))
+                .toList();
 
-        assertEquals(1, eventTags.size());
+            assertEquals(1, eventTags.size());
 
-        EventTag eventTag = (EventTag) eventTags.get(0);
-        assertEquals(nip01Event.getId(), eventTag.getIdEvent());
+            EventTag eventTag = (EventTag) eventTags.get(0);
+            assertEquals(nip01Event.getId(), eventTag.getIdEvent());
 
-        List<BaseTag> addressTags = deletedEvent.getTags()
-            .stream()
-            .filter(t -> "a".equals(t.getCode()))
-            .toList();
+            List<BaseTag> addressTags = deletedEvent.getTags()
+                .stream()
+                .filter(t -> "a".equals(t.getCode()))
+                .toList();
 
-        assertEquals(1, addressTags.size());
+            assertEquals(1, addressTags.size());
 
-        AddressTag addressTag = (AddressTag) addressTags.get(0);
-        assertEquals(10_001, addressTag.getKind());
-        assertEquals(replaceableEvent.getId(), addressTag.getIdentifierTag().getUuid());
-        assertEquals(identity.getPublicKey(), addressTag.getPublicKey());
+            AddressTag addressTag = (AddressTag) addressTags.get(0);
+            assertEquals(10_001, addressTag.getKind());
+            assertEquals(replaceableEvent.getId(), addressTag.getIdentifierTag().getUuid());
+            assertEquals(identity.getPublicKey(), addressTag.getPublicKey());
 
-        List<BaseTag> kindTags = deletedEvent.getTags()
-            .stream()
-            .filter(t -> "k".equals(t.getCode()))
-            .toList();
+            List<BaseTag> kindTags = deletedEvent.getTags()
+                .stream()
+                .filter(t -> "k".equals(t.getCode()))
+                .toList();
 
-        assertEquals(2, kindTags.size());
+            assertEquals(2, kindTags.size());
 
-        nip01.close();
-        nip011.close();
-        nip09.close();
+            nip01.close();
+            nip011.close();
+            nip09.close();
+        }
     }
 }

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/SpringWebSocketClient.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Component
 @Slf4j
-public class SpringWebSocketClient {
+public class SpringWebSocketClient implements AutoCloseable {
   private final WebSocketClientIF webSocketClientIF;
 
   @Getter
@@ -82,10 +82,19 @@ public class SpringWebSocketClient {
     throw ex;
   }
 
-  public void closeSocket() throws IOException {
+  @Override
+  public void close() throws IOException {
     log.debug("Closing WebSocket client for relay {}", relayUrl);
-    webSocketClientIF.closeSocket();
+    webSocketClientIF.close();
     log.debug("WebSocket client closed for relay {}", relayUrl);
+  }
+
+  /**
+   * @deprecated use {@link #close()} instead.
+   */
+  @Deprecated
+  public void closeSocket() throws IOException {
+    close();
   }
 }
 

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
@@ -113,7 +113,16 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
   @Override
   public void close() throws IOException {
     if (clientSession.isOpen()) {
-      clientSession.close();
+    if (clientSession != null) {
+      boolean open = false;
+      try {
+        open = clientSession.isOpen();
+      } catch (Exception e) {
+        log.warn("Exception while checking if clientSession is open during close()", e);
+      }
+      if (open) {
+        clientSession.close();
+      }
     }
   }
 

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
@@ -112,7 +112,6 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
 
   @Override
   public void close() throws IOException {
-    if (clientSession.isOpen()) {
     if (clientSession != null) {
       boolean open = false;
       try {

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
@@ -111,7 +111,17 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
   }
 
   @Override
+  public void close() throws IOException {
+    if (clientSession.isOpen()) {
+      clientSession.close();
+    }
+  }
+
+  /**
+   * @deprecated use {@link #close()} instead.
+   */
+  @Deprecated
   public void closeSocket() throws IOException {
-    clientSession.close();
+    close();
   }
 }

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/WebSocketClientIF.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/WebSocketClientIF.java
@@ -10,9 +10,9 @@ import java.util.List;
  *
  * <p>Implementations typically maintain a single active connection and are
  * not required to be thread-safe. Callers should serialize access and invoke
- * {@link #closeSocket()} when the client is no longer needed.</p>
+ * {@link #close()} when the client is no longer needed.</p>
  */
-public interface WebSocketClientIF {
+public interface WebSocketClientIF extends AutoCloseable {
 
   /**
    * Sends the provided Nostr message over the current WebSocket connection.
@@ -44,8 +44,7 @@ public interface WebSocketClientIF {
   List<String> send(String json) throws IOException;
 
   /**
-   * Closes the underlying WebSocket session and releases associated
-   * resources.
+   * Closes the underlying WebSocket session and releases associated resources.
    *
    * <p>The caller that created this client is responsible for invoking this
    * method when the connection is no longer required. After invocation, the
@@ -53,5 +52,14 @@ public interface WebSocketClientIF {
    *
    * @throws IOException if an I/O error occurs while closing the connection
    */
-  void closeSocket() throws IOException;
+  @Override
+  void close() throws IOException;
+
+  /**
+   * @deprecated use {@link #close()} instead.
+   */
+  @Deprecated
+  default void closeSocket() throws IOException {
+    close();
+  }
 }

--- a/nostr-java-client/src/test/java/nostr/client/springwebsocket/SpringWebSocketClientTest.java
+++ b/nostr-java-client/src/test/java/nostr/client/springwebsocket/SpringWebSocketClientTest.java
@@ -51,7 +51,7 @@ class SpringWebSocketClientTest {
         }
 
         @Override
-        public void closeSocket() {
+        public void close() {
         }
     }
 

--- a/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientTimeoutTest.java
+++ b/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientTimeoutTest.java
@@ -14,9 +14,10 @@ public class StandardWebSocketClientTimeoutTest {
   @Test
   public void testTimeoutReturnsEmptyListAndClosesSession() throws Exception {
     WebSocketSession session = Mockito.mock(WebSocketSession.class);
-    StandardWebSocketClient client = new StandardWebSocketClient(session, 100, 50);
-    List<String> result = client.send("test");
-    assertTrue(result.isEmpty());
+    try (StandardWebSocketClient client = new StandardWebSocketClient(session, 100, 50)) {
+      List<String> result = client.send("test");
+      assertTrue(result.isEmpty());
+    }
     Mockito.verify(session).sendMessage(Mockito.any(TextMessage.class));
     Mockito.verify(session).close();
   }


### PR DESCRIPTION
## Summary
- Make `WebSocketClientIF` extend `AutoCloseable` and expose a `close()` method
- Guard websocket session shutdowns and provide `close()` implementations in Standard and Spring clients
- Switch handlers, usage sites, and tests to the new `close()` API and try-with-resources

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_b_689929b8f5048331bbde279ac9cf8e20