### PR TITLE
Add TextNoteEvent example and update overview

### DIFF
--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -51,6 +51,22 @@ GenericEvent event = new GenericEvent(identity.getPublicKey(), Kind.TEXT_NOTE,
 identity.sign(event);
 ```
 
+## Creating text note events with TextNoteEvent
+The `TextNoteEventExample` illustrates constructing a text note directly with the
+out-of-the-box `TextNoteEvent` class and sending it to a relay using the
+`StandardWebSocketClient`:
+
+```java
+Identity identity = Identity.generateRandomIdentity();
+TextNoteEvent event = new TextNoteEvent(identity.getPublicKey(),
+        List.<BaseTag>of(),
+        "Hello from TextNoteEvent!\n");
+identity.sign(event);
+try (StandardWebSocketClient client = new StandardWebSocketClient("ws://localhost:5555")) {
+    client.send(new EventMessage(event));
+}
+```
+
 ## Sending text events with NostrSpringWebSocketClient
 The `SpringClientTextEventExample` demonstrates using the `NIP01` helper class to
 publish a simple text note via `NostrSpringWebSocketClient`:

--- a/nostr-java-examples/src/main/java/nostr/examples/TextNoteEventExample.java
+++ b/nostr-java-examples/src/main/java/nostr/examples/TextNoteEventExample.java
@@ -1,0 +1,29 @@
+package nostr.examples;
+
+import java.util.List;
+
+import nostr.client.springwebsocket.StandardWebSocketClient;
+import nostr.event.BaseTag;
+import nostr.event.impl.TextNoteEvent;
+import nostr.event.message.EventMessage;
+import nostr.id.Identity;
+
+/**
+ * Demonstrates creating, signing, and sending a text note using the {@link TextNoteEvent} class.
+ */
+public class TextNoteEventExample {
+
+    private static final String RELAY_URI = "ws://localhost:5555";
+
+    public static void main(String[] args) throws Exception {
+        Identity identity = Identity.generateRandomIdentity();
+        TextNoteEvent event = new TextNoteEvent(identity.getPublicKey(), List.<BaseTag>of(),
+                "Hello from TextNoteEvent!\n");
+        identity.sign(event);
+        try (StandardWebSocketClient client = new StandardWebSocketClient(RELAY_URI)) {
+            client.send(new EventMessage(event));
+        }
+        System.out.println(event);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add `TextNoteEventExample` to demonstrate creating, signing, and sending a text note with the out-of-the-box class
- Document the example in `CODEBASE_OVERVIEW.md`

## Testing
- `./mvnw -q verify` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689b89117df083318c9ef4cc074921b4