### PR TITLE
Add GitHub Packages publish workflow

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -1,0 +1,31 @@
+name: Publish to GitHub Packages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/pom.xml'
+      - '.github/workflows/publish-github-packages.yml'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+          server-id: github
+          server-username: ${{ github.actor }}
+          server-password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish modules
+        run: ./mvnw -B -q deploy -DskipTests -Dgpg.skip=true \
+          -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Artifacts are published to GitHub Packages and can be consumed from Maven by add
 
 Authenticating to GitHub Packages is required; provide a personal access token with the appropriate scopes or `GITHUB_TOKEN` credentials. See the [GitHub Packages documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry) for more details.
 
+## Publishing Modules
+
+This repository includes a [GitHub Actions workflow](.github/workflows/publish-github-packages.yml) that publishes all Maven modules to GitHub Packages. The workflow runs on pushes to `main` that modify `pom.xml` files and can also be triggered manually from the Actions tab.
+
 ## Examples
 Example usages are located in the [`nostr-java-examples`](./nostr-java-examples) module. Additional demonstrations can be found in [nostr-client](https://github.com/tcheeric/nostr-client) and [SuperConductor](https://github.com/avlo/superconductor).
 


### PR DESCRIPTION
## Summary
- add workflow to deploy Maven modules to GitHub Packages
- document GitHub Packages publish workflow in the README

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed)*


------
https://chatgpt.com/codex/tasks/task_b_689b963d2cdc833198ac3889aa210676