### PR TITLE
Add Jacoco coverage verification

### DIFF
--- a/buildSrc/src/main/groovy/nostr-java.conventions.gradle
+++ b/buildSrc/src/main/groovy/nostr-java.conventions.gradle
@@ -13,6 +13,7 @@ plugins {
     id 'io.spring.dependency-management'
     id 'com.adarshr.test-logger'
     id 'org.gradle.test-retry'
+    id 'jacoco'
 }
 
 group = rootProject.property("nostr-java.group")
@@ -115,4 +116,30 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.withType(Javadoc).configureEach {
     options.encoding = 'UTF-8'
+}
+
+tasks.jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        csv.required = false
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn test
+    violationRules {
+        rule {
+            limit {
+                counter = 'INSTRUCTION'
+                value = 'COVEREDRATIO'
+                minimum = 0.60
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn jacocoTestCoverageVerification
 }


### PR DESCRIPTION
## Summary
- apply Jacoco plugin via nostr-java conventions
- enforce 60% instruction coverage through jacocoTestCoverageVerification
- attach coverage verification to the check task

## Testing
- `mvn -q verify` *(fails: ApiNIP99RequestIT IllegalState Previous attempts to find a Docker environment failed)*
- `gradle --no-daemon :nostr-java-util:check`

------
https://chatgpt.com/codex/tasks/task_b_6899534846488331be98ed7c02013f41