### PR TITLE
Fix Spring Boot plugin declarations in Gradle modules

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,8 @@ nostr-java.version=0.7.3-SNAPSHOT
 nostr-java.description=nostr-java
 
 nostr-java.java-version=21
-nostr-java.springBootVersion=3.4.3
+springBootVersion=3.4.3
+nostr-java.springBootVersion=${springBootVersion}
 nostr-java.apacheCommonsLang3=3.17.0
 nostr-java.jacksonModuleBlackbird=2.17.2
 nostr-java.googleGuava=33.4.0-jre

--- a/nostr-java-api/build.gradle
+++ b/nostr-java-api/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.springframework.boot' version "${rootProject.findProperty('nostr-java.springBootVersion')}"
-    id 'org.springframework.boot' version rootProject.findProperty('nostr-java.springBootVersion')
+    id 'org.springframework.boot'
 }
 
 group = 'xyz.tcheeric'
@@ -20,7 +19,7 @@ dependencies {
     api project(':nostr-java-util')
     api project(':nostr-java-crypto')
 
-    implementation 'org.springframework.boot:spring-boot-starter:3.4.3'
+    implementation "org.springframework.boot:spring-boot-starter:$springBootVersion"
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     compileOnly 'org.projectlombok:lombok:1.18.36'
     annotationProcessor 'org.projectlombok:lombok:1.18.36'
@@ -29,7 +28,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation 'org.testcontainers:junit-jupiter:1.21.3'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.4.3'
+    testImplementation "org.springframework.boot:spring-boot-starter-test:$springBootVersion"
     testImplementation 'com.google.guava:guava:33.4.0-jre'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }

--- a/nostr-java-client/build.gradle
+++ b/nostr-java-client/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.springframework.boot' version "${rootProject.findProperty('nostr-java.springBootVersion')}"
-    id 'org.springframework.boot' version rootProject.findProperty('nostr-java.springBootVersion')
+    id 'org.springframework.boot'
 }
 
 group = 'xyz.tcheeric'
@@ -15,7 +14,7 @@ repositories {
 dependencies {
     api project(':nostr-java-id')
 
-    implementation "org.springframework.boot:spring-boot-starter-websocket:${rootProject.findProperty('nostr-java.springBootVersion')}"
+    implementation "org.springframework.boot:spring-boot-starter-websocket:$springBootVersion"
     implementation 'org.springframework:spring-websocket'
     implementation "org.awaitility:awaitility:${rootProject.findProperty('nostr-java.awaitility')}"
     compileOnly "org.projectlombok:lombok:${rootProject.findProperty('nostr-java.lombok')}"
@@ -26,7 +25,7 @@ dependencies {
     implementation 'org.springframework:spring-aspects'
 
     testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.findProperty('nostr-java.junitJupiter')}"
-    testImplementation "org.springframework.boot:spring-boot-starter-test:${rootProject.findProperty('nostr-java.springBootVersion')}"
+    testImplementation "org.springframework.boot:spring-boot-starter-test:$springBootVersion"
     testImplementation 'org.springframework:spring-test'
 }
 


### PR DESCRIPTION
## Summary
- drop explicit Spring Boot plugin versions from API and client modules
- expose shared `springBootVersion` property for dependency declarations

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*


------
https://chatgpt.com/codex/tasks/task_b_689a4b7914808331a704c99a96463cae