### PR TITLE
Refactor GenericTagQuery into record

### DIFF
--- a/nostr-java-base/src/main/java/nostr/base/GenericTagQuery.java
+++ b/nostr-java-base/src/main/java/nostr/base/GenericTagQuery.java
@@ -1,27 +1,7 @@
 
 package nostr.base;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /**
  * @author squirrel
  */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class GenericTagQuery {
-
-    private String tagName;
-
-    @JsonProperty
-    private String value;
-
-    @JsonIgnore
-    public Integer getNip() {
-        return 1;
-    }
-}
+public record GenericTagQuery(String tagName, String value) implements IElement {}

--- a/nostr-java-event/src/main/java/nostr/event/filter/GenericTagQueryFilter.java
+++ b/nostr-java-event/src/main/java/nostr/event/filter/GenericTagQueryFilter.java
@@ -15,7 +15,7 @@ public class GenericTagQueryFilter<T extends GenericTagQuery> extends AbstractFi
     public static final String HASH_PREFIX = "#";
 
     public GenericTagQueryFilter(T genericTagQuery) {
-        super(genericTagQuery, genericTagQuery.getTagName());
+        super(genericTagQuery, genericTagQuery.tagName());
     }
 
     @Override
@@ -34,12 +34,12 @@ public class GenericTagQueryFilter<T extends GenericTagQuery> extends AbstractFi
 
     @Override
     public String getFilterKey() {
-        return getGenericTagQuery().getTagName();
+        return getGenericTagQuery().tagName();
     }
 
     @Override
     public String getFilterableValue() {
-        return getGenericTagQuery().getValue();
+        return getGenericTagQuery().value();
     }
 
     private T getGenericTagQuery() {

--- a/nostr-java-id/src/test/java/nostr/id/EntityFactory.java
+++ b/nostr-java-id/src/test/java/nostr/id/EntityFactory.java
@@ -151,12 +151,7 @@ public class EntityFactory {
             list.add(v2);
             list.add(v1);
 
-            return list.stream().map(item -> {
-                var result = new GenericTagQuery();
-                result.setTagName(c.toString());
-                result.setValue(item);
-                return result;
-            }).toList();
+            return list.stream().map(item -> new GenericTagQuery(c.toString(), item)).toList();
         }
     }
 


### PR DESCRIPTION
## Summary
- replace `GenericTagQuery` class with a compact record implementing `IElement`
- update `GenericTagQueryFilter` to use record accessors
- streamline factory tests to construct `GenericTagQuery` via new constructor

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment; integration tests require Docker)*

## Network Access
- no network calls were made


------
https://chatgpt.com/codex/tasks/task_b_6899414955d883319c72b0bb7e1b7263