### PR TITLE
Add filter example

### DIFF
--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -63,6 +63,32 @@ client.createTextNoteEvent("Hello from NostrSpringWebSocketClient!\n")
       .signAndSend();
 ```
 
+## Requesting events with filters
+The `FilterExample` shows how to query a relay for events matching a set of filters.
+It builds filters for author and kind, sends them with `NIP01`, and prints each
+returned event:
+
+```java
+Identity sender = Identity.generateRandomIdentity();
+NIP01 client = new NIP01(sender);
+client.setRelays(Map.of("damus", "wss://relay.damus.io"));
+
+Filters filters = new Filters(
+        new AuthorFilter<>(new PublicKey("21ef0d8541375ae4bca85285097fba370f7e540b5a30e5e75670c16679f9d144")),
+        new KindFilter<>(Kind.TEXT_NOTE)
+);
+
+List<String> responses = client.sendRequest(filters, "filter-example-" + System.currentTimeMillis());
+var decoder = new BaseMessageDecoder<BaseMessage>();
+for (String json : responses) {
+    BaseMessage message = decoder.decode(json);
+    if (message instanceof EventMessage eventMessage) {
+        System.out.println(eventMessage.getEvent());
+    }
+}
+client.close();
+```
+
 ## Creating custom events and tags
 Custom tag types can be introduced without modifying existing core code by
 registering them with the `TagRegistry`. The registry maps tag codes to factory

--- a/nostr-java-examples/src/main/java/nostr/examples/FilterExample.java
+++ b/nostr-java-examples/src/main/java/nostr/examples/FilterExample.java
@@ -1,0 +1,50 @@
+package nostr.examples;
+
+import java.util.List;
+import java.util.Map;
+
+import nostr.api.NIP01;
+import nostr.base.Kind;
+import nostr.base.PublicKey;
+import nostr.event.BaseMessage;
+import nostr.event.filter.AuthorFilter;
+import nostr.event.filter.Filters;
+import nostr.event.filter.KindFilter;
+import nostr.event.json.codec.BaseMessageDecoder;
+import nostr.event.message.EventMessage;
+import nostr.id.Identity;
+
+/**
+ * Demonstrates requesting events from a relay using filters for author and kind.
+ */
+public class FilterExample {
+
+    private static final String RELAY_URL = "wss://relay.damus.io";
+
+    public static void main(String[] args) throws Exception {
+        var author = new PublicKey("21ef0d8541375ae4bca85285097fba370f7e540b5a30e5e75670c16679f9d144");
+
+        var filters = new Filters(
+                new AuthorFilter<>(author),
+                new KindFilter<>(Kind.TEXT_NOTE)
+        );
+
+        var subId = "filter-example-" + System.currentTimeMillis();
+
+        Identity sender = Identity.generateRandomIdentity();
+        NIP01 client = new NIP01(sender);
+        client.setRelays(Map.of("damus", RELAY_URL));
+
+        List<String> responses = client.sendRequest(filters, subId);
+
+        var decoder = new BaseMessageDecoder<BaseMessage>();
+        for (String json : responses) {
+            BaseMessage message = decoder.decode(json);
+            if (message instanceof EventMessage eventMessage) {
+                System.out.println(eventMessage.getEvent());
+            }
+        }
+        client.close();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add example demonstrating filtering notes by author and kind
- instantiate `NIP01` with a random identity before sending filters
- document the filter example in CODEBASE_OVERVIEW

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment. Please see logs and check configuration)*

------
https://chatgpt.com/codex/tasks/task_b_689aa6dcdab48331bea5a372c21642e6