### PR TITLE
chore: remove test application properties

### DIFF
--- a/nostr-java-base/src/test/resources/application-test.properties
+++ b/nostr-java-base/src/test/resources/application-test.properties
@@ -1,4 +1,0 @@
-spring.threads.virtual.enabled=true
-
-logging.level.nostr.base=INFO
-logging.pattern.console=%msg%n


### PR DESCRIPTION
## Summary
- remove redundant test `application-test.properties` file from base module

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*


------
https://chatgpt.com/codex/tasks/task_b_689940f6169483319117a79f8b5ca18a