### PR TITLE
docs: streamline README and move setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 # nostr-java
-[![CI](https://github.com/tcheeric/nostr-java/actions/workflows/ci.yml/badge.svg)](https://github.com/tcheeric/nostr-java/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/tcheeric/nostr-java/branch/main/graph/badge.svg)](https://codecov.io/gh/tcheeric/nostr-java)
-[![GitHub release](https://img.shields.io/github/v/release/tcheeric/nostr-java)](https://github.com/tcheeric/nostr-java/releases)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 `nostr-java` is a Java SDK for the [Nostr](https://github.com/nostr-protocol/nips) protocol. It provides utilities for creating, signing and publishing Nostr events to relays.
 
@@ -10,54 +6,12 @@
 - Maven
 - Java 21+
 
-## Getting Started
-Clone the repository and build the modules. Installing them locally allows you to add the artifacts as dependencies in your own projects:
-
-```bash
-$ git clone https://github.com/tcheeric/nostr-java.git
-$ cd nostr-java
-$ ./mvnw clean install
-```
-
-You can also consume published artifacts from our Maven repository instead of building from source.
-
-### Maven
-
-```xml
-<repositories>
-  <repository>
-    <id>nostr-java</id>
-    <url>https://maven.398ja.xyz/releases</url>
-  </repository>
-</repositories>
-
-<dependency>
-  <groupId>xyz.tcheeric</groupId>
-  <artifactId>nostr-java-api</artifactId>
-  <version>[VERSION]</version>
-</dependency>
-```
-
-Snapshot builds are available at `https://maven.398ja.xyz/snapshots`.
-
-### Gradle
-
-```gradle
-repositories {
-    maven { url 'https://maven.398ja.xyz/releases' }
-}
-
-dependencies {
-    implementation 'xyz.tcheeric:nostr-java-api:[VERSION]'
-}
-```
-
-Replace `[VERSION]` with the latest release number from the [releases page](https://github.com/tcheeric/nostr-java/releases).
+See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for installation and usage instructions.
 
 See [`docs/CODEBASE_OVERVIEW.md`](docs/CODEBASE_OVERVIEW.md) for details about running tests and contributing.
 
 ## Examples
-Example usages are located in the [`nostr-java-examples`](./nostr-java-examples) module. Additional demonstrations can be found in [nostr-client](https://github.com/tcheeric/nostr-client) and [SuperConductor](https://github.com/avlo/superconductor).
+Examples are located in the [`nostr-java-examples`](./nostr-java-examples) module.
 
 ## Supported NIPs
 The API currently implements the following [NIPs](https://github.com/nostr-protocol/nips):

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # nostr-java
+[![CI](https://github.com/tcheeric/nostr-java/actions/workflows/ci.yml/badge.svg)](https://github.com/tcheeric/nostr-java/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/tcheeric/nostr-java/branch/main/graph/badge.svg)](https://codecov.io/gh/tcheeric/nostr-java)
+[![GitHub release](https://img.shields.io/github/v/release/tcheeric/nostr-java)](https://github.com/tcheeric/nostr-java/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 `nostr-java` is a Java SDK for the [Nostr](https://github.com/nostr-protocol/nips) protocol. It provides utilities for creating, signing and publishing Nostr events to relays.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,51 @@
+# Getting Started
+
+## Prerequisites
+- Maven
+- Java 21+
+
+## Building from Source
+
+```bash
+git clone https://github.com/tcheeric/nostr-java.git
+cd nostr-java
+./mvnw clean install
+```
+
+## Using Maven
+
+Artifacts are published to `https://maven.398ja.xyz/releases`:
+
+```xml
+<repositories>
+  <repository>
+    <id>nostr-java</id>
+    <url>https://maven.398ja.xyz/releases</url>
+  </repository>
+</repositories>
+
+<dependency>
+  <groupId>xyz.tcheeric</groupId>
+  <artifactId>nostr-java-api</artifactId>
+  <version>[VERSION]</version>
+</dependency>
+```
+
+Snapshot builds are available at `https://maven.398ja.xyz/snapshots`.
+
+## Using Gradle
+
+```gradle
+repositories {
+    maven { url 'https://maven.398ja.xyz/releases' }
+}
+
+dependencies {
+    implementation 'xyz.tcheeric:nostr-java-api:[VERSION]'
+}
+```
+
+Replace `[VERSION]` with the latest release number from the [releases page](https://github.com/tcheeric/nostr-java/releases).
+
+Examples are available in the [`nostr-java-examples`](../nostr-java-examples) module.
+


### PR DESCRIPTION
## Summary
- strip badges and marketing copy from README
- move setup and dependency instructions into new docs/GETTING_STARTED.md

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment; see logs)*


------
https://chatgpt.com/codex/tasks/task_b_68a48db89dc883318bd941a41ac2046f