### PR TITLE
Add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- add CodeQL workflow running on pushes and PRs to main and develop branches

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*
- Attempted to fetch CodeQL alerts via GitHub API but received 403 (authorization required)

## Network Access
- `api.github.com` (403, GitHub API requires authorization)


------
https://chatgpt.com/codex/tasks/task_b_6899da98eaec83318af36bdb22133eb7