### PR TITLE
Split GitHub release workflow steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,14 +59,6 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref_name }}
           draft: false
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref }}" \
-            --notes "" \
-            --verify-tag \
-            --latest
 
       - name: Upload JAR artifacts
         env:


### PR DESCRIPTION
## Summary
- split create-release and asset upload steps in release workflow
- limit `GH_TOKEN` usage to CLI steps

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*
- `actionlint .github/workflows/release.yml`


------
https://chatgpt.com/codex/tasks/task_b_689bb753a48c833190853d65ce90856e