### PR TITLE
chore: add issue labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+bug:
+  - '(?i)\bbug\b'
+feature:
+  - '(?i)\bfeature\b'
+question:
+  - '(?i)\bquestion\b'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,19 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3
+        with:
+          configuration-path: .github/labeler.yml
+          include-title: 1
+          repo-token: ${{ github.token }}


### PR DESCRIPTION
## Summary
- add issue labeler configuration
- add workflow to apply labels to new issues

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed)*
- `gh issue create --title "Labeler test" --body "bug"` *(fails: gh auth login required)*

------
https://chatgpt.com/codex/tasks/task_b_6899da71f8d883318faaa6ce75e92442