### PR TITLE
chore: add stale issue workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,34 @@
+name: Close Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: 7
+          exempt-issue-labels: pinned,security
+          exempt-pr-labels: pinned,security
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >-
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs.
+          stale-pr-message: >-
+            This pull request has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs.
+          close-issue-message: >-
+            Closing this issue due to prolonged inactivity.
+          close-pr-message: >-
+            Closing this pull request due to prolonged inactivity.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to mark and close stale issues and PRs

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed. Will not retry. Please see logs and check configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6899da83ec20833183b96764fad9c449