### PR TITLE
refactor: reuse publish workflow

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -1,6 +1,14 @@
 name: Publish to GitHub Packages
 
 on:
+  workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      GPG_PRIVATE_KEY:
+        required: false
+      GPG_PASSPHRASE:
+        required: false
   push:
     branches: [main]
     paths:
@@ -14,6 +22,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,6 +37,17 @@ jobs:
           server-id: github
           server-username: ${{ github.actor }}
           server-password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Import GPG key
+        if: env.GPG_PRIVATE_KEY != ''
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
       - name: Publish modules
-        run: ./mvnw -B -q deploy -DskipTests -Dgpg.skip=true \
-          -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}
+        run: |
+          if [ -n "$GPG_PRIVATE_KEY" ]; then
+            ./mvnw -q -P release deploy -Dgpg.passphrase="$GPG_PASSPHRASE" \
+              -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}
+          else
+            ./mvnw -B -q deploy -DskipTests -Dgpg.skip=true \
+              -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,18 +28,10 @@ jobs:
         run: |
           echo "$GPG_PRIVATE_KEY" | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
-
       - name: Build and deploy
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: ./mvnw -q -P release deploy -Dgpg.passphrase="$GPG_PASSPHRASE"
-
-      - name: Deploy to GitHub Packages
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          ./mvnw -q -P release deploy -Dgpg.passphrase="$GPG_PASSPHRASE" \
-            -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/tcheeric/nostr-java
 
       - name: Collect JAR artifacts
         run: |
@@ -75,3 +67,11 @@ jobs:
           for file in release-jars/*.jar; do
             gh release upload "${{ github.ref_name }}" "$file" --clobber
           done
+
+  publish-packages:
+    needs: release
+    uses: ./.github/workflows/publish-github-packages.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,17 @@ Authenticating to GitHub Packages is required; provide a personal access token w
 
 ## Publishing Modules
 
-This repository includes a [GitHub Actions workflow](.github/workflows/publish-github-packages.yml) that publishes all Maven modules to GitHub Packages. The workflow runs on pushes to `main` that modify `pom.xml` files and can also be triggered manually from the Actions tab.
+This repository includes a [GitHub Actions workflow](.github/workflows/publish-github-packages.yml) that publishes all Maven modules to GitHub Packages. The workflow runs on pushes to `main` that modify `pom.xml` files and can also be triggered manually from the Actions tab. It is also exposed as a reusable workflow and can be invoked from other workflows, such as the release pipeline:
+
+```yaml
+jobs:
+  publish-packages:
+    uses: ./.github/workflows/publish-github-packages.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+```
 
 ## Examples
 Example usages are located in the [`nostr-java-examples`](./nostr-java-examples) module. Additional demonstrations can be found in [nostr-client](https://github.com/tcheeric/nostr-client) and [SuperConductor](https://github.com/avlo/superconductor).


### PR DESCRIPTION
## Summary
- make GitHub Packages workflow reusable
- invoke publish workflow from release pipeline
- document how to call reusable publish workflow

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*


------
https://chatgpt.com/codex/tasks/task_b_689bb75116e4833198cbb6bf37ab33e9