### PR TITLE
chore: run dependabot against develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    target-branch: "develop"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    target-branch: "develop"


### PR DESCRIPTION
## Summary
- configure dependabot to open PRs against `develop`

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

## Network Access
- No issues encountered

------
https://chatgpt.com/codex/tasks/task_b_68a4d45e4e1c8331b201b85a801a0c34