### PR TITLE
ci: surface build errors in failure issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,14 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v4
@@ -17,7 +21,10 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Build with Maven
-        run: ./mvnw -q verify
+        id: build
+        run: |
+          set -o pipefail
+          ./mvnw -q verify | tee build.log
       - name: Upload surefire reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -42,3 +49,21 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Create issue on failure
+        if: failure() && github.ref == 'refs/heads/develop'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const file = fs.readFileSync('build.log', 'utf8').split('\\n');
+            const errors = file.filter(line => line.startsWith('[ERROR]'))
+              .slice(-20)
+              .join('\\n');
+            const log = file.slice(-50).join('\\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `CI build failed for ${context.sha.slice(0,7)}`,
+              body: `Build failed for commit ${context.sha} in workflow run ${context.runId}.\\n\\nBuild error:\\n\\n\u0060\u0060\u0060\\n${errors}\\n\u0060\u0060\u0060\\n\\nLast lines of build log:\\n\\n\u0060\u0060\u0060\\n${log}\\n\u0060\u0060\u0060`,
+              labels: ['ci']
+            });


### PR DESCRIPTION
## Summary
- log Maven error lines in CI failure issue and limit issue creation to the develop branch

## Testing
- ❌ `./mvnw -q verify` (network unreachable)

## Network Access
- `repo.maven.apache.org` (network unreachable)


------
https://chatgpt.com/codex/tasks/task_b_68a6c830fa10833191762c442c77d6bb