### PR TITLE
Add missing logging and Spring dependencies to Gradle modules

### DIFF
--- a/nostr-java-client/build.gradle
+++ b/nostr-java-client/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:${rootProject.findProperty('nostr-java.lombok')}"
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework:spring-aspects'
+    implementation 'org.slf4j:slf4j-api'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.findProperty('nostr-java.junitJupiter')}"
     testImplementation "org.springframework.boot:spring-boot-starter-test:$springBootVersion"

--- a/nostr-java-client/pom.xml
+++ b/nostr-java-client/pom.xml
@@ -38,6 +38,15 @@
             <artifactId>spring-aspects</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
         <!-- Utilities -->
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/nostr-java-encryption/build.gradle
+++ b/nostr-java-encryption/build.gradle
@@ -17,5 +17,7 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:${rootProject.findProperty('nostr-java.lombok')}"
     testCompileOnly "org.projectlombok:lombok:${rootProject.findProperty('nostr-java.lombok')}"
     testAnnotationProcessor "org.projectlombok:lombok:${rootProject.findProperty('nostr-java.lombok')}"
+    implementation 'org.slf4j:slf4j-api'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation "org.junit.jupiter:junit-jupiter:${rootProject.findProperty('nostr-java.junitJupiter')}"
 }

--- a/nostr-java-encryption/pom.xml
+++ b/nostr-java-encryption/pom.xml
@@ -27,6 +27,15 @@
             <version>${nostr-java.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/nostr-java-examples/build.gradle
+++ b/nostr-java-examples/build.gradle
@@ -12,4 +12,6 @@ repositories {
 
 dependencies {
     api project(':nostr-java-api')
+    implementation 'org.slf4j:slf4j-api'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 }

--- a/nostr-java-examples/pom.xml
+++ b/nostr-java-examples/pom.xml
@@ -18,5 +18,13 @@
             <artifactId>nostr-java-api</artifactId>
             <version>${nostr-java.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- Add slf4j and jackson-databind to nostr-java-client
- Include logging and jackson-databind in encryption and examples modules, limiting Spring Retry/Aspects to the client
- Mirror dependency changes in corresponding Maven poms

## Testing
- `mvn -q verify` *(fails: Non-resolvable parent POM for xyz.tcheeric:nostr-java: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

## Network Access
- `https://repo.maven.apache.org/maven2` (network unreachable)


------
https://chatgpt.com/codex/tasks/task_b_689a4feb37b4833186f8600b8ef2bfac