### PR TITLE
fix: remove reserved token from reusable workflow

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -3,8 +3,6 @@ name: Publish to GitHub Packages
 on:
   workflow_call:
     secrets:
-      GITHUB_TOKEN:
-        required: true
       GPG_PRIVATE_KEY:
         required: false
       GPG_PASSPHRASE:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,5 @@ jobs:
     needs: release
     uses: ./.github/workflows/publish-github-packages.yml
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
## Summary
- remove reserved `GITHUB_TOKEN` from reusable workflow declaration
- stop passing `GITHUB_TOKEN` to publishing workflow

## Testing
- `mvn -q verify` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689bbbc6719483318a48549e1914a9fb