### PR TITLE
Refine WebSocket client synchronization for concurrent operations

### DIFF
--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -39,7 +39,7 @@ The project can be built with Maven or Gradle. Unit tests do not require a runni
 Integration tests start a `nostr-rs-relay` container automatically. The image used can be overridden in `src/test/resources/relay-container.properties` by setting `relay.container.image=<image>`.
 
 ## WebSocket configuration
-`StandardWebSocketClient` waits for relay responses when sending messages. The timeout and polling interval are configured with the following properties (values in milliseconds):
+`StandardWebSocketClient` waits for relay responses when sending messages. It now uses a per-send `BlockingQueue` and `CountDownLatch` to coordinate responses, allowing multiple send operations to run concurrently. The timeout and polling interval are configured with the following properties (values in milliseconds):
 ```
 nostr.websocket.await-timeout-ms=60000
 nostr.websocket.poll-interval-ms=500

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/StandardWebSocketClient.java
@@ -13,12 +13,16 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.awaitility.Awaitility.await;
+import org.awaitility.core.ConditionTimeoutException;
 
 @Component
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
@@ -33,8 +37,12 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
   private long pollIntervalMs;
 
   private final WebSocketSession clientSession;
-  private List<String> events = new ArrayList<>();
-  private final AtomicBoolean completed = new AtomicBoolean(false);
+  private final BlockingQueue<SendContext> contexts = new LinkedBlockingQueue<>();
+
+  private static class SendContext {
+    final BlockingQueue<String> events = new LinkedBlockingQueue<>();
+    final CountDownLatch latch = new CountDownLatch(1);
+  }
 
   /**
    * Creates a new {@code StandardWebSocketClient} connected to the provided relay URI.
@@ -53,10 +61,19 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
             .get();
   }
 
+  StandardWebSocketClient(WebSocketSession clientSession, long awaitTimeoutMs, long pollIntervalMs) {
+    this.clientSession = clientSession;
+    this.awaitTimeoutMs = awaitTimeoutMs;
+    this.pollIntervalMs = pollIntervalMs;
+  }
+
   @Override
   protected void handleTextMessage(@NonNull WebSocketSession session, TextMessage message) {
-    events.add(message.getPayload());
-    completed.setRelease(true);
+    SendContext context = contexts.poll();
+    if (context != null) {
+      context.events.offer(message.getPayload());
+      context.latch.countDown();
+    }
   }
 
   @Override
@@ -66,16 +83,26 @@ public class StandardWebSocketClient extends TextWebSocketHandler implements Web
 
   @Override
   public List<String> send(String json) throws IOException {
+    SendContext context = new SendContext();
+    contexts.offer(context);
     clientSession.sendMessage(new TextMessage(json));
-    Duration awaitTimeout = awaitTimeoutMs > 0 ? Duration.ofMillis(awaitTimeoutMs) : DEFAULT_AWAIT_TIMEOUT;
-    Duration pollInterval = pollIntervalMs > 0 ? Duration.ofMillis(pollIntervalMs) : DEFAULT_POLL_INTERVAL;
-    await()
-        .atMost(awaitTimeout)
-        .pollInterval(pollInterval)
-        .untilTrue(completed);
-    List<String> eventList = List.copyOf(events);
-    events = new ArrayList<>();
-    completed.setRelease(false);
+    Duration awaitTimeout =
+        awaitTimeoutMs > 0 ? Duration.ofMillis(awaitTimeoutMs) : DEFAULT_AWAIT_TIMEOUT;
+    Duration pollInterval =
+        pollIntervalMs > 0 ? Duration.ofMillis(pollIntervalMs) : DEFAULT_POLL_INTERVAL;
+    try {
+      await()
+          .atMost(awaitTimeout)
+          .pollInterval(pollInterval)
+          .until(() -> context.latch.getCount() == 0);
+    } catch (ConditionTimeoutException e) {
+      contexts.remove(context);
+      clientSession.close();
+      return Collections.emptyList();
+    }
+    List<String> eventList = new ArrayList<>();
+    context.events.drainTo(eventList);
+    context.events.clear();
     return eventList;
   }
 

--- a/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientConcurrencyTest.java
+++ b/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientConcurrencyTest.java
@@ -1,0 +1,109 @@
+package nostr.client.springwebsocket;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.socket.*;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StandardWebSocketClientConcurrencyTest {
+
+    static class StubWebSocketSession implements WebSocketSession {
+        private final CountDownLatch sendLatch;
+        private boolean open = true;
+
+        StubWebSocketSession(CountDownLatch sendLatch) {
+            this.sendLatch = sendLatch;
+        }
+
+        @Override
+        public String getId() { return "1"; }
+
+        @Override
+        public URI getUri() { return null; }
+
+        @Override
+        public HttpHeaders getHandshakeHeaders() { return new HttpHeaders(); }
+
+        @Override
+        public Map<String, Object> getAttributes() { return Collections.emptyMap(); }
+
+        @Override
+        public Principal getPrincipal() { return null; }
+
+        @Override
+        public InetSocketAddress getLocalAddress() { return null; }
+
+        @Override
+        public InetSocketAddress getRemoteAddress() { return null; }
+
+        @Override
+        public String getAcceptedProtocol() { return null; }
+
+        @Override
+        public void setTextMessageSizeLimit(int messageSizeLimit) { }
+
+        @Override
+        public int getTextMessageSizeLimit() { return 0; }
+
+        @Override
+        public void setBinaryMessageSizeLimit(int messageSizeLimit) { }
+
+        @Override
+        public int getBinaryMessageSizeLimit() { return 0; }
+
+        @Override
+        public List<WebSocketExtension> getExtensions() { return List.of(); }
+
+        @Override
+        public void sendMessage(WebSocketMessage<?> message) {
+            sendLatch.countDown();
+        }
+
+        @Override
+        public boolean isOpen() { return open; }
+
+        @Override
+        public void close() { open = false; }
+
+        @Override
+        public void close(CloseStatus status) { open = false; }
+    }
+
+    @Test
+    void concurrentSendsReceiveResponses() throws Exception {
+        CountDownLatch sendLatch = new CountDownLatch(2);
+        StubWebSocketSession session = new StubWebSocketSession(sendLatch);
+        StandardWebSocketClient client = new StandardWebSocketClient(session, 1000, 10);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        Future<List<String>> f1 = executor.submit(() -> {
+            start.await();
+            return client.send("msg1");
+        });
+        Future<List<String>> f2 = executor.submit(() -> {
+            start.await();
+            return client.send("msg2");
+        });
+
+        start.countDown();
+        sendLatch.await(1, TimeUnit.SECONDS);
+
+        client.handleTextMessage(session, new TextMessage("resp1"));
+        client.handleTextMessage(session, new TextMessage("resp2"));
+
+        List<String> r1 = f1.get(2, TimeUnit.SECONDS);
+        List<String> r2 = f2.get(2, TimeUnit.SECONDS);
+        assertEquals(Set.of(List.of("resp1"), List.of("resp2")), Set.of(r1, r2));
+
+        executor.shutdownNow();
+    }
+}

--- a/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientTimeoutTest.java
+++ b/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientTimeoutTest.java
@@ -1,0 +1,85 @@
+package nostr.client.springwebsocket;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketExtension;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StandardWebSocketClientTimeoutTest {
+
+    static class StubWebSocketSession implements WebSocketSession {
+        private boolean open = true;
+
+        @Override
+        public String getId() { return "1"; }
+
+        @Override
+        public URI getUri() { return null; }
+
+        @Override
+        public HttpHeaders getHandshakeHeaders() { return new HttpHeaders(); }
+
+        @Override
+        public Map<String, Object> getAttributes() { return Collections.emptyMap(); }
+
+        @Override
+        public Principal getPrincipal() { return null; }
+
+        @Override
+        public InetSocketAddress getLocalAddress() { return null; }
+
+        @Override
+        public InetSocketAddress getRemoteAddress() { return null; }
+
+        @Override
+        public String getAcceptedProtocol() { return null; }
+
+        @Override
+        public void setTextMessageSizeLimit(int messageSizeLimit) { }
+
+        @Override
+        public int getTextMessageSizeLimit() { return 0; }
+
+        @Override
+        public void setBinaryMessageSizeLimit(int messageSizeLimit) { }
+
+        @Override
+        public int getBinaryMessageSizeLimit() { return 0; }
+
+        @Override
+        public List<WebSocketExtension> getExtensions() { return List.of(); }
+
+        @Override
+        public void sendMessage(WebSocketMessage<?> message) { }
+
+        @Override
+        public boolean isOpen() { return open; }
+
+        @Override
+        public void close() { open = false; }
+
+        @Override
+        public void close(CloseStatus status) { open = false; }
+    }
+
+    @Test
+    void testTimeoutReturnsEmptyListAndClosesSession() throws Exception {
+        StubWebSocketSession session = new StubWebSocketSession();
+        StandardWebSocketClient client = new StandardWebSocketClient(session, 100, 10);
+
+        assertTrue(client.send("payload").isEmpty());
+        assertFalse(session.isOpen());
+    }
+}


### PR DESCRIPTION
## Summary
- synchronize StandardWebSocketClient with per-send BlockingQueue and CountDownLatch
- reset collections via clear and expose testing constructor
- handle send timeouts by closing the WebSocket session and returning an empty list
- verify concurrent sends, receives, and timeout behavior with new unit tests

## Testing
- `mvn -q -pl nostr-java-client -am test`
- `mvn -q verify` *(fails: Could not find a valid Docker environment. Please see logs and check configuration)*

------
https://chatgpt.com/codex/tasks/task_b_689923b143c48331a4a88fcb949e450d