### PR TITLE
ci: surface build errors in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,14 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Build with Maven
-        run: ./mvnw -q verify
+        run: ./mvnw -q verify |& tee build.log
+      - name: Show build log
+        if: failure()
+        run: |
+          echo "Build error"
+          grep '^\[ERROR\]' build.log || true
+          echo "Build log tail"
+          tail -n 200 build.log
       - name: Upload surefire reports
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- capture Maven build output to a log file
- print build errors before the log tail on failure

## Testing
- `./mvnw -q verify` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_b_68a6ed11578c8331a3cf9a256362f5b6