### PR TITLE
Handle EOSE responses correctly

### DIFF
--- a/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientEOSETest.java
+++ b/nostr-java-client/src/test/java/nostr/client/springwebsocket/StandardWebSocketClientEOSETest.java
@@ -1,0 +1,43 @@
+package nostr.client.springwebsocket;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StandardWebSocketClientEOSETest {
+
+  @Test
+  public void testCollectsEventsUntilEOSE() throws Exception {
+    WebSocketSession session = Mockito.mock(WebSocketSession.class);
+    try (StandardWebSocketClient client = new StandardWebSocketClient(session, 1000, 50)) {
+      CompletableFuture<List<String>> future = CompletableFuture.supplyAsync(() -> {
+        try {
+          return client.send("test");
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      });
+
+      // Ensure the send call has time to register the context
+      TimeUnit.MILLISECONDS.sleep(100);
+
+      client.handleTextMessage(session, new TextMessage("{\"type\":\"EVENT\"}"));
+      client.handleTextMessage(session, new TextMessage("{\"type\":\"EOSE\"}"));
+
+      List<String> result = future.get(1, TimeUnit.SECONDS);
+      assertEquals(2, result.size());
+      assertTrue(result.get(0).contains("EVENT"));
+      assertTrue(result.get(1).contains("EOSE"));
+    }
+    Mockito.verify(session).sendMessage(Mockito.any(TextMessage.class));
+  }
+}


### PR DESCRIPTION
## Summary
- Track send contexts across multiple relay messages and release when an `EOSE` response arrives
- Collect all event payloads for a request and clear them after returning to the caller
- Add unit test covering `EOSE` handling and multi-message aggregation

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment. Please see logs and check configuration)*


------
https://chatgpt.com/codex/tasks/task_b_6899396e0f1483318de294656c7042ed