### PR TITLE
docs: remove Gradle references from overview

### DIFF
--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -14,27 +14,17 @@ This document provides an overview of the project structure and instructions for
 - **nostr-java-examples** – sample applications demonstrating how to use the API.
 
 ## Building and testing
-The project can be built with Maven or Gradle. Unit tests do not require a running relay, while integration tests use Testcontainers to start a relay in Docker.
+The project is built with Maven. Unit tests do not require a running relay, while integration tests use Testcontainers to start a relay in Docker.
 
 ### Unit-tested build
 ```bash
-# Maven
 ./mvnw clean test
 ./mvnw install -Dmaven.test.skip=true
-
-# Gradle
-./gradlew clean test
-./gradlew publishToMavenLocal
 ```
 
 ### Integration-tested build (requires Docker)
 ```bash
-# Maven
 ./mvnw clean install
-
-# Gradle
-./gradlew clean check
-./gradlew publishToMavenLocal
 ```
 Integration tests start a `nostr-rs-relay` container automatically. The image used can be overridden in `src/test/resources/relay-container.properties` by setting `relay.container.image=<image>`.
 


### PR DESCRIPTION
## Summary
- Clarify build instructions to use Maven only and drop Gradle-specific steps.

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

## Network Access
- No external network requests were made; integration tests failed before contacting Docker.

------
https://chatgpt.com/codex/tasks/task_b_689a5be16b208331a2e8b07d6b29746a