### PR TITLE
Remove duplicate test filter

### DIFF
--- a/buildSrc/src/main/groovy/nostr-java.conventions.gradle
+++ b/buildSrc/src/main/groovy/nostr-java.conventions.gradle
@@ -87,12 +87,6 @@ test {
     }
 }
 
-test {
-    filter {
-        excludeTestsMatching("nostr.api.integration.*");
-    }
-}
-
 tasks.bootJar {
     enabled = false
 }


### PR DESCRIPTION
## Summary
- remove duplicate `test` block in buildSrc conventions to maintain single exclusion for `nostr.api.integration.*`

## Testing
- `mvn -q verify` *(fails: ApiNIP99RequestIT IllegalState: Previous attempts to find a Docker environment failed)*


------
https://chatgpt.com/codex/tasks/task_b_6899534446f083319d410008bb563068