### PR TITLE
docs: add quick API guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ dependencies {
 
 Replace `[VERSION]` with the latest release number from the [releases page](https://github.com/tcheeric/nostr-java/releases).
 
+For a quick API walkthrough, see [`docs/howto/use-nostr-java-api.md`](docs/howto/use-nostr-java-api.md).
+
 See [`docs/CODEBASE_OVERVIEW.md`](docs/CODEBASE_OVERVIEW.md) for details about running tests and contributing.
 
 ## Examples

--- a/docs/howto/use-nostr-java-api.md
+++ b/docs/howto/use-nostr-java-api.md
@@ -1,0 +1,44 @@
+# Using the nostr-java API
+
+This guide shows how to set up the library and publish a basic [Nostr](https://github.com/nostr-protocol/nips) event.
+
+## Minimal setup
+
+Add the API module to your project:
+
+```xml
+<dependency>
+  <groupId>xyz.tcheeric</groupId>
+  <artifactId>nostr-java-api</artifactId>
+  <version>[VERSION]</version>
+</dependency>
+```
+
+Replace `[VERSION]` with the latest release number.
+
+## Create, sign, and publish an event
+
+```java
+import nostr.api.NIP01;
+import nostr.id.Identity;
+
+import java.util.Map;
+
+public class QuickStart {
+    public static void main(String[] args) {
+        Identity identity = Identity.generateRandomIdentity();
+        Map<String, String> relays = Map.of("local", "wss://nostr.example");
+
+        new NIP01(identity)
+            .createTextNoteEvent("Hello nostr")
+            .sign()
+            .send(relays);
+    }
+}
+```
+
+### Reference
+- [`Identity.generateRandomIdentity`](../../nostr-java-id/src/main/java/nostr/id/Identity.java)
+- [`NIP01.createTextNoteEvent`](../../nostr-java-api/src/main/java/nostr/api/NIP01.java)
+- [`EventNostr.sign`](../../nostr-java-api/src/main/java/nostr/api/EventNostr.java)
+- [`EventNostr.send`](../../nostr-java-api/src/main/java/nostr/api/EventNostr.java)


### PR DESCRIPTION
## Summary
- document minimal nostr-java API usage with setup and text note example
- link to new how-to guide from README

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed. Will not retry)*

------
https://chatgpt.com/codex/tasks/task_b_68a48d97715483319a3a42172a5673a9