### PR TITLE
chore: remove GitHub Packages distribution management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,17 +57,6 @@
         <tag>main</tag>
     </scm>
 
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/tcheeric/nostr-java</url>
-        </repository>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <modules>
         <module>nostr-java-base</module>
         <module>nostr-java-crypto</module>


### PR DESCRIPTION
## Summary
- remove GitHub Packages distribution management from root pom
- verify no modules reference the old distribution repository

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed. Will not retry.)*


------
https://chatgpt.com/codex/tasks/task_b_689bc4d05174833187a0615275bea610