### PR TITLE
Refactor Gradle conventions and module dependencies

### DIFF
--- a/buildSrc/src/main/groovy/nostr-java.conventions.gradle
+++ b/buildSrc/src/main/groovy/nostr-java.conventions.gradle
@@ -9,10 +9,7 @@ plugins {
     id 'java'
     id 'java-library'
     id 'maven-publish'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
     id 'com.adarshr.test-logger'
-    id 'org.gradle.test-retry'
 }
 
 group = rootProject.property("nostr-java.group")
@@ -36,69 +33,6 @@ publishing {
 ////  TODO: below placeholder for eric        
 //        someRemoteRepo()
     }
-}
-
-dependencies {
-    def springBootVersion = rootProject.property("nostr-java.springBootVersion")
-    def apacheCommonsLang3 = rootProject.property("nostr-java.apacheCommonsLang3")
-    def jacksonModuleAfterburner = rootProject.property("nostr-java.jacksonModuleAfterburner")
-    def jacksonModuleBlackbird = rootProject.property("nostr-java.jacksonModuleBlackbird")
-    def googleGuava = rootProject.property("nostr-java.googleGuava")
-    def bouncyCastle = rootProject.property("nostr-java.bouncyCastle")
-    def awaitility = rootProject.property("nostr-java.awaitility")
-    def lombok = rootProject.property("nostr-java.lombok")
-    def logger = rootProject.property("nostr-java.adarshrGradleTestLoggerPlugin")
-
-    implementation 'org.springframework.boot:spring-boot-starter:' + springBootVersion
-    implementation 'org.springframework.boot:spring-boot-devtools:' + springBootVersion
-    annotationProcessor 'org.springframework.boot:spring-boot-autoconfigure:' + springBootVersion
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor:' + springBootVersion
-
-    implementation 'org.springframework.boot:spring-boot-starter-validation:' + springBootVersion
-    implementation 'org.springframework.boot:spring-boot-starter-websocket:' + springBootVersion
-
-    implementation 'com.fasterxml.jackson.module:jackson-module-afterburner:' + jacksonModuleAfterburner
-    implementation 'com.fasterxml.jackson.module:jackson-module-blackbird:' + jacksonModuleBlackbird
-    implementation 'org.bouncycastle:bcprov-jdk18on:' + bouncyCastle
-
-    implementation 'org.apache.commons:commons-lang3:' + apacheCommonsLang3
-    implementation 'org.awaitility:awaitility:' + awaitility
-    implementation 'org.projectlombok:lombok:' + lombok
-    annotationProcessor 'org.awaitility:awaitility:' + awaitility
-    annotationProcessor 'org.projectlombok:lombok:' + lombok
-
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:' + springBootVersion
-    testImplementation 'org.projectlombok:lombok:' + lombok
-    testImplementation 'org.awaitility:awaitility:' + awaitility
-    testImplementation 'com.adarshr:gradle-test-logger-plugin:' + logger
-    testImplementation 'com.google.guava:guava:' + googleGuava
-    
-    testAnnotationProcessor 'org.projectlombok:lombok:' + lombok
-}
-
-tasks.test {
-    systemProperty("spring.profiles.active", "test")
-    useJUnitPlatform()
-}
-
-test {
-    filter {
-        excludeTestsMatching("nostr.api.integration.*");
-    }
-}
-
-test {
-    filter {
-        excludeTestsMatching("nostr.api.integration.*");
-    }
-}
-
-tasks.bootJar {
-    enabled = false
-}
-
-tasks.jar {
-    archiveClassifier = ''
 }
 
 java.sourceCompatibility = JavaVersion.toVersion(rootProject.property("nostr-java.java-version"))

--- a/nostr-java-api/build.gradle
+++ b/nostr-java-api/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+    id 'org.springframework.boot'
+    id 'org.gradle.test-retry'
     id 'nostr-java.conventions'
 }
 
@@ -7,7 +9,29 @@ description = 'nostr-java-api'
 dependencies {
     api project(':nostr-java-client')
     api project(':nostr-java-encryption')
+    api project(':nostr-java-id')
+    api project(':nostr-java-event')
+    api project(':nostr-java-util')
+    api project(':nostr-java-crypto')
+
+    implementation "org.springframework.boot:spring-boot-starter:${rootProject.property('nostr-java.springBootVersion')}"
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    compileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    annotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testCompileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testAnnotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+
+    implementation 'org.slf4j:slf4j-api'
+
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation "org.springframework.boot:spring-boot-starter-test:${rootProject.property('nostr-java.springBootVersion')}"
+    testImplementation 'com.google.guava:guava:33.4.0-jre'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }
+
+tasks.named('bootJar') { enabled = false }
+tasks.named('jar') { archiveClassifier = '' }
 
 tasks.register('apiIntegrationTest', Test) {
     description = 'api integration tests.'

--- a/nostr-java-base/build.gradle
+++ b/nostr-java-base/build.gradle
@@ -5,6 +5,20 @@ plugins {
 description = 'nostr-java-base'
 
 dependencies {
+    implementation platform("org.springframework.boot:spring-boot-dependencies:${rootProject.property('nostr-java.springBootVersion')}")
+
     api project(':nostr-java-util')
     api project(':nostr-java-crypto')
+
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation "com.fasterxml.jackson.module:jackson-module-blackbird:${rootProject.property('nostr-java.jacksonModuleBlackbird')}"
+    implementation "com.fasterxml.jackson.module:jackson-module-afterburner:${rootProject.property('nostr-java.jacksonModuleAfterburner')}"
+
+    compileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    annotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testCompileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testAnnotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+
+    implementation 'org.slf4j:slf4j-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/nostr-java-client/build.gradle
+++ b/nostr-java-client/build.gradle
@@ -1,9 +1,29 @@
 plugins {
+    id 'org.springframework.boot'
     id 'nostr-java.conventions'
 }
 
 description = 'nostr-java-client'
 
 dependencies {
-    api project(':nostr-java-id')
+    implementation project(':nostr-java-id')
+
+    implementation "org.springframework.boot:spring-boot-starter-websocket:${rootProject.property('nostr-java.springBootVersion')}"
+    implementation 'org.springframework:spring-websocket'
+    implementation 'org.awaitility:awaitility:4.2.2'
+
+    compileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    annotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testCompileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testAnnotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation "org.springframework.boot:spring-boot-starter-test:${rootProject.property('nostr-java.springBootVersion')}"
+    testImplementation 'org.springframework:spring-test'
+
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
 }
+
+tasks.named('bootJar') { enabled = false }
+tasks.named('jar') { archiveClassifier = '' }

--- a/nostr-java-crypto/build.gradle
+++ b/nostr-java-crypto/build.gradle
@@ -5,5 +5,17 @@ plugins {
 description = 'nostr-java-crypto'
 
 dependencies {
+    implementation platform("org.springframework.boot:spring-boot-dependencies:${rootProject.property('nostr-java.springBootVersion')}")
+
     api project(':nostr-java-util')
+
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.78'
+
+    compileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    annotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testCompileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testAnnotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+
+    implementation 'org.slf4j:slf4j-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/nostr-java-encryption/build.gradle
+++ b/nostr-java-encryption/build.gradle
@@ -5,6 +5,15 @@ plugins {
 description = 'nostr-java-encryption'
 
 dependencies {
+    implementation platform("org.springframework.boot:spring-boot-dependencies:${rootProject.property('nostr-java.springBootVersion')}")
+
     api project(':nostr-java-crypto')
     api project(':nostr-java-util')
+
+    compileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    annotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testCompileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testAnnotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/nostr-java-event/build.gradle
+++ b/nostr-java-event/build.gradle
@@ -5,5 +5,20 @@ plugins {
 description = 'nostr-java-event'
 
 dependencies {
+    implementation platform("org.springframework.boot:spring-boot-dependencies:${rootProject.property('nostr-java.springBootVersion')}")
+
     api project(':nostr-java-base')
+    api project(':nostr-java-crypto')
+    api project(':nostr-java-util')
+
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation "com.fasterxml.jackson.module:jackson-module-afterburner:${rootProject.property('nostr-java.jacksonModuleAfterburner')}"
+
+    compileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    annotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testCompileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testAnnotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+
+    implementation 'org.slf4j:slf4j-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/nostr-java-examples/build.gradle
+++ b/nostr-java-examples/build.gradle
@@ -5,5 +5,5 @@ plugins {
 description = 'nostr-java-examples'
 
 dependencies {
-    api project(':nostr-java-api')
+    implementation project(':nostr-java-api')
 }

--- a/nostr-java-id/build.gradle
+++ b/nostr-java-id/build.gradle
@@ -5,5 +5,15 @@ plugins {
 description = 'nostr-java-id'
 
 dependencies {
+    implementation platform("org.springframework.boot:spring-boot-dependencies:${rootProject.property('nostr-java.springBootVersion')}")
+
     api project(':nostr-java-event')
+
+    compileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    annotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testCompileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testAnnotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+
+    implementation 'org.slf4j:slf4j-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/nostr-java-util/build.gradle
+++ b/nostr-java-util/build.gradle
@@ -3,3 +3,19 @@ plugins {
 }
 
 description = 'nostr-java-util'
+
+dependencies {
+    implementation platform("org.springframework.boot:spring-boot-dependencies:${rootProject.property('nostr-java.springBootVersion')}")
+
+    implementation "org.apache.commons:commons-lang3:${rootProject.property('nostr-java.apacheCommonsLang3')}"
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation "com.fasterxml.jackson.module:jackson-module-afterburner:${rootProject.property('nostr-java.jacksonModuleAfterburner')}"
+
+    compileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    annotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testCompileOnly "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+    testAnnotationProcessor "org.projectlombok:lombok:${rootProject.property('nostr-java.lombok')}"
+
+    implementation 'org.slf4j:slf4j-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}


### PR DESCRIPTION
## Summary
- Remove global Spring Boot and other dependency declarations from conventions plugin, retaining only shared Java, repository, publishing, and test logger configuration.
- Declare dependencies explicitly within each module and import the Spring Boot BOM where needed.
- Apply the Spring Boot plugin only to `nostr-java-client` and `nostr-java-api`, matching their Maven counterparts.

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment, tests error out)*


------
https://chatgpt.com/codex/tasks/task_b_6899533e95008331abade1cf788dd38d