### PR TITLE
ci: add codex label step

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -17,3 +17,13 @@ jobs:
           configuration-path: .github/labeler.yml
           include-title: 1
           repo-token: ${{ github.token }}
+      - if: github.actor == 'github-actions[bot]'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['codex']
+            })


### PR DESCRIPTION
## Why now?
Automatically label workflow-created issues with `codex`.
Related issue: #0

## What changed?
- add github-script step to apply `codex` label when workflow runs as GitHub Actions bot

## BREAKING
- n/a

## Review focus
- workflow logic

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)


------
https://chatgpt.com/codex/tasks/task_b_68a723e2c99883318087e8358a49dabf