### PR TITLE
Add Snyk dependency scanning workflow and badge

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,24 @@
+name: Snyk Scan
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/maven@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --all-projects

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # nostr-java
-[![CI](https://github.com/tcheeric/nostr-java/actions/workflows/ci.yml/badge.svg)](https://github.com/tcheeric/nostr-java/actions/workflows/ci.yml)
+[![CI](https://github.com/tcheeric/nostr-java/actions/workflows/ci.yml/badge.svg)](https://github.com/tcheeric/nostr-java/actions/workflows/ci.yml) [![Known Vulnerabilities](https://snyk.io/test/github/tcheeric/nostr-java/badge.svg)](https://snyk.io/test/github/tcheeric/nostr-java)
 
 `nostr-java` is a Java SDK for the [Nostr](https://github.com/nostr-protocol/nips) protocol. It provides utilities for creating, signing and publishing Nostr events to relays.
 


### PR DESCRIPTION
## Summary
- add Snyk GitHub Actions workflow to scan Maven projects for vulnerabilities
- expose Snyk known vulnerabilities badge in the README

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed)*


------
https://chatgpt.com/codex/tasks/task_b_6899e2046bf483319e4e9c82d26d0b60