### PR TITLE
Use pull_request_target for Copilot reviewer workflow

### DIFF
--- a/.github/workflows/assign-copilot-review.yml
+++ b/.github/workflows/assign-copilot-review.yml
@@ -1,7 +1,7 @@
 name: Assign Copilot Reviewer
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [develop]
     types: [opened, reopened, ready_for_review]
 


### PR DESCRIPTION
## Summary
- run Copilot reviewer assignment when PRs target `develop`
- switch trigger to `pull_request_target` so the workflow has write access

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*


------
https://chatgpt.com/codex/tasks/task_b_68a4d6de179483318664b351279ff2a8