### PR TITLE
docs: reinforce PR submission guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ The URL format for the NIPs is https://github.com/nostr-protocol/nips/blob/maste
 
 ## Pull Requests
 
-- Use the pull request template at `.github/pull_request_template.md` and fill out all sections.
+- Always follow the PR submission guidelines and use the pull request template at `.github/pull_request_template.md`, filling out all sections.
 - Summarize the changes made and describe how they were tested.
 - Include any limitations or known issues in the description.
 - Add a "Network Access" section summarizing blocked domains if network requests were denied.


### PR DESCRIPTION
## Why now?
Ensure contributors consistently follow pull request submission guidelines and use the standard PR template.
Related issue: #0

## What changed?
- Reinforced requirement in AGENTS.md to always follow PR submission guidelines and use the pull request template.

## BREAKING
- None

## Review focus
- Wording of the new instruction

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [x] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)

### Testing
- ⚠️ `mvn -q verify` (fails: Docker environment not found)

### Notes
- Tests require a running Docker environment.


------
https://chatgpt.com/codex/tasks/task_b_68a65003a3d48331ac8198bcc1c3a65f