### PR TITLE
refactor: use record for ElementAttribute

### DIFF
--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiEventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiEventIT.java
@@ -515,7 +515,7 @@ public class ApiEventIT extends BaseRelayIntegrationTest {
 
         assertEquals("L", langNS.getCode());
         assertEquals(1, langNS.getAttributes().size());
-        assertEquals("Languages", langNS.getAttributes().iterator().next().getValue());
+        assertEquals("Languages", langNS.getAttributes().iterator().next().value());
     }
 
     @Test

--- a/nostr-java-api/src/test/java/nostr/api/unit/JsonParseTest.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/JsonParseTest.java
@@ -261,8 +261,8 @@ public class JsonParseTest {
 
     assertEquals("saturn", tag.getCode());
     assertEquals(2, tag.getAttributes().size());
-    assertEquals("jetpack", ((ElementAttribute) (tag.getAttributes().toArray())[0]).getValue());
-    assertEquals(false, Boolean.valueOf(((ElementAttribute) (tag.getAttributes().toArray())[1]).getValue().toString()));
+    assertEquals("jetpack", ((ElementAttribute) (tag.getAttributes().toArray())[0]).value());
+    assertEquals(false, Boolean.valueOf(((ElementAttribute) (tag.getAttributes().toArray())[1]).value().toString()));
   }
 
   @Test
@@ -320,16 +320,16 @@ public class JsonParseTest {
         .map(GenericTag.class::cast).toList();
 
     assertEquals("title ipsum", genericTags.stream()
-        .filter(tag -> tag.getCode().equalsIgnoreCase("title")).map(GenericTag::getAttributes).toList().getFirst().getFirst().getValue());
+        .filter(tag -> tag.getCode().equalsIgnoreCase("title")).map(GenericTag::getAttributes).toList().getFirst().getFirst().value());
 
     assertEquals("summary ipsum", genericTags.stream()
-        .filter(tag -> tag.getCode().equalsIgnoreCase("summary")).map(GenericTag::getAttributes).toList().getFirst().getFirst().getValue());
+        .filter(tag -> tag.getCode().equalsIgnoreCase("summary")).map(GenericTag::getAttributes).toList().getFirst().getFirst().value());
 
     assertEquals("1687765220", genericTags.stream()
-        .filter(tag -> tag.getCode().equalsIgnoreCase("published_at")).map(GenericTag::getAttributes).toList().getFirst().getFirst().getValue());
+        .filter(tag -> tag.getCode().equalsIgnoreCase("published_at")).map(GenericTag::getAttributes).toList().getFirst().getFirst().value());
 
     assertEquals("location ipsum", genericTags.stream()
-        .filter(tag -> tag.getCode().equalsIgnoreCase("location")).map(GenericTag::getAttributes).toList().getFirst().getFirst().getValue());
+        .filter(tag -> tag.getCode().equalsIgnoreCase("location")).map(GenericTag::getAttributes).toList().getFirst().getFirst().value());
   }
 
   @Test

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP31Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP31Test.java
@@ -13,6 +13,6 @@ public class NIP31Test {
     public void testCreateAltTag() {
         BaseTag tag = NIP31.createAltTag("desc");
         assertEquals("alt", tag.getCode());
-        assertEquals("desc", ((GenericTag) tag).getAttributes().get(0).getValue());
+        assertEquals("desc", ((GenericTag) tag).getAttributes().get(0).value());
     }
 }

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP42Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP42Test.java
@@ -15,10 +15,10 @@ public class NIP42Test {
         Relay relay = new Relay("wss://relay");
         BaseTag rTag = NIP42.createRelayTag(relay);
         assertEquals("relay", rTag.getCode());
-        assertEquals(relay.getUri(), ((GenericTag) rTag).getAttributes().get(0).getValue());
+        assertEquals(relay.getUri(), ((GenericTag) rTag).getAttributes().get(0).value());
 
         BaseTag cTag = NIP42.createChallengeTag("abc");
         assertEquals("challenge", cTag.getCode());
-        assertEquals("abc", ((GenericTag) cTag).getAttributes().get(0).getValue());
+        assertEquals("abc", ((GenericTag) cTag).getAttributes().get(0).value());
     }
 }

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP60Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP60Test.java
@@ -90,12 +90,12 @@ public class NIP60Test {
 
         // First tag should be balance
         Assertions.assertEquals("balance", contentTags[0].getCode());
-        Assertions.assertEquals("100", contentTags[0].getAttributes().get(0).getValue());
-        Assertions.assertEquals("sat", contentTags[0].getAttributes().get(1).getValue());
+        Assertions.assertEquals("100", contentTags[0].getAttributes().get(0).value());
+        Assertions.assertEquals("sat", contentTags[0].getAttributes().get(1).value());
 
         // Second tag should be privkey
         Assertions.assertEquals("privkey", contentTags[1].getCode());
-        Assertions.assertEquals("hexkey", contentTags[1].getAttributes().get(0).getValue());
+        Assertions.assertEquals("hexkey", contentTags[1].getAttributes().get(0).value());
     }
 
     @Test
@@ -203,13 +203,13 @@ public class NIP60Test {
         // Assert direction
         GenericTag directionTag = (GenericTag) contentTags[0];
         Assertions.assertEquals("direction", directionTag.getCode());
-        Assertions.assertEquals("in", directionTag.getAttributes().get(0).getValue().toString());
+        Assertions.assertEquals("in", directionTag.getAttributes().get(0).value().toString());
 
         // Assert amount
         GenericTag amountTag = (GenericTag) contentTags[1];
         Assertions.assertEquals("amount", amountTag.getCode());
-        Assertions.assertEquals("1", amountTag.getAttributes().get(0).getValue());
-        Assertions.assertEquals("sat", amountTag.getAttributes().get(1).getValue());
+        Assertions.assertEquals("1", amountTag.getAttributes().get(0).value());
+        Assertions.assertEquals("sat", amountTag.getAttributes().get(1).value());
 
         // Assert event
         EventTag eTag = (EventTag) contentTags[2];
@@ -256,7 +256,7 @@ public class NIP60Test {
         // Assert CashuMint tag
         GenericTag mintTag = (GenericTag) tags.get(1);
         Assertions.assertEquals("mint", mintTag.getCode());
-        Assertions.assertEquals("<mint-url>", mintTag.getAttributes().get(0).getValue());
+        Assertions.assertEquals("<mint-url>", mintTag.getAttributes().get(0).value());
 
         // Assert a-tag
         AddressTag aTag = (AddressTag) tags.get(2);
@@ -267,14 +267,14 @@ public class NIP60Test {
 
     private String getMintUrl(@NonNull BaseTag tag) {
         if (tag instanceof GenericTag mintTag) {
-            return mintTag.getAttributes().get(0).getValue().toString();
+            return mintTag.getAttributes().get(0).value().toString();
         }
         return null;
     }
 
     private String getRelayUrl(@NonNull BaseTag tag) {
         if (tag instanceof GenericTag relayTag) {
-            return relayTag.getAttributes().get(0).getValue().toString();
+            return relayTag.getAttributes().get(0).value().toString();
         }
         return null;
     }

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP61Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP61Test.java
@@ -52,8 +52,8 @@ public class NIP61Test {
                 .map(tag -> (GenericTag) tag)
                 .toList();
         Assertions.assertEquals(2, pubkeyTags.size());
-        Assertions.assertEquals("pubkey1", pubkeyTags.get(0).getAttributes().get(0).getValue());
-        Assertions.assertEquals("pubkey2", pubkeyTags.get(1).getAttributes().get(0).getValue());
+        Assertions.assertEquals("pubkey1", pubkeyTags.get(0).getAttributes().get(0).value());
+        Assertions.assertEquals("pubkey2", pubkeyTags.get(1).getAttributes().get(0).value());
 
         // Verify relay tags
         List<GenericTag> relayTags = tags.stream()
@@ -61,8 +61,8 @@ public class NIP61Test {
                 .map(tag -> (GenericTag) tag)
                 .toList();
         Assertions.assertEquals(2, relayTags.size());
-        Assertions.assertEquals("wss://relay1.example.com", relayTags.get(0).getAttributes().get(0).getValue());
-        Assertions.assertEquals("wss://relay2.example.com", relayTags.get(1).getAttributes().get(0).getValue());
+        Assertions.assertEquals("wss://relay1.example.com", relayTags.get(0).getAttributes().get(0).value());
+        Assertions.assertEquals("wss://relay2.example.com", relayTags.get(1).getAttributes().get(0).value());
 
         // Verify mint tags
         List<GenericTag> mintTags = tags.stream()
@@ -70,8 +70,8 @@ public class NIP61Test {
                 .map(tag -> (GenericTag) tag)
                 .toList();
         Assertions.assertEquals(2, mintTags.size());
-        Assertions.assertEquals("https://mint1.example.com", mintTags.get(0).getAttributes().get(0).getValue());
-        Assertions.assertEquals("https://mint2.example.com", mintTags.get(1).getAttributes().get(0).getValue());
+        Assertions.assertEquals("https://mint1.example.com", mintTags.get(0).getAttributes().get(0).value());
+        Assertions.assertEquals("https://mint2.example.com", mintTags.get(1).getAttributes().get(0).value());
     }
 
     @SneakyThrows
@@ -126,7 +126,7 @@ public class NIP61Test {
                 .toList();
         assertInstanceOf(GenericTag.class, amountTags.get(0));
         Assertions.assertEquals(1, amountTags.size());
-        Assertions.assertEquals("100", ((GenericTag) amountTags.get(0)).getAttributes().get(0).getValue());
+        Assertions.assertEquals("100", ((GenericTag) amountTags.get(0)).getAttributes().get(0).value());
 
         // Verify unit tag
         List<BaseTag> unitTags = tags.stream()
@@ -134,7 +134,7 @@ public class NIP61Test {
                 .toList();
         assertInstanceOf(GenericTag.class, unitTags.get(0));
         Assertions.assertEquals(1, unitTags.size());
-        Assertions.assertEquals("sat", ((GenericTag) unitTags.get(0)).getAttributes().get(0).getValue());
+        Assertions.assertEquals("sat", ((GenericTag) unitTags.get(0)).getAttributes().get(0).value());
 
         // Verify pubkey tag
         List<BaseTag> pubkeyTags = tags.stream()
@@ -155,7 +155,7 @@ public class NIP61Test {
         BaseTag p2pkTag = NIP61.createP2pkTag(pubkey);
         assertInstanceOf(GenericTag.class, p2pkTag);
         Assertions.assertEquals("pubkey", p2pkTag.getCode());
-        Assertions.assertEquals(pubkey, ((GenericTag) p2pkTag).getAttributes().get(0).getValue());
+        Assertions.assertEquals(pubkey, ((GenericTag) p2pkTag).getAttributes().get(0).value());
 
         // Test URL tag creation
         String url = "https://example.com";
@@ -170,6 +170,6 @@ public class NIP61Test {
         BaseTag proofTag = NIP61.createProofTag(proof);
         assertInstanceOf(GenericTag.class, proofTag);
         Assertions.assertEquals("proof", proofTag.getCode());
-        Assertions.assertTrue(((GenericTag) proofTag).getAttributes().get(0).getValue().toString().contains("test-proof-id"));
+        Assertions.assertTrue(((GenericTag) proofTag).getAttributes().get(0).value().toString().contains("test-proof-id"));
     }
 }

--- a/nostr-java-base/src/main/java/nostr/base/ElementAttribute.java
+++ b/nostr-java-base/src/main/java/nostr/base/ElementAttribute.java
@@ -1,32 +1,9 @@
 package nostr.base;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NonNull;
-import lombok.ToString;
-
 /**
+ * Element attribute consisting of a name and value.
  *
- * @author squirrel
+ * @param name attribute name
+ * @param value attribute value
  */
-@Builder
-@Data
-@ToString
-@EqualsAndHashCode
-@AllArgsConstructor
-public class ElementAttribute {
-
-    @JsonProperty    
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @EqualsAndHashCode.Include
-    @NonNull
-    private final String name;
-    
-    @JsonProperty
-    @EqualsAndHashCode.Include
-    private final Object value;
-}
+public record ElementAttribute(String name, Object value) {}

--- a/nostr-java-base/src/main/java/nostr/base/GenericElementUtil.java
+++ b/nostr-java-base/src/main/java/nostr/base/GenericElementUtil.java
@@ -26,11 +26,11 @@ public class GenericElementUtil {
 
     public Object getAttributeValue(int index) {
         var attribute = getAttribute(index);
-        return attribute.getValue();
+        return attribute.value();
     }
 
     public String getAttributeName(int index) {
         var attribute = getAttribute(index);
-        return attribute.getName();
+        return attribute.name();
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/filter/GenericTagQueryFilter.java
+++ b/nostr-java-event/src/main/java/nostr/event/filter/GenericTagQueryFilter.java
@@ -27,7 +27,7 @@ public class GenericTagQueryFilter<T extends GenericTagQuery> extends AbstractFi
                         .anyMatch(genericTag ->
                                 genericTag
                                         .getAttributes().stream().map(
-                                                ElementAttribute::getValue).toList()
+                                                ElementAttribute::value).toList()
                                         .contains(
                                                 getFilterableValue()));
     }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CalendarDateBasedEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CalendarDateBasedEvent.java
@@ -71,16 +71,16 @@ public class CalendarDateBasedEvent<T extends BaseTag> extends AbstractBaseCalen
     protected CalendarContent<T> getCalendarContent() {
         CalendarContent<T> calendarContent = new CalendarContent<>(
             (IdentifierTag) getTag("d"),
-            ((GenericTag) getTag("title")).getAttributes().get(0).getValue().toString(),
-            Long.parseLong(((GenericTag) getTag("start")).getAttributes().get(0).getValue().toString())
+            ((GenericTag) getTag("title")).getAttributes().get(0).value().toString(),
+            Long.parseLong(((GenericTag) getTag("start")).getAttributes().get(0).value().toString())
         );
 
         // Update the calendarContent object with the values from the tags
         Optional.ofNullable(getTag("end")).ifPresent(baseTag -> 
-            calendarContent.setEnd(Long.parseLong(((GenericTag) baseTag).getAttributes().get(0).getValue().toString())));
+            calendarContent.setEnd(Long.parseLong(((GenericTag) baseTag).getAttributes().get(0).value().toString())));
         
         Optional.ofNullable(getTag("location")).ifPresent(baseTag ->
-            calendarContent.setLocation(((GenericTag) baseTag).getAttributes().get(0).getValue().toString()));
+            calendarContent.setLocation(((GenericTag) baseTag).getAttributes().get(0).value().toString()));
 
         Optional.ofNullable(getTag("g")).ifPresent(baseTag -> calendarContent.setGeohashTag((GeohashTag) baseTag));
 

--- a/nostr-java-event/src/main/java/nostr/event/impl/CalendarEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CalendarEvent.java
@@ -54,7 +54,7 @@ public class CalendarEvent extends AbstractBaseCalendarEvent<JsonContent> {
 
         CalendarContent<BaseTag> calendarContent = new CalendarContent<>(
                 (IdentifierTag) identifierTag,
-                ((GenericTag)titleTag).getAttributes().get(0).getValue().toString(),
+                ((GenericTag)titleTag).getAttributes().get(0).value().toString(),
                 -1L);
 
         List<BaseTag> aTags = getTags("a");

--- a/nostr-java-event/src/main/java/nostr/event/impl/CalendarRsvpEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CalendarRsvpEvent.java
@@ -68,7 +68,7 @@ public class CalendarRsvpEvent extends AbstractBaseCalendarEvent<CalendarRsvpCon
     }
 
     public Optional<FB> getFB() {
-        return getCalendarContent().getFbTag().map(fbTag -> fbTag.getAttributes().get(0).getValue().toString().toUpperCase()).map(FB::valueOf);
+        return getCalendarContent().getFbTag().map(fbTag -> fbTag.getAttributes().get(0).value().toString().toUpperCase()).map(FB::valueOf);
     }
 
     public Optional<String> getEventId() {
@@ -88,7 +88,7 @@ public class CalendarRsvpEvent extends AbstractBaseCalendarEvent<CalendarRsvpCon
         CalendarRsvpContent calendarRsvpContent = CalendarRsvpContent.builder(
                 (IdentifierTag) getTag("d"),
                 (AddressTag) getTag("a"),
-                ((GenericTag) getTag("status")).getAttributes().get(0).getValue().toString()
+                ((GenericTag) getTag("status")).getAttributes().get(0).value().toString()
         ).build();
 
         Optional.ofNullable(getTag("e")).ifPresent(baseTag -> calendarRsvpContent.setEventTag((EventTag) baseTag));

--- a/nostr-java-event/src/main/java/nostr/event/impl/CalendarTimeBasedEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CalendarTimeBasedEvent.java
@@ -52,10 +52,10 @@ public class CalendarTimeBasedEvent<T extends BaseTag> extends CalendarDateBased
         CalendarContent<T> calendarContent = super.getCalendarContent();
 
         // Update the calendarContent object with the values from the tags
-        calendarContent.setStartTzid(((GenericTag)getTag("start_tzid")).getAttributes().get(0).getValue().toString());
-        calendarContent.setEndTzid(((GenericTag) getTag("end_tzid")).getAttributes().get(0).getValue().toString());
-        calendarContent.setSummary(((GenericTag) getTag("summary")).getAttributes().get(0).getValue().toString());
-        calendarContent.setLocation(((GenericTag) getTag("location")).getAttributes().get(0).getValue().toString());
+        calendarContent.setStartTzid(((GenericTag)getTag("start_tzid")).getAttributes().get(0).value().toString());
+        calendarContent.setEndTzid(((GenericTag) getTag("end_tzid")).getAttributes().get(0).value().toString());
+        calendarContent.setSummary(((GenericTag) getTag("summary")).getAttributes().get(0).value().toString());
+        calendarContent.setLocation(((GenericTag) getTag("location")).getAttributes().get(0).value().toString());
         getTags("l").forEach(baseTag -> calendarContent.addLabelTag((LabelTag) baseTag));
 
         return calendarContent;

--- a/nostr-java-event/src/main/java/nostr/event/impl/CanonicalAuthenticationEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CanonicalAuthenticationEvent.java
@@ -25,7 +25,7 @@ public class CanonicalAuthenticationEvent extends EphemeralEvent {
     public String getChallenge() {
         BaseTag challengeTag = getTag("challenge");
         if (challengeTag != null && !((GenericTag) challengeTag).getAttributes().isEmpty()) {
-            return ((GenericTag) challengeTag).getAttributes().get(0).getValue().toString();
+            return ((GenericTag) challengeTag).getAttributes().get(0).value().toString();
         }
         return null;
     }
@@ -33,7 +33,7 @@ public class CanonicalAuthenticationEvent extends EphemeralEvent {
     public Relay getRelay() {
         BaseTag relayTag = getTag("relay");
         if (relayTag != null && !((GenericTag) relayTag).getAttributes().isEmpty()) {
-            return new Relay(((GenericTag) relayTag).getAttributes().get(0).getValue().toString());
+            return new Relay(((GenericTag) relayTag).getAttributes().get(0).value().toString());
         }
         return null;
     }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ClassifiedListingEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ClassifiedListingEvent.java
@@ -42,32 +42,32 @@ public class ClassifiedListingEvent extends NIP99Event {
 
     public Instant getPublishedAt() {
         BaseTag publishedAtTag = getTag("published_at");
-        return Instant.ofEpochSecond(Long.parseLong(((GenericTag) publishedAtTag).getAttributes().get(0).getValue().toString()));
+        return Instant.ofEpochSecond(Long.parseLong(((GenericTag) publishedAtTag).getAttributes().get(0).value().toString()));
     }
 
     public String getLocation() {
         BaseTag locationTag = getTag("location");
-        return ((GenericTag) locationTag).getAttributes().get(0).getValue().toString();
+        return ((GenericTag) locationTag).getAttributes().get(0).value().toString();
     }
 
     public String getTitle() {
         BaseTag titleTag = getTag("title");
-        return ((GenericTag) titleTag).getAttributes().get(0).getValue().toString();
+        return ((GenericTag) titleTag).getAttributes().get(0).value().toString();
     }
 
     public String getSummary() {
         BaseTag summaryTag = getTag("summary");
-        return ((GenericTag) summaryTag).getAttributes().get(0).getValue().toString();
+        return ((GenericTag) summaryTag).getAttributes().get(0).value().toString();
     }
 
     public String getImage() {
         BaseTag imageTag = getTag("image");
-        return ((GenericTag) imageTag).getAttributes().get(0).getValue().toString();
+        return ((GenericTag) imageTag).getAttributes().get(0).value().toString();
     }
 
     public Status getStatus() {
         BaseTag statusTag = getTag("status");
-        String status = ((GenericTag) statusTag).getAttributes().get(0).getValue().toString();
+        String status = ((GenericTag) statusTag).getAttributes().get(0).value().toString();
         return Status.valueOf(status);
     }
 
@@ -91,7 +91,7 @@ public class ClassifiedListingEvent extends NIP99Event {
             throw new AssertionError("Missing `published_at` tag for the publication date/time.");
         }
         try {
-            Long.parseLong(((GenericTag) publishedAtTag).getAttributes().get(0).getValue().toString());
+            Long.parseLong(((GenericTag) publishedAtTag).getAttributes().get(0).value().toString());
         } catch (NumberFormatException e) {
             throw new AssertionError("Invalid `published_at` tag value: must be a numeric timestamp.");
         }

--- a/nostr-java-event/src/main/java/nostr/event/impl/MerchantEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/MerchantEvent.java
@@ -36,7 +36,7 @@ public abstract class MerchantEvent<T extends NIP15Content.MerchantContent> exte
             throw new AssertionError("Missing `d` tag.");
         }
 
-        String id = ((GenericTag) dTag).getAttributes().getFirst().getValue().toString();
+        String id = ((GenericTag) dTag).getAttributes().getFirst().value().toString();
         String entityId = getEntity().getId();
         if (!id.equals(entityId)) {
             throw new AssertionError("The d-tag value MUST be the same as the stall id.");

--- a/nostr-java-event/src/main/java/nostr/event/impl/NutZapEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/NutZapEvent.java
@@ -96,13 +96,13 @@ public class NutZapEvent extends GenericEvent {
     }
 
     private CashuMint getMintFromTag(GenericTag mintTag) {
-        String url = mintTag.getAttributes().get(0).getValue().toString();
+        String url = mintTag.getAttributes().get(0).value().toString();
         CashuMint mint = new CashuMint(url);
         return mint;
     }
 
     private CashuProof getProofFromTag(GenericTag proofTag) {
-        String proof = proofTag.getAttributes().get(0).getValue().toString();
+        String proof = proofTag.getAttributes().get(0).value().toString();
         CashuProof cashuProof = IEvent.MAPPER_AFTERBURNER.convertValue(proof, CashuProof.class);
         return cashuProof;
     }

--- a/nostr-java-event/src/main/java/nostr/event/impl/NutZapInformationalEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/NutZapInformationalEvent.java
@@ -44,7 +44,7 @@ public class NutZapInformationalEvent extends ReplaceableEvent {
         nutZapInformation.setMints(mintTags.stream()
                 .map(this::getMintFromTag)
                 .toList());
-        nutZapInformation.setP2pkPubkey(p2pkTag.getAttributes().get(0).getValue().toString());
+        nutZapInformation.setP2pkPubkey(p2pkTag.getAttributes().get(0).value().toString());
 
         return nutZapInformation;
     }
@@ -83,12 +83,12 @@ public class NutZapInformationalEvent extends ReplaceableEvent {
     }
 
     private Relay getRelayFromTag(@NonNull GenericTag tag) {
-        String url = tag.getAttributes().get(0).getValue().toString();
+        String url = tag.getAttributes().get(0).value().toString();
         return new Relay(url);
     }
 
     private CashuMint getMintFromTag(@NonNull GenericTag tag) {
-        String mintUrl = tag.getAttributes().get(0).getValue().toString();
+        String mintUrl = tag.getAttributes().get(0).value().toString();
         return new CashuMint(mintUrl);
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ZapReceiptEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ZapReceiptEvent.java
@@ -29,9 +29,9 @@ public class ZapReceiptEvent extends GenericEvent {
         BaseTag bolt11Tag = requireTag("bolt11");
 
         return new ZapReceipt(
-                ((GenericTag) bolt11Tag).getAttributes().get(0).getValue().toString(),
-                ((GenericTag) descriptionTag).getAttributes().get(0).getValue().toString(),
-                ((GenericTag) preimageTag).getAttributes().get(0).getValue().toString()
+                ((GenericTag) bolt11Tag).getAttributes().get(0).value().toString(),
+                ((GenericTag) descriptionTag).getAttributes().get(0).value().toString(),
+                ((GenericTag) preimageTag).getAttributes().get(0).value().toString()
         );
     }
 
@@ -69,7 +69,7 @@ public class ZapReceiptEvent extends GenericEvent {
         if (eventTag == null) {
             return null;
         }
-        return ((GenericTag) eventTag).getAttributes().get(0).getValue().toString();
+        return ((GenericTag) eventTag).getAttributes().get(0).value().toString();
     }
 
     @Override

--- a/nostr-java-event/src/main/java/nostr/event/impl/ZapRequestEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ZapRequestEvent.java
@@ -32,8 +32,8 @@ public class ZapRequestEvent extends GenericEvent {
 
         return new ZapRequest(
                 (RelaysTag) relaysTag,
-                Long.parseLong(((GenericTag) amountTag).getAttributes().get(0).getValue().toString()),
-                ((GenericTag) lnUrlTag).getAttributes().get(0).getValue().toString()
+                Long.parseLong(((GenericTag) amountTag).getAttributes().get(0).value().toString()),
+                ((GenericTag) lnUrlTag).getAttributes().get(0).value().toString()
         );
     }
 
@@ -48,7 +48,7 @@ public class ZapRequestEvent extends GenericEvent {
     public String getEventId() {
         return this.getTags().stream()
                 .filter(tag -> "e".equals(tag.getCode()))
-                .map(tag -> ((GenericTag) tag).getAttributes().get(0).getValue().toString())
+                .map(tag -> ((GenericTag) tag).getAttributes().get(0).value().toString())
                 .findFirst()
                 .orElse(null);
     }

--- a/nostr-java-event/src/main/java/nostr/event/json/serializer/GenericTagSerializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/serializer/GenericTagSerializer.java
@@ -15,6 +15,6 @@ public class GenericTagSerializer<T extends GenericTag> extends AbstractTagSeria
 
 	@Override
 	protected void applyCustomAttributes(ObjectNode node, T value) {
-		value.getAttributes().forEach(a -> node.put(a.getName(), a.getValue().toString()));
-	}
+                value.getAttributes().forEach(a -> node.put(a.name(), a.value().toString()));
+        }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/serializer/TagSerializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/serializer/TagSerializer.java
@@ -25,7 +25,7 @@ public class TagSerializer extends AbstractTagSerializer<BaseTag> {
     protected void applyCustomAttributes(ObjectNode node, BaseTag value) {
         if (value instanceof GenericTag genericTag) {
             genericTag.getAttributes()
-                    .forEach(a -> node.put(a.getName(), a.getValue().toString()));
+                    .forEach(a -> node.put(a.name(), a.value().toString()));
         }
     }
 

--- a/nostr-java-event/src/main/java/nostr/event/message/CanonicalAuthenticationMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/CanonicalAuthenticationMessage.java
@@ -67,6 +67,6 @@ public class CanonicalAuthenticationMessage extends BaseAuthMessage {
     private static String getAttributeValue(List<GenericTag> genericTags, String attributeName) {
 //    TODO: stream optional
         return genericTags.stream()
-                .filter(tag -> tag.getCode().equalsIgnoreCase(attributeName)).map(GenericTag::getAttributes).toList().get(0).get(0).getValue().toString();
+                .filter(tag -> tag.getCode().equalsIgnoreCase(attributeName)).map(GenericTag::getAttributes).toList().get(0).get(0).value().toString();
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/message/GenericMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/GenericMessage.java
@@ -50,7 +50,7 @@ public class GenericMessage extends BaseMessage implements IGenericElement, IEle
     public String encode() throws JsonProcessingException {
         var encoderArrayNode = JsonNodeFactory.instance.arrayNode();
         encoderArrayNode.add(getCommand());
-        getAttributes().stream().map(ElementAttribute::getValue).forEach(v -> encoderArrayNode.add(v.toString()));
+        getAttributes().stream().map(ElementAttribute::value).forEach(v -> encoderArrayNode.add(v.toString()));
         return ENCODER_MAPPED_AFTERBURNER.writeValueAsString(encoderArrayNode);
     }
 
@@ -58,7 +58,7 @@ public class GenericMessage extends BaseMessage implements IGenericElement, IEle
         GenericMessage gm = new GenericMessage(msgArr[0].toString());
         for (int i = 1; i < msgArr.length; i++) {
             if (msgArr[i] instanceof String) {
-                gm.addAttribute(ElementAttribute.builder().value(msgArr[i]).build());
+                gm.addAttribute(new ElementAttribute(null, msgArr[i]));
             }
         }
         return (T) gm;

--- a/nostr-java-event/src/main/java/nostr/event/tag/AddressTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/AddressTag.java
@@ -57,7 +57,7 @@ public class AddressTag extends BaseTag {
 
         AddressTag addressTag = new AddressTag();
         List<ElementAttribute> attributes = tag.getAttributes();
-        String attr0 = attributes.get(0).getValue().toString();
+        String attr0 = attributes.get(0).value().toString();
         Integer kind = Integer.parseInt(attr0.split(":")[0]);
         PublicKey publicKey = new PublicKey(attr0.split(":")[1]);
         String id = attr0.split(":").length == 3 ? attr0.split(":")[2] : null;
@@ -66,7 +66,7 @@ public class AddressTag extends BaseTag {
         addressTag.setPublicKey(publicKey);
         addressTag.setIdentifierTag(id != null ? new IdentifierTag(id) : null);
         if (tag.getAttributes().size() == 2) {
-            addressTag.setRelay(new Relay(tag.getAttributes().get(1).getValue().toString()));
+            addressTag.setRelay(new Relay(tag.getAttributes().get(1).value().toString()));
         }
         return addressTag;
     }

--- a/nostr-java-event/src/main/java/nostr/event/tag/EmojiTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/EmojiTag.java
@@ -42,8 +42,8 @@ public class EmojiTag extends BaseTag {
             throw new IllegalArgumentException("Invalid tag code for EmojiTag");
         }
 
-        String shortcode = tag.getAttributes().get(0).getValue().toString();
-        String url = tag.getAttributes().get(1).getValue().toString();
+        String shortcode = tag.getAttributes().get(0).value().toString();
+        String url = tag.getAttributes().get(1).value().toString();
         EmojiTag emojiTag = new EmojiTag(shortcode, url);
         return emojiTag;
     }

--- a/nostr-java-event/src/main/java/nostr/event/tag/EventTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/EventTag.java
@@ -61,12 +61,12 @@ public class EventTag extends BaseTag {
         if (!"e".equals(tag.getCode())) {
             throw new IllegalArgumentException("Invalid tag code for EventTag");
         }
-        EventTag eventTag = new EventTag(tag.getAttributes().get(0).getValue().toString());
+        EventTag eventTag = new EventTag(tag.getAttributes().get(0).value().toString());
         if (tag.getAttributes().size() > 1) {
-            eventTag.setRecommendedRelayUrl(tag.getAttributes().get(1).getValue().toString());
+            eventTag.setRecommendedRelayUrl(tag.getAttributes().get(1).value().toString());
         }
         if (tag.getAttributes().size() > 2) {
-            eventTag.setMarker(Marker.valueOf(tag.getAttributes().get(2).getValue().toString()));
+            eventTag.setMarker(Marker.valueOf(tag.getAttributes().get(2).value().toString()));
         }
 
         return eventTag;

--- a/nostr-java-event/src/main/java/nostr/event/tag/ExpirationTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/ExpirationTag.java
@@ -40,7 +40,7 @@ public class ExpirationTag extends BaseTag {
         if (!"expiration".equals(tag.getCode())) {
             throw new IllegalArgumentException("Invalid tag code for ExpirationTag");
         }
-        String expiration = tag.getAttributes().get(0).getValue().toString();
+        String expiration = tag.getAttributes().get(0).value().toString();
         ExpirationTag expirationTag = new ExpirationTag(Integer.parseInt(expiration));
         return expirationTag;
     }

--- a/nostr-java-event/src/main/java/nostr/event/tag/GeohashTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/GeohashTag.java
@@ -43,7 +43,7 @@ public class GeohashTag extends BaseTag {
         }
 
         GeohashTag tag = new GeohashTag();
-        tag.setLocation(genericTag.getAttributes().get(0).getValue().toString());
+        tag.setLocation(genericTag.getAttributes().get(0).value().toString());
         return tag;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/HashtagTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/HashtagTag.java
@@ -43,7 +43,7 @@ public class HashtagTag extends BaseTag {
         }
 
         HashtagTag tag = new HashtagTag();
-        tag.setHashTag(genericTag.getAttributes().get(0).getValue().toString());
+        tag.setHashTag(genericTag.getAttributes().get(0).value().toString());
         return tag;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/IdentifierTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/IdentifierTag.java
@@ -34,7 +34,7 @@ public class IdentifierTag extends BaseTag {
     }
 
     public static IdentifierTag updateFields(@NonNull GenericTag tag) {
-        IdentifierTag identifierTag = new IdentifierTag(tag.getAttributes().get(0).getValue().toString());
+        IdentifierTag identifierTag = new IdentifierTag(tag.getAttributes().get(0).value().toString());
         return identifierTag;
     }
 

--- a/nostr-java-event/src/main/java/nostr/event/tag/LabelNamespaceTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/LabelNamespaceTag.java
@@ -29,7 +29,7 @@ public class LabelNamespaceTag extends BaseTag {
     }
 
     public static LabelNamespaceTag updateFields(@NonNull GenericTag tag) {
-        LabelNamespaceTag labelNamespaceTag = new LabelNamespaceTag(tag.getAttributes().get(0).getValue().toString());
+        LabelNamespaceTag labelNamespaceTag = new LabelNamespaceTag(tag.getAttributes().get(0).value().toString());
         return labelNamespaceTag;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/LabelTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/LabelTag.java
@@ -42,8 +42,8 @@ public class LabelTag extends BaseTag {
             throw new IllegalArgumentException("Invalid tag code for LabelTag");
         }
         LabelTag labelTag = new LabelTag();
-        labelTag.setLabel(tag.getAttributes().get(0).getValue().toString());
-        labelTag.setNameSpace(tag.getAttributes().get(1).getValue().toString());
+        labelTag.setLabel(tag.getAttributes().get(0).value().toString());
+        labelTag.setNameSpace(tag.getAttributes().get(1).value().toString());
         return labelTag;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/NonceTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/NonceTag.java
@@ -53,8 +53,8 @@ public class NonceTag extends BaseTag {
         }
 
         NonceTag tag = new NonceTag();
-        tag.setNonce(Integer.valueOf(genericTag.getAttributes().get(0).getValue().toString()));
-        tag.setDifficulty(Integer.valueOf(genericTag.getAttributes().get(1).getValue().toString()));
+        tag.setNonce(Integer.valueOf(genericTag.getAttributes().get(0).value().toString()));
+        tag.setDifficulty(Integer.valueOf(genericTag.getAttributes().get(1).value().toString()));
         return tag;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/PriceTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/PriceTag.java
@@ -72,11 +72,11 @@ public class PriceTag extends BaseTag {
         }
 
         PriceTag tag = new PriceTag();
-        tag.setNumber(new BigDecimal(genericTag.getAttributes().get(0).getValue().toString()));
-        tag.setCurrency(genericTag.getAttributes().get(1).getValue().toString());
+        tag.setNumber(new BigDecimal(genericTag.getAttributes().get(0).value().toString()));
+        tag.setCurrency(genericTag.getAttributes().get(1).value().toString());
 
         if (genericTag.getAttributes().size() > 2) {
-            tag.setFrequency(genericTag.getAttributes().get(2).getValue().toString());
+            tag.setFrequency(genericTag.getAttributes().get(2).value().toString());
         }
         return tag;
     }

--- a/nostr-java-event/src/main/java/nostr/event/tag/PubKeyTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/PubKeyTag.java
@@ -67,10 +67,10 @@ public class PubKeyTag extends BaseTag {
             throw new IllegalArgumentException("Invalid tag code for PubKeyTag");
         }
 
-        PublicKey pubKey = new PublicKey(tag.getAttributes().get(0).getValue().toString());
+        PublicKey pubKey = new PublicKey(tag.getAttributes().get(0).value().toString());
 
-        String mainRelayUrl = tag.getAttributes().size() > 1 ? tag.getAttributes().get(1).getValue().toString() : null;
-        String petName = tag.getAttributes().size() > 2 ? tag.getAttributes().get(2).getValue().toString() : null;
+        String mainRelayUrl = tag.getAttributes().size() > 1 ? tag.getAttributes().get(1).value().toString() : null;
+        String petName = tag.getAttributes().size() > 2 ? tag.getAttributes().get(2).value().toString() : null;
         PubKeyTag pubKeyTag = new PubKeyTag(pubKey, mainRelayUrl, petName);
         return pubKeyTag;
     }

--- a/nostr-java-event/src/main/java/nostr/event/tag/ReferenceTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/ReferenceTag.java
@@ -57,9 +57,9 @@ public class ReferenceTag extends BaseTag {
         }
 
         ReferenceTag tag = new ReferenceTag();
-        tag.setUri(URI.create(genericTag.getAttributes().get(0).getValue().toString()));
+        tag.setUri(URI.create(genericTag.getAttributes().get(0).value().toString()));
         if (genericTag.getAttributes().size() == 2) {
-            tag.setMarker(Marker.valueOf(genericTag.getAttributes().get(1).getValue().toString().toUpperCase()));
+            tag.setMarker(Marker.valueOf(genericTag.getAttributes().get(1).value().toString().toUpperCase()));
         } else {
             tag.setMarker(null);
         }

--- a/nostr-java-event/src/main/java/nostr/event/tag/RelaysTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/RelaysTag.java
@@ -47,7 +47,7 @@ public class RelaysTag extends BaseTag {
 
         List<Relay> relays = new ArrayList<>();
         for (ElementAttribute attribute : genericTag.getAttributes()) {
-            relays.add(new Relay(attribute.getValue().toString()));
+            relays.add(new Relay(attribute.value().toString()));
         }
 
         RelaysTag relaysTag = new RelaysTag(relays);

--- a/nostr-java-event/src/main/java/nostr/event/tag/SubjectTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/SubjectTag.java
@@ -42,7 +42,7 @@ public final class SubjectTag extends BaseTag {
             throw new IllegalArgumentException("Invalid tag code for SubjectTag");
         }
 
-        SubjectTag subjectTag = new SubjectTag(genericTag.getAttributes().get(0).getValue().toString());
+        SubjectTag subjectTag = new SubjectTag(genericTag.getAttributes().get(0).value().toString());
         return subjectTag;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/tag/UrlTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/UrlTag.java
@@ -38,7 +38,7 @@ public class UrlTag extends BaseTag {
         }
 
         UrlTag urlTag = new UrlTag();
-        urlTag.setUrl(tag.getAttributes().get(0).getValue().toString());
+        urlTag.setUrl(tag.getAttributes().get(0).value().toString());
 
         return urlTag;
     }

--- a/nostr-java-event/src/main/java/nostr/event/tag/VoteTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/VoteTag.java
@@ -35,7 +35,7 @@ public class VoteTag extends BaseTag {
             throw new IllegalArgumentException("Invalid tag code for VoteTag");
         }
 
-        VoteTag voteTag = new VoteTag(Integer.valueOf(genericTag.getAttributes().get(0).getValue().toString()));
+        VoteTag voteTag = new VoteTag(Integer.valueOf(genericTag.getAttributes().get(0).value().toString()));
         return voteTag;
     }
 }

--- a/nostr-java-event/src/test/java/nostr/event/unit/BaseTagTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/BaseTagTest.java
@@ -241,7 +241,7 @@ class BaseTagTest {
 
     @Test
     void testToString() {
-        String result = "GenericTag(code=id, attributes=[ElementAttribute(name=param0, value=value)])";
+        String result = "GenericTag(code=id, attributes=[ElementAttribute[name=param0, value=value]])";
         assertInstanceOf(GenericTag.class, genericTag);
         assertEquals(result, genericTag.toString());
     }

--- a/nostr-java-event/src/test/java/nostr/event/unit/GenericTagTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/GenericTagTest.java
@@ -19,6 +19,6 @@ public class GenericTagTest {
 
         assertInstanceOf(GenericTag.class, tag);
         assertEquals(code, tag.getCode());
-        assertEquals("test-value", ((GenericTag)tag).getAttributes().get(0).getValue());
+        assertEquals("test-value", ((GenericTag)tag).getAttributes().get(0).value());
     }
 }

--- a/nostr-java-event/src/test/java/nostr/event/unit/TagDeserializerTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/TagDeserializerTest.java
@@ -66,6 +66,6 @@ class TagDeserializerTest {
         assertInstanceOf(GenericTag.class, tag);
         GenericTag gTag = (GenericTag) tag;
         assertEquals("unknown", gTag.getCode());
-        assertEquals("value", gTag.getAttributes().get(0).getValue());
+        assertEquals("value", gTag.getAttributes().get(0).value());
     }
 }

--- a/nostr-java-event/src/test/java/nostr/event/unit/TagRegistryTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/TagRegistryTest.java
@@ -21,7 +21,7 @@ class TagRegistryTest {
 
         static CustomTag updateFields(GenericTag genericTag) {
             CustomTag tag = new CustomTag();
-            tag.value = genericTag.getAttributes().get(0).getValue().toString();
+            tag.value = genericTag.getAttributes().get(0).value().toString();
             return tag;
         }
     }

--- a/nostr-java-id/src/test/java/nostr/id/EntityFactory.java
+++ b/nostr-java-id/src/test/java/nostr/id/EntityFactory.java
@@ -122,7 +122,7 @@ public class EntityFactory {
 
         public static GenericTag createGenericTag(PublicKey publicKey, IEvent event) {
             GenericTag tag = new GenericTag("devil");
-            tag.addAttribute(ElementAttribute.builder().name("param0").value("Lucifer").build());
+            tag.addAttribute(new ElementAttribute("param0", "Lucifer"));
             ((GenericEvent) event).addTag(tag);
             return tag;
         }
@@ -135,7 +135,7 @@ public class EntityFactory {
         @Deprecated(forRemoval = true)
         public static GenericTag createGenericTag(PublicKey publicKey, IEvent event, Integer tagNip) {
             GenericTag tag = new GenericTag("devil");
-            tag.addAttribute(ElementAttribute.builder().name("param0").value("Lucifer").build());
+            tag.addAttribute(new ElementAttribute("param0", "Lucifer"));
             ((GenericEvent) event).addTag(tag);
             return tag;
         }

--- a/nostr-java-id/src/test/java/nostr/id/EventTest.java
+++ b/nostr-java-id/src/test/java/nostr/id/EventTest.java
@@ -90,9 +90,9 @@ public class EventTest {
 
         GenericMessage msg = new GenericMessage("AUTH");
         String attr = "challenge-string";
-        msg.addAttribute(ElementAttribute.builder().name("challenge").value(attr).build());
+        msg.addAttribute(new ElementAttribute("challenge", attr));
 
-        var muattr = (msg.getAttributes().getFirst().getValue()).toString();
+        var muattr = (msg.getAttributes().getFirst().value()).toString();
         assertEquals(attr, muattr);
     }
 


### PR DESCRIPTION
## Summary
- replace ElementAttribute class with Java record
- drop Lombok usage and update accessors to record components
- adjust call sites and tests to use new constructor and `value()` accessors

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*


------
https://chatgpt.com/codex/tasks/task_b_6899413196f0833196ea7a9c37278140