### PR TITLE
docs: list NIP titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,27 @@ Examples are located in the [`nostr-java-examples`](./nostr-java-examples) modul
 
 ## Supported NIPs
 The API currently implements the following [NIPs](https://github.com/nostr-protocol/nips):
-- [NIP-1](https://github.com/nostr-protocol/nips/blob/master/01.md)
-- [NIP-2](https://github.com/nostr-protocol/nips/blob/master/02.md)
-- [NIP-3](https://github.com/nostr-protocol/nips/blob/master/03.md)
-- [NIP-4](https://github.com/nostr-protocol/nips/blob/master/04.md)
-- [NIP-5](https://github.com/nostr-protocol/nips/blob/master/05.md)
-- [NIP-8](https://github.com/nostr-protocol/nips/blob/master/08.md)
-- [NIP-9](https://github.com/nostr-protocol/nips/blob/master/09.md)
-- [NIP-12](https://github.com/nostr-protocol/nips/blob/master/12.md)
-- [NIP-14](https://github.com/nostr-protocol/nips/blob/master/14.md)
-- [NIP-15](https://github.com/nostr-protocol/nips/blob/master/15.md)
-- [NIP-20](https://github.com/nostr-protocol/nips/blob/master/20.md)
-- [NIP-23](https://github.com/nostr-protocol/nips/blob/master/23.md)
-- [NIP-25](https://github.com/nostr-protocol/nips/blob/master/25.md)
-- [NIP-28](https://github.com/nostr-protocol/nips/blob/master/28.md)
-- [NIP-30](https://github.com/nostr-protocol/nips/blob/master/30.md)
-- [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md)
-- [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md)
-- [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md)
-- [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md)
-- [NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md)
-- [NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md)
-- [NIP-60](https://github.com/nostr-protocol/nips/blob/master/60.md)
-- [NIP-61](https://github.com/nostr-protocol/nips/blob/master/61.md)
-- [NIP-99](https://github.com/nostr-protocol/nips/blob/master/99.md)
+- [NIP-1](https://github.com/nostr-protocol/nips/blob/master/01.md) - Basic protocol flow description
+- [NIP-2](https://github.com/nostr-protocol/nips/blob/master/02.md) - Follow List
+- [NIP-3](https://github.com/nostr-protocol/nips/blob/master/03.md) - OpenTimestamps Attestations for Events
+- [NIP-4](https://github.com/nostr-protocol/nips/blob/master/04.md) - Encrypted Direct Message
+- [NIP-5](https://github.com/nostr-protocol/nips/blob/master/05.md) - Mapping Nostr keys to DNS-based internet identifiers
+- [NIP-8](https://github.com/nostr-protocol/nips/blob/master/08.md) - Handling Mentions
+- [NIP-9](https://github.com/nostr-protocol/nips/blob/master/09.md) - Event Deletion Request
+- [NIP-12](https://github.com/nostr-protocol/nips/blob/master/12.md) - Generic Tag Queries
+- [NIP-14](https://github.com/nostr-protocol/nips/blob/master/14.md) - Subject tag in Text events
+- [NIP-15](https://github.com/nostr-protocol/nips/blob/master/15.md) - Nostr Marketplace
+- [NIP-20](https://github.com/nostr-protocol/nips/blob/master/20.md) - Command Results
+- [NIP-23](https://github.com/nostr-protocol/nips/blob/master/23.md) - Long-form Content
+- [NIP-25](https://github.com/nostr-protocol/nips/blob/master/25.md) - Reactions
+- [NIP-28](https://github.com/nostr-protocol/nips/blob/master/28.md) - Public Chat
+- [NIP-30](https://github.com/nostr-protocol/nips/blob/master/30.md) - Custom Emoji
+- [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) - Labeling
+- [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) - Expiration Timestamp
+- [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md) - Authentication of clients to relays
+- [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) - Encrypted Payloads (Versioned)
+- [NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) - Nostr Remote Signing
+- [NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md) - Lightning Zaps
+- [NIP-60](https://github.com/nostr-protocol/nips/blob/master/60.md) - Cashu Wallets
+- [NIP-61](https://github.com/nostr-protocol/nips/blob/master/61.md) - Nutzaps
+- [NIP-99](https://github.com/nostr-protocol/nips/blob/master/99.md) - Classified Listings


### PR DESCRIPTION
## Why now?
The supported NIP list only referenced numbers, making it hard to identify each proposal.
Related issue: #000

## What changed?
- Show each supported NIP's title alongside its number in the README.

## BREAKING
- n/a

## Review focus
- Accuracy of the NIP titles and links.

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [x] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)


------
https://chatgpt.com/codex/tasks/task_b_68a728bc78a88331851aa6c901ed06e5