### PR TITLE
chore: remove NipUtil

### DIFF
--- a/nostr-java-base/src/main/java/nostr/base/NipUtil.java
+++ b/nostr-java-base/src/main/java/nostr/base/NipUtil.java
@@ -1,9 +1,0 @@
-package nostr.base;
-
-/**
- *
- * @author squirrel
- */
-@Deprecated(forRemoval = true)
-public class NipUtil {
-}


### PR DESCRIPTION
## Summary
- remove unused `NipUtil` helper

## Testing
- `rg NipUtil`
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_b_689940ee836c8331beca4ad3eac6226a