### PR TITLE
Rename Afterburner mapper constant to Blackbird

### DIFF
--- a/nostr-java-api/src/main/java/nostr/api/NIP05.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP05.java
@@ -16,7 +16,7 @@ import nostr.util.validator.Nip05Validator;
 
 import java.util.ArrayList;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static nostr.util.NostrUtil.escapeJsonString;
 
 /**
@@ -44,7 +44,7 @@ public class NIP05 extends EventNostr {
 
 	private String getContent(UserProfile profile) {
 		try {
-			String jsonString = MAPPER_AFTERBURNER.writeValueAsString(new Nip05Validator(profile.getNip05(), profile.getPublicKey().toString()));
+			String jsonString = MAPPER_BLACKBIRD.writeValueAsString(new Nip05Validator(profile.getNip05(), profile.getPublicKey().toString()));
 			return escapeJsonString(jsonString);
 		} catch (JsonProcessingException ex) {
 			throw new RuntimeException(ex);

--- a/nostr-java-api/src/main/java/nostr/api/NIP28.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP28.java
@@ -189,7 +189,7 @@ public class NIP28 extends EventNostr {
 
         public String toString() {
             try {
-                return IEvent.MAPPER_AFTERBURNER.writeValueAsString(this);
+                return IEvent.MAPPER_BLACKBIRD.writeValueAsString(this);
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }

--- a/nostr-java-api/src/main/java/nostr/api/NIP46.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP46.java
@@ -16,7 +16,7 @@ import java.io.Serializable;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 @Slf4j
 public final class NIP46 extends EventNostr {
@@ -68,7 +68,7 @@ public final class NIP46 extends EventNostr {
 
         public String toString() {
             try {
-                return MAPPER_AFTERBURNER.writeValueAsString(this);
+                return MAPPER_BLACKBIRD.writeValueAsString(this);
             } catch (JsonProcessingException ex) {
                 log.warn("Error converting request to JSON: {}", ex.getMessage());
                 return "{}"; // Return an empty JSON object as a fallback
@@ -77,7 +77,7 @@ public final class NIP46 extends EventNostr {
 
         public static Request fromString(@NonNull String jsonString) {
             try {
-                return MAPPER_AFTERBURNER.readValue(jsonString, Request.class);
+                return MAPPER_BLACKBIRD.readValue(jsonString, Request.class);
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }
@@ -95,7 +95,7 @@ public final class NIP46 extends EventNostr {
 
         public String toString() {
             try {
-                return MAPPER_AFTERBURNER.writeValueAsString(this);
+                return MAPPER_BLACKBIRD.writeValueAsString(this);
             } catch (JsonProcessingException ex) {
                 log.warn("Error converting response to JSON: {}", ex.getMessage());
                 return "{}"; // Return an empty JSON object as a fallback
@@ -104,7 +104,7 @@ public final class NIP46 extends EventNostr {
 
         public static Response fromString(@NonNull String jsonString) {
             try {
-                return MAPPER_AFTERBURNER.readValue(jsonString, Response.class);
+                return MAPPER_BLACKBIRD.readValue(jsonString, Response.class);
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }

--- a/nostr-java-api/src/main/java/nostr/api/NIP57.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP57.java
@@ -134,7 +134,7 @@ public class NIP57 extends EventNostr {
         genericEvent.addTag(NIP01.createPubKeyTag(zapRecipient));
 
         // Zap receipt tags
-        String descriptionSha256 = IEvent.MAPPER_AFTERBURNER.writeValueAsString(zapRequestEvent);
+        String descriptionSha256 = IEvent.MAPPER_BLACKBIRD.writeValueAsString(zapRequestEvent);
         genericEvent.addTag(createDescriptionTag(StringEscapeUtils.escapeJson(descriptionSha256)));
         genericEvent.addTag(createBolt11Tag(bolt11));
         genericEvent.addTag(createPreImageTag(preimage));

--- a/nostr-java-api/src/main/java/nostr/api/NIP60.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP60.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 public class NIP60 extends EventNostr {
 
@@ -136,12 +136,12 @@ public class NIP60 extends EventNostr {
         unitSet.forEach(u -> tags.add(NIP60.createBalanceTag(wallet.getBalance(), u)));
         tags.add(NIP60.createPrivKeyTag(wallet.getPrivateKey()));
 
-        return NIP44.encrypt(getSender(), MAPPER_AFTERBURNER.writeValueAsString(tags), getSender().getPublicKey());
+        return NIP44.encrypt(getSender(), MAPPER_BLACKBIRD.writeValueAsString(tags), getSender().getPublicKey());
     }
 
     @SneakyThrows
     private String getTokenEventContent(@NonNull CashuToken token) {
-        return NIP44.encrypt(getSender(), MAPPER_AFTERBURNER.writeValueAsString(token), getSender().getPublicKey());
+        return NIP44.encrypt(getSender(), MAPPER_BLACKBIRD.writeValueAsString(token), getSender().getPublicKey());
     }
 
     @SneakyThrows

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiEventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiEventIT.java
@@ -53,7 +53,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -416,7 +416,7 @@ public class ApiEventIT extends BaseRelayIntegrationTest {
 
         // Fetch the content and compare with the above original
         var content = instance.getEvent().getContent();
-        var expected = MAPPER_AFTERBURNER.readValue(content, Stall.class);
+        var expected = MAPPER_BLACKBIRD.readValue(content, Stall.class);
 
         assertEquals(expected, stall);
     }

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiEventTestUsingSpringWebSocketClientIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiEventTestUsingSpringWebSocketClientIT.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import static nostr.api.integration.ApiEventIT.createProduct;
 import static nostr.api.integration.ApiEventIT.createStall;
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringJUnitConfig(RelayConfig.class)
@@ -64,13 +64,13 @@ class ApiEventTestUsingSpringWebSocketClientIT extends BaseRelayIntegrationTest 
             String eventResponse = client.send(message).stream().findFirst().orElseThrow();
 
             // Extract and compare only first 3 elements of the JSON array
-            var expectedArray = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(0).asText();
-            var expectedSubscriptionId = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(1).asText();
-            var expectedSuccess = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(2).asBoolean();
+            var expectedArray = MAPPER_BLACKBIRD.readTree(expectedResponseJson(event.getId())).get(0).asText();
+            var expectedSubscriptionId = MAPPER_BLACKBIRD.readTree(expectedResponseJson(event.getId())).get(1).asText();
+            var expectedSuccess = MAPPER_BLACKBIRD.readTree(expectedResponseJson(event.getId())).get(2).asBoolean();
 
-            var actualArray = MAPPER_AFTERBURNER.readTree(eventResponse).get(0).asText();
-            var actualSubscriptionId = MAPPER_AFTERBURNER.readTree(eventResponse).get(1).asText();
-            var actualSuccess = MAPPER_AFTERBURNER.readTree(eventResponse).get(2).asBoolean();
+            var actualArray = MAPPER_BLACKBIRD.readTree(eventResponse).get(0).asText();
+            var actualSubscriptionId = MAPPER_BLACKBIRD.readTree(eventResponse).get(1).asText();
+            var actualSuccess = MAPPER_BLACKBIRD.readTree(eventResponse).get(2).asBoolean();
 
             assertEquals(expectedArray, actualArray, "First element should match");
             assertEquals(expectedSubscriptionId, actualSubscriptionId, "Subscription ID should match");

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52EventIT.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("test")
@@ -51,18 +51,18 @@ class ApiNIP52EventIT extends BaseRelayIntegrationTest {
     EventMessage message = new EventMessage(event);
 
     try (SpringWebSocketClient client = springWebSocketClient) {
-      var expectedJson = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId()));
+      var expectedJson = MAPPER_BLACKBIRD.readTree(expectedResponseJson(event.getId()));
       var actualJson =
-          MAPPER_AFTERBURNER.readTree(client.send(message).stream().findFirst().orElseThrow());
+          MAPPER_BLACKBIRD.readTree(client.send(message).stream().findFirst().orElseThrow());
 
       // Compare only first 3 elements of the JSON arrays
       assertTrue(
           JsonComparator.isEquivalentJson(
-              MAPPER_AFTERBURNER.createArrayNode()
+              MAPPER_BLACKBIRD.createArrayNode()
                   .add(expectedJson.get(0)) // OK Command
                   .add(expectedJson.get(1)) // event id
                   .add(expectedJson.get(2)), // Accepted?
-              MAPPER_AFTERBURNER.createArrayNode()
+              MAPPER_BLACKBIRD.createArrayNode()
                   .add(actualJson.get(0))
                   .add(actualJson.get(1))
                   .add(actualJson.get(2))));

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52RequestIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP52RequestIT.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ActiveProfiles("test")
@@ -113,13 +113,13 @@ class ApiNIP52RequestIT extends BaseRelayIntegrationTest {
       String eventResponse = springWebSocketEventClient.send(eventMessage).stream().findFirst().orElseThrow();
 
       // Extract and compare only first 3 elements of the JSON array
-      var expectedArray = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(0).asText();
-      var expectedSubscriptionId = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(1).asText();
-      var expectedSuccess = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(2).asBoolean();
+      var expectedArray = MAPPER_BLACKBIRD.readTree(expectedEventResponseJson(event.getId())).get(0).asText();
+      var expectedSubscriptionId = MAPPER_BLACKBIRD.readTree(expectedEventResponseJson(event.getId())).get(1).asText();
+      var expectedSuccess = MAPPER_BLACKBIRD.readTree(expectedEventResponseJson(event.getId())).get(2).asBoolean();
 
-      var actualArray = MAPPER_AFTERBURNER.readTree(eventResponse).get(0).asText();
-      var actualSubscriptionId = MAPPER_AFTERBURNER.readTree(eventResponse).get(1).asText();
-      var actualSuccess = MAPPER_AFTERBURNER.readTree(eventResponse).get(2).asBoolean();
+      var actualArray = MAPPER_BLACKBIRD.readTree(eventResponse).get(0).asText();
+      var actualSubscriptionId = MAPPER_BLACKBIRD.readTree(eventResponse).get(1).asText();
+      var actualSuccess = MAPPER_BLACKBIRD.readTree(eventResponse).get(2).asBoolean();
 
       assertEquals(expectedArray, actualArray, "First element should match");
       assertEquals(expectedSubscriptionId, actualSubscriptionId, "Subscription ID should match");
@@ -140,8 +140,8 @@ class ApiNIP52RequestIT extends BaseRelayIntegrationTest {
 /*
       assertTrue(
           JsonComparator.isEquivalentJson(
-              MAPPER_AFTERBURNER.readTree(expected),
-              MAPPER_AFTERBURNER.readTree(reqResponse)));
+              MAPPER_BLACKBIRD.readTree(expected),
+              MAPPER_BLACKBIRD.readTree(reqResponse)));
 */
     }
   }

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99EventIT.java
@@ -25,7 +25,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ActiveProfiles("test")
@@ -88,15 +88,15 @@ class ApiNIP99EventIT extends BaseRelayIntegrationTest {
     EventMessage message = new EventMessage(event);
 
     // Extract and compare only first 3 elements of the JSON array
-    var expectedArray = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(0).asText();
-    var expectedSubscriptionId = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(1).asText();
-    var expectedSuccess = MAPPER_AFTERBURNER.readTree(expectedResponseJson(event.getId())).get(2).asBoolean();
+    var expectedArray = MAPPER_BLACKBIRD.readTree(expectedResponseJson(event.getId())).get(0).asText();
+    var expectedSubscriptionId = MAPPER_BLACKBIRD.readTree(expectedResponseJson(event.getId())).get(1).asText();
+    var expectedSuccess = MAPPER_BLACKBIRD.readTree(expectedResponseJson(event.getId())).get(2).asBoolean();
 
     try (SpringWebSocketClient client = springWebSocketClient) {
       String eventResponse = client.send(message).stream().findFirst().get();
-      var actualArray = MAPPER_AFTERBURNER.readTree(eventResponse).get(0).asText();
-      var actualSubscriptionId = MAPPER_AFTERBURNER.readTree(eventResponse).get(1).asText();
-      var actualSuccess = MAPPER_AFTERBURNER.readTree(eventResponse).get(2).asBoolean();
+      var actualArray = MAPPER_BLACKBIRD.readTree(eventResponse).get(0).asText();
+      var actualSubscriptionId = MAPPER_BLACKBIRD.readTree(eventResponse).get(1).asText();
+      var actualSuccess = MAPPER_BLACKBIRD.readTree(eventResponse).get(2).asBoolean();
 
       assertEquals(expectedArray, actualArray, "First element should match");
       assertEquals(expectedSubscriptionId, actualSubscriptionId, "Subscription ID should match");

--- a/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99RequestIT.java
+++ b/nostr-java-api/src/test/java/nostr/api/integration/ApiNIP99RequestIT.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -103,13 +103,13 @@ class ApiNIP99RequestIT extends BaseRelayIntegrationTest {
       assertEquals(1, eventResponses.size(), "Expected 1 event response, but got " + eventResponses.size());
 
       // Extract and compare only first 3 elements of the JSON array
-      var expectedArray = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(0).asText();
-      var expectedSubscriptionId = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(1).asText();
-      var expectedSuccess = MAPPER_AFTERBURNER.readTree(expectedEventResponseJson(event.getId())).get(2).asBoolean();
+      var expectedArray = MAPPER_BLACKBIRD.readTree(expectedEventResponseJson(event.getId())).get(0).asText();
+      var expectedSubscriptionId = MAPPER_BLACKBIRD.readTree(expectedEventResponseJson(event.getId())).get(1).asText();
+      var expectedSuccess = MAPPER_BLACKBIRD.readTree(expectedEventResponseJson(event.getId())).get(2).asBoolean();
 
-      var actualArray = MAPPER_AFTERBURNER.readTree(eventResponses.getFirst()).get(0).asText();
-      var actualSubscriptionId = MAPPER_AFTERBURNER.readTree(eventResponses.getFirst()).get(1).asText();
-      var actualSuccess = MAPPER_AFTERBURNER.readTree(eventResponses.getFirst()).get(2).asBoolean();
+      var actualArray = MAPPER_BLACKBIRD.readTree(eventResponses.getFirst()).get(0).asText();
+      var actualSubscriptionId = MAPPER_BLACKBIRD.readTree(eventResponses.getFirst()).get(1).asText();
+      var actualSuccess = MAPPER_BLACKBIRD.readTree(eventResponses.getFirst()).get(2).asBoolean();
 
       assertEquals(expectedArray, actualArray, "First element should match");
       assertEquals(expectedSubscriptionId, actualSubscriptionId, "Subscription ID should match");
@@ -123,8 +123,8 @@ class ApiNIP99RequestIT extends BaseRelayIntegrationTest {
       String reqJson = createReqJson(UUID.randomUUID().toString(), eventId);
       List<String> reqResponses = springWebSocketRequestClient.send(reqJson).stream().toList();
 
-      var actualJson = MAPPER_AFTERBURNER.readTree(reqResponses.getFirst());
-      var expectedJson = MAPPER_AFTERBURNER.readTree(expectedRequestResponseJson());
+      var actualJson = MAPPER_BLACKBIRD.readTree(reqResponses.getFirst());
+      var expectedJson = MAPPER_BLACKBIRD.readTree(expectedRequestResponseJson());
 
       // Verify you receive the event
       assertEquals("EVENT", actualJson.get(0).asText(), "Event should be received, and not " + actualJson.get(0).asText());

--- a/nostr-java-api/src/test/java/nostr/api/unit/CalendarTimeBasedEventTest.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/CalendarTimeBasedEventTest.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -118,8 +118,8 @@ class CalendarTimeBasedEventTest {
 
     @Test
     void testCalendarTimeBasedEventEncoding() throws JsonProcessingException {
-        var instanceJson = MAPPER_AFTERBURNER.readTree(new BaseEventEncoder<>(instance).encode());
-        var expectedJson = MAPPER_AFTERBURNER.readTree(expectedEncodedJson);
+        var instanceJson = MAPPER_BLACKBIRD.readTree(new BaseEventEncoder<>(instance).encode());
+        var expectedJson = MAPPER_BLACKBIRD.readTree(expectedEncodedJson);
 
         // Helper function to find tag value
         BiFunction<JsonNode, String, JsonNode> findTagArray = (tags, tagName) -> {
@@ -139,11 +139,11 @@ class CalendarTimeBasedEventTest {
 
     @Test
     void testCalendarTimeBasedEventDecoding() throws JsonProcessingException {
-        var decodedJson = MAPPER_AFTERBURNER.readTree(
+        var decodedJson = MAPPER_BLACKBIRD.readTree(
             new BaseEventEncoder<>(
-                MAPPER_AFTERBURNER.readValue(expectedEncodedJson, GenericEvent.class))
+                MAPPER_BLACKBIRD.readValue(expectedEncodedJson, GenericEvent.class))
                 .encode());
-        var instanceJson = MAPPER_AFTERBURNER.readTree(new BaseEventEncoder<>(instance).encode());
+        var instanceJson = MAPPER_BLACKBIRD.readTree(new BaseEventEncoder<>(instance).encode());
 
         // Helper function to find tag value
         BiFunction<JsonNode, String, JsonNode> findTagArray = (tags, tagName) -> {

--- a/nostr-java-api/src/test/java/nostr/api/unit/ConstantsTest.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/ConstantsTest.java
@@ -6,7 +6,7 @@ import nostr.event.json.codec.BaseEventEncoder;
 import nostr.id.Identity;
 import org.junit.jupiter.api.Test;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConstantsTest {
@@ -35,6 +35,6 @@ public class ConstantsTest {
 
         String json = new BaseEventEncoder<>(event).encode();
         assertEquals(Constants.Kind.SHORT_TEXT_NOTE,
-                MAPPER_AFTERBURNER.readTree(json).get("kind").asInt());
+                MAPPER_BLACKBIRD.readTree(json).get("kind").asInt());
     }
 }

--- a/nostr-java-api/src/test/java/nostr/api/unit/JsonParseTest.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/JsonParseTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.util.List;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -652,11 +652,11 @@ public class JsonParseTest {
             new IdentifierTagFilter<>(new IdentifierTag(uuidValue2))));
 
     assertTrue(JsonComparator.isEquivalentJson(
-        MAPPER_AFTERBURNER.createArrayNode()
-            .add(MAPPER_AFTERBURNER.readTree(
+        MAPPER_BLACKBIRD.createArrayNode()
+            .add(MAPPER_BLACKBIRD.readTree(
                 expectedReqMessage.encode())),
-        MAPPER_AFTERBURNER.createArrayNode()
-            .add(MAPPER_AFTERBURNER.readTree(decodedReqMessage.encode()))));
+        MAPPER_BLACKBIRD.createArrayNode()
+            .add(MAPPER_BLACKBIRD.readTree(decodedReqMessage.encode()))));
     assertEquals(expectedReqMessage, decodedReqMessage);
   }
 

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP60Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP60Test.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 public class NIP60Test {
 
@@ -86,7 +86,7 @@ public class NIP60Test {
 
         // Decrypt and verify content
         String decryptedContent = NIP44.decrypt(sender, event.getContent(), sender.getPublicKey());
-        GenericTag[] contentTags = MAPPER_AFTERBURNER.readValue(decryptedContent, GenericTag[].class);
+        GenericTag[] contentTags = MAPPER_BLACKBIRD.readValue(decryptedContent, GenericTag[].class);
 
         // First tag should be balance
         Assertions.assertEquals("balance", contentTags[0].getCode());
@@ -146,7 +146,7 @@ public class NIP60Test {
 
         // Decrypt and verify content
         String decryptedContent = NIP44.decrypt(sender, event.getContent(), sender.getPublicKey());
-        CashuToken contentToken = MAPPER_AFTERBURNER.readValue(decryptedContent, CashuToken.class);
+        CashuToken contentToken = MAPPER_BLACKBIRD.readValue(decryptedContent, CashuToken.class);
         Assertions.assertEquals("https://stablenut.umint.cash", contentToken.getMint().getUrl());
 
         CashuProof proofContent = contentToken.getProofs().get(0);
@@ -198,7 +198,7 @@ public class NIP60Test {
 
         // Decrypt and verify content
         String decryptedContent = NIP44.decrypt(sender, event.getContent(), sender.getPublicKey());
-        BaseTag[] contentTags = MAPPER_AFTERBURNER.readValue(decryptedContent, BaseTag[].class);
+        BaseTag[] contentTags = MAPPER_BLACKBIRD.readValue(decryptedContent, BaseTag[].class);
 
         // Assert direction
         GenericTag directionTag = (GenericTag) contentTags[0];

--- a/nostr-java-base/src/main/java/nostr/base/IEvent.java
+++ b/nostr-java-base/src/main/java/nostr/base/IEvent.java
@@ -9,6 +9,6 @@ import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
  * @author squirrel
  */
 public interface IEvent extends IElement, IBech32Encodable {
-    ObjectMapper MAPPER_AFTERBURNER = JsonMapper.builder().addModule(new BlackbirdModule()).build();
+    ObjectMapper MAPPER_BLACKBIRD = JsonMapper.builder().addModule(new BlackbirdModule()).build();
     String getId();
 }

--- a/nostr-java-event/src/main/java/nostr/event/JsonContent.java
+++ b/nostr-java-event/src/main/java/nostr/event/JsonContent.java
@@ -2,7 +2,7 @@ package nostr.event;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 /**
  * @author eric
@@ -11,7 +11,7 @@ public interface JsonContent {
 
   default String value() {
     try {
-      return MAPPER_AFTERBURNER.writeValueAsString(this);
+      return MAPPER_BLACKBIRD.writeValueAsString(this);
     } catch (JsonProcessingException ex) {
       throw new RuntimeException(ex);
     }

--- a/nostr-java-event/src/main/java/nostr/event/entities/CashuProof.java
+++ b/nostr-java-event/src/main/java/nostr/event/entities/CashuProof.java
@@ -9,7 +9,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 @Data
 @NoArgsConstructor
@@ -36,6 +36,6 @@ public class CashuProof {
     @SneakyThrows
     @Override
     public String toString() {
-        return MAPPER_AFTERBURNER.writeValueAsString(this);
+        return MAPPER_BLACKBIRD.writeValueAsString(this);
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/entities/UserProfile.java
+++ b/nostr-java-event/src/main/java/nostr/event/entities/UserProfile.java
@@ -15,7 +15,7 @@ import nostr.base.PublicKey;
 import nostr.crypto.bech32.Bech32;
 import nostr.crypto.bech32.Bech32Prefix;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 /**
  *
@@ -52,7 +52,7 @@ public final class UserProfile extends Profile implements IBech32Encodable {
     @Override
     public String toString() {
         try {
-            return MAPPER_AFTERBURNER.writeValueAsString(this);
+            return MAPPER_BLACKBIRD.writeValueAsString(this);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/nostr-java-event/src/main/java/nostr/event/filter/Filterable.java
+++ b/nostr-java-event/src/main/java/nostr/event/filter/Filterable.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 public interface Filterable {
   Predicate<GenericEvent> getPredicate();
@@ -26,7 +26,7 @@ public interface Filterable {
   }
 
   default ObjectNode toObjectNode(ObjectNode objectNode) {
-    ArrayNode arrayNode = MAPPER_AFTERBURNER.createArrayNode();
+    ArrayNode arrayNode = MAPPER_BLACKBIRD.createArrayNode();
 
     Optional.ofNullable(objectNode.get(getFilterKey()))
         .ifPresent(jsonNode ->
@@ -39,7 +39,7 @@ public interface Filterable {
 
   default void addToArrayNode(ArrayNode arrayNode) {
     arrayNode.addAll(
-        MAPPER_AFTERBURNER.createArrayNode().add(
+        MAPPER_BLACKBIRD.createArrayNode().add(
             getFilterableValue().toString()));
   }
 }

--- a/nostr-java-event/src/main/java/nostr/event/filter/KindFilter.java
+++ b/nostr-java-event/src/main/java/nostr/event/filter/KindFilter.java
@@ -9,7 +9,7 @@ import nostr.event.impl.GenericEvent;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 @EqualsAndHashCode(callSuper = true)
 public class KindFilter<T extends Kind> extends AbstractFilterable<T> {
@@ -28,7 +28,7 @@ public class KindFilter<T extends Kind> extends AbstractFilterable<T> {
   @Override
   public void addToArrayNode(ArrayNode arrayNode) {
     arrayNode.addAll(
-        MAPPER_AFTERBURNER.createArrayNode().add(
+        MAPPER_BLACKBIRD.createArrayNode().add(
             getFilterableValue()));
   }
 

--- a/nostr-java-event/src/main/java/nostr/event/filter/SinceFilter.java
+++ b/nostr-java-event/src/main/java/nostr/event/filter/SinceFilter.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 @EqualsAndHashCode(callSuper = true)
 public class SinceFilter extends AbstractFilterable<Long> {
@@ -27,7 +27,7 @@ public class SinceFilter extends AbstractFilterable<Long> {
 
   @Override
   public ObjectNode toObjectNode(ObjectNode objectNode) {
-    return MAPPER_AFTERBURNER.createObjectNode().put(FILTER_KEY, getSince());
+    return MAPPER_BLACKBIRD.createObjectNode().put(FILTER_KEY, getSince());
   }
 
   @Override

--- a/nostr-java-event/src/main/java/nostr/event/filter/UntilFilter.java
+++ b/nostr-java-event/src/main/java/nostr/event/filter/UntilFilter.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 @EqualsAndHashCode(callSuper = true)
 public class UntilFilter extends AbstractFilterable<Long> {
@@ -27,7 +27,7 @@ public class UntilFilter extends AbstractFilterable<Long> {
 
   @Override
   public ObjectNode toObjectNode(ObjectNode objectNode) {
-    return MAPPER_AFTERBURNER.createObjectNode().put(FILTER_KEY, getUntil());
+    return MAPPER_BLACKBIRD.createObjectNode().put(FILTER_KEY, getUntil());
   }
 
   @Override

--- a/nostr-java-event/src/main/java/nostr/event/impl/ChannelCreateEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ChannelCreateEvent.java
@@ -24,7 +24,7 @@ public class ChannelCreateEvent extends GenericEvent {
     @SneakyThrows
     public ChannelProfile getChannelProfile() {
         String content = getContent();
-        return MAPPER_AFTERBURNER.readValue(content, ChannelProfile.class);
+        return MAPPER_BLACKBIRD.readValue(content, ChannelProfile.class);
     }
 
     @Override

--- a/nostr-java-event/src/main/java/nostr/event/impl/ChannelMetadataEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ChannelMetadataEvent.java
@@ -27,7 +27,7 @@ public class ChannelMetadataEvent extends GenericEvent {
     @SneakyThrows
     public ChannelProfile getChannelProfile() {
         String content = getContent();
-        return MAPPER_AFTERBURNER.readValue(content, ChannelProfile.class);
+        return MAPPER_BLACKBIRD.readValue(content, ChannelProfile.class);
     }
 
     @Override

--- a/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateProductEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateProductEvent.java
@@ -25,7 +25,7 @@ public class CreateOrUpdateProductEvent extends MerchantEvent<Product> {
 
     @SneakyThrows
     public Product getProduct() {
-        return IEvent.MAPPER_AFTERBURNER.readValue(getContent(), Product.class);
+        return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), Product.class);
     }
 
     protected Product getEntity() {

--- a/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateStallEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateStallEvent.java
@@ -30,7 +30,7 @@ public class CreateOrUpdateStallEvent extends MerchantEvent<Stall> {
 
     @SneakyThrows
     public Stall getStall() {
-        return IEvent.MAPPER_AFTERBURNER.readValue(getContent(), Stall.class);
+        return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), Stall.class);
     }
 
     @Override

--- a/nostr-java-event/src/main/java/nostr/event/impl/CustomerOrderEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CustomerOrderEvent.java
@@ -30,7 +30,7 @@ public class CustomerOrderEvent extends CheckoutEvent<CustomerOrder> {
 
     @SneakyThrows
     public CustomerOrder getCustomerOrder() {
-        return IEvent.MAPPER_AFTERBURNER.readValue(getContent(), CustomerOrder.class);
+        return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), CustomerOrder.class);
     }
 
     protected CustomerOrder getEntity() {

--- a/nostr-java-event/src/main/java/nostr/event/impl/InternetIdentifierMetadataEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/InternetIdentifierMetadataEvent.java
@@ -29,7 +29,7 @@ public final class InternetIdentifierMetadataEvent extends NIP05Event {
     @SneakyThrows
     public UserProfile getProfile() {
         String content = getContent();
-        return MAPPER_AFTERBURNER.readValue(content, UserProfile.class);
+        return MAPPER_BLACKBIRD.readValue(content, UserProfile.class);
     }
 
     @Override

--- a/nostr-java-event/src/main/java/nostr/event/impl/MerchantRequestPaymentEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/MerchantRequestPaymentEvent.java
@@ -27,7 +27,7 @@ public class MerchantRequestPaymentEvent extends CheckoutEvent<PaymentRequest> {
     }
 
     public PaymentRequest getPaymentRequest() {
-        return IEvent.MAPPER_AFTERBURNER.convertValue(getContent(), PaymentRequest.class);
+        return IEvent.MAPPER_BLACKBIRD.convertValue(getContent(), PaymentRequest.class);
     }
 
     protected PaymentRequest getEntity() {

--- a/nostr-java-event/src/main/java/nostr/event/impl/NostrMarketplaceEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/NostrMarketplaceEvent.java
@@ -28,6 +28,6 @@ public abstract class NostrMarketplaceEvent extends AddressableEvent {
 
     @SneakyThrows
     public Product getProduct() {
-        return IEvent.MAPPER_AFTERBURNER.readValue(getContent(), Product.class);
+        return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), Product.class);
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/NutZapEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/NutZapEvent.java
@@ -103,7 +103,7 @@ public class NutZapEvent extends GenericEvent {
 
     private CashuProof getProofFromTag(GenericTag proofTag) {
         String proof = proofTag.getAttributes().get(0).getValue().toString();
-        CashuProof cashuProof = IEvent.MAPPER_AFTERBURNER.convertValue(proof, CashuProof.class);
+        CashuProof cashuProof = IEvent.MAPPER_BLACKBIRD.convertValue(proof, CashuProof.class);
         return cashuProof;
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/VerifyPaymentOrShippedEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/VerifyPaymentOrShippedEvent.java
@@ -27,7 +27,7 @@ public class VerifyPaymentOrShippedEvent extends CheckoutEvent<PaymentShipmentSt
     }
 
     public PaymentShipmentStatus getPaymentShipmentStatus() {
-        return IEvent.MAPPER_AFTERBURNER.convertValue(getContent(), PaymentShipmentStatus.class);
+        return IEvent.MAPPER_BLACKBIRD.convertValue(getContent(), PaymentShipmentStatus.class);
     }
 
     protected PaymentShipmentStatus getEntity() {

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/BaseTagDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/BaseTagDecoder.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import nostr.base.IDecoder;
 import nostr.event.BaseTag;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 /**
  *
@@ -23,7 +23,7 @@ public class BaseTagDecoder<T extends BaseTag> implements IDecoder<T> {
     @Override
     public T decode(String jsonString) {
         try {
-            return MAPPER_AFTERBURNER.readValue(jsonString, clazz);
+            return MAPPER_BLACKBIRD.readValue(jsonString, clazz);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/FiltersDecoder.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 /**
  * @author eric
@@ -24,7 +24,7 @@ public class FiltersDecoder implements FDecoder<Filters> {
   public Filters decode(@NonNull String jsonFiltersList) {
     final List<Filterable> filterables = new ArrayList<>();
 
-    Map<String, JsonNode> filtersMap = MAPPER_AFTERBURNER.readValue(
+    Map<String, JsonNode> filtersMap = MAPPER_BLACKBIRD.readValue(
         jsonFiltersList,
         new TypeReference<Map<String, JsonNode>>() {});
 

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/Nip05ContentDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/Nip05ContentDecoder.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import nostr.base.IDecoder;
 import nostr.event.Nip05Content;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 /**
  *
@@ -23,7 +23,7 @@ public class Nip05ContentDecoder<T extends Nip05Content> implements IDecoder<T> 
     @Override
     public T decode(String jsonContent) {
         try {
-            return MAPPER_AFTERBURNER.readValue(jsonContent, clazz);
+            return MAPPER_BLACKBIRD.readValue(jsonContent, clazz);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(ex);
         }

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/CalendarDateBasedEventDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/CalendarDateBasedEventDeserializer.java
@@ -34,7 +34,7 @@ public class CalendarDateBasedEventDeserializer extends StdDeserializer<Calendar
                 .map(
                         JsonNode::elements)
                 .map(element ->
-                        IEvent.MAPPER_AFTERBURNER.convertValue(element, BaseTag.class)).toList();
+                        IEvent.MAPPER_BLACKBIRD.convertValue(element, BaseTag.class)).toList();
 
 
         Map<String, String> generalMap = new HashMap<>();

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/CalendarEventDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/CalendarEventDeserializer.java
@@ -33,7 +33,7 @@ public class CalendarEventDeserializer extends StdDeserializer<CalendarEvent> {
                 .map(
                         JsonNode::elements)
                 .map(element ->
-                        IEvent.MAPPER_AFTERBURNER.convertValue(element, BaseTag.class)).toList();
+                        IEvent.MAPPER_BLACKBIRD.convertValue(element, BaseTag.class)).toList();
 
 
         Map<String, String> generalMap = new HashMap<>();

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/CalendarRsvpEventDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/CalendarRsvpEventDeserializer.java
@@ -33,7 +33,7 @@ public class CalendarRsvpEventDeserializer extends StdDeserializer<CalendarRsvpE
                 .map(
                         JsonNode::elements)
                 .map(element ->
-                        IEvent.MAPPER_AFTERBURNER.convertValue(element, BaseTag.class)).toList();
+                        IEvent.MAPPER_BLACKBIRD.convertValue(element, BaseTag.class)).toList();
 
         Map<String, String> generalMap = new HashMap<>();
         calendarTimeBasedEventNode.fields().forEachRemaining(generalTag ->

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/CalendarTimeBasedEventDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/CalendarTimeBasedEventDeserializer.java
@@ -33,7 +33,7 @@ public class CalendarTimeBasedEventDeserializer extends StdDeserializer<Calendar
                 .map(
                         JsonNode::elements)
                 .map(element ->
-                        IEvent.MAPPER_AFTERBURNER.convertValue(element, BaseTag.class)).toList();
+                        IEvent.MAPPER_BLACKBIRD.convertValue(element, BaseTag.class)).toList();
 
 
         Map<String, String> generalMap = new HashMap<>();

--- a/nostr-java-event/src/main/java/nostr/event/json/deserializer/ClassifiedListingEventDeserializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/deserializer/ClassifiedListingEventDeserializer.java
@@ -31,7 +31,7 @@ public class ClassifiedListingEventDeserializer extends StdDeserializer<Classifi
         List<BaseTag> baseTags = StreamSupport.stream(tags.spliterator(), false).toList()
                 .stream()
                 .map(JsonNode::elements)
-                .map(element -> IEvent.MAPPER_AFTERBURNER.convertValue(element, BaseTag.class)).toList();
+                .map(element -> IEvent.MAPPER_BLACKBIRD.convertValue(element, BaseTag.class)).toList();
         Map<String, String> generalMap = new HashMap<>();
         classifiedListingEventNode.fields().forEachRemaining(generalTag ->
                 generalMap.put(

--- a/nostr-java-event/src/test/java/nostr/event/unit/RelaysTagTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/RelaysTagTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -33,7 +33,7 @@ class RelaysTagTest {
     void testDeserialize() {
         final String EXPECTED = "[\"relays\",\"ws://localhost:5555\"]";
         assertDoesNotThrow(() -> {
-            JsonNode node = MAPPER_AFTERBURNER.readTree(EXPECTED);
+            JsonNode node = MAPPER_BLACKBIRD.readTree(EXPECTED);
             BaseTag deserialize = RelaysTag.deserialize(node);
             assertEquals(RELAYS_KEY, deserialize.getCode());
             assertEquals(HOST_VALUE, ((RelaysTag) deserialize).getRelays().getFirst().getUri());

--- a/nostr-java-event/src/test/java/nostr/event/unit/TagDeserializerTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/TagDeserializerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
-import static nostr.base.IEvent.MAPPER_AFTERBURNER;
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.junit.jupiter.api.Assertions.*;
 
 class TagDeserializerTest {
@@ -19,7 +19,7 @@ class TagDeserializerTest {
     void testAddressTagDeserialization() throws Exception {
         String pubKey = "bbbd79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76984";
         String json = "[\"a\",\"1:" + pubKey + ":test\",\"ws://localhost:8080\"]";
-        BaseTag tag = MAPPER_AFTERBURNER.readValue(json, BaseTag.class);
+        BaseTag tag = MAPPER_BLACKBIRD.readValue(json, BaseTag.class);
         assertInstanceOf(AddressTag.class, tag);
         AddressTag aTag = (AddressTag) tag;
         assertEquals(1, aTag.getKind());
@@ -32,7 +32,7 @@ class TagDeserializerTest {
     void testEventTagDeserialization() throws Exception {
         String id = "494001ac0c8af2a10f60f23538e5b35d3cdacb8e1cc956fe7a16dfa5cbfc4346";
         String json = "[\"e\",\"" + id + "\",\"wss://relay.example.com\",\"root\"]";
-        BaseTag tag = MAPPER_AFTERBURNER.readValue(json, BaseTag.class);
+        BaseTag tag = MAPPER_BLACKBIRD.readValue(json, BaseTag.class);
         assertInstanceOf(EventTag.class, tag);
         EventTag eTag = (EventTag) tag;
         assertEquals(id, eTag.getIdEvent());
@@ -43,7 +43,7 @@ class TagDeserializerTest {
     @Test
     void testPriceTagDeserialization() throws Exception {
         String json = "[\"price\",\"10.99\",\"USD\"]";
-        BaseTag tag = MAPPER_AFTERBURNER.readValue(json, BaseTag.class);
+        BaseTag tag = MAPPER_BLACKBIRD.readValue(json, BaseTag.class);
         assertInstanceOf(PriceTag.class, tag);
         PriceTag pTag = (PriceTag) tag;
         assertEquals(new BigDecimal("10.99"), pTag.getNumber());
@@ -53,7 +53,7 @@ class TagDeserializerTest {
     @Test
     void testUrlTagDeserialization() throws Exception {
         String json = "[\"u\",\"http://example.com\"]";
-        BaseTag tag = MAPPER_AFTERBURNER.readValue(json, BaseTag.class);
+        BaseTag tag = MAPPER_BLACKBIRD.readValue(json, BaseTag.class);
         assertInstanceOf(UrlTag.class, tag);
         UrlTag uTag = (UrlTag) tag;
         assertEquals("http://example.com", uTag.getUrl());
@@ -62,7 +62,7 @@ class TagDeserializerTest {
     @Test
     void testGenericFallback() throws Exception {
         String json = "[\"unknown\",\"value\"]";
-        BaseTag tag = MAPPER_AFTERBURNER.readValue(json, BaseTag.class);
+        BaseTag tag = MAPPER_BLACKBIRD.readValue(json, BaseTag.class);
         assertInstanceOf(GenericTag.class, tag);
         GenericTag gTag = (GenericTag) tag;
         assertEquals("unknown", gTag.getCode());


### PR DESCRIPTION
## Summary
- rename `MAPPER_AFTERBURNER` to `MAPPER_BLACKBIRD` in the base event interface
- update all static imports and usages to the new mapper constant

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed. Will not retry)*

------
https://chatgpt.com/codex/tasks/task_b_689945572e1883319fd9743d2037e3ef