### PR TITLE
docs: remove Gradle sync requirement from repo guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,6 @@ The URL format for the NIPs is https://github.com/nostr-protocol/nips/blob/maste
 - Maintain the versions in the configuration section of the pom.xml files.
 - Always make sure that the events are compliant with the Nostr protocol specifications, and that the events are valid according to the NIP specifications.
 - Always remove unused imports
-- Any change in pom files should be reflected in the corresponding graddle build files.
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary
- drop outdated instruction about syncing pom changes to Gradle build files in `AGENTS.md`
- confirm remaining guidelines still reference running `mvn -q verify`

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment; multiple integration tests error out)*


------
https://chatgpt.com/codex/tasks/task_b_689a5be9a7248331a2559be4012435f3