### PR TITLE
docs: direct contributors to use develop branch for PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ nostr-java implements the Nostr protocol. A complete index of current Nostr Impl
 ## Development Guidelines
 
 - Run `mvn -q verify` from the repository root before committing.
+- Submit pull requests against the `develop` branch.
 - PR titles and commit messages must follow the `type: description` format.
   - Allowed types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`, `style`.
   - The description must be a concise verb + object phrase (e.g., `refactor: update auth middleware to async`).


### PR DESCRIPTION
## Why now?
Clarifies which branch contributors should target with pull requests to prevent accidental merges into the wrong branch.
Related issue: #____

## What changed?
- document that pull requests must target the `develop` branch

## BREAKING
- n/a

## Review focus
- wording of new contributing guideline

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [x] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)


------
https://chatgpt.com/codex/tasks/task_b_68a650faea788331a45800b6b42ca8c0