### PR TITLE
chore: shorten PR quality gate and skip dependabot

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -1,4 +1,4 @@
-name: PR Quality Gate — AI-Era Expertise Standard
+name: PR Quality Gate
 
 on:
   pull_request:
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   review:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- rename workflow to shorter "PR Quality Gate"
- skip running the workflow on Dependabot PRs

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_b_68a4cfb1b8a8833189418a1f416f54ee