### PR TITLE
fix: introduce dedicated exception for signing failures

### DIFF
--- a/nostr-java-api/src/main/java/nostr/api/NostrIF.java
+++ b/nostr-java-api/src/main/java/nostr/api/NostrIF.java
@@ -20,7 +20,7 @@ public interface NostrIF {
   List<String> sendRequest(@NonNull Filters filters, @NonNull String subscriptionId, Map<String, String> relays);
   List<String> sendRequest(@NonNull List<Filters> filtersList, @NonNull String subscriptionId);
   List<String> sendRequest(@NonNull List<Filters> filtersList, @NonNull String subscriptionId, Map<String, String> relays);
-  NostrIF sign(@NonNull Identity identity, @NonNull ISignable signable) throws Exception;
+  NostrIF sign(@NonNull Identity identity, @NonNull ISignable signable);
   boolean verify(@NonNull GenericEvent event);
   Identity getSender();
   Map<String, String> getRelays();

--- a/nostr-java-id/src/main/java/nostr/id/Identity.java
+++ b/nostr-java-id/src/main/java/nostr/id/Identity.java
@@ -88,7 +88,6 @@ public class Identity {
         return cachedPublicKey;
     }
 
-    //    TODO: exceptions refactor
     /**
      * Signs the supplied {@link ISignable} using this identity's private key.
      * The resulting {@link Signature} is returned and also provided to the
@@ -96,7 +95,8 @@ public class Identity {
      *
      * @param signable the entity to sign
      * @return the generated signature
-     * @throws Exception if the signature cannot be created
+     * @throws IllegalStateException if the SHA-256 algorithm is unavailable
+     * @throws SigningException      if the signature cannot be created
      */
     public Signature sign(@NonNull ISignable signable) {
         try {
@@ -117,7 +117,7 @@ public class Identity {
             throw new IllegalStateException("SHA-256 algorithm not available", ex);
         } catch (Exception ex) {
             log.error("Signing failed", ex);
-            throw new IllegalArgumentException("Failed to sign with provided key", ex);
+            throw new SigningException("Failed to sign with provided key", ex);
         }
     }
 

--- a/nostr-java-id/src/main/java/nostr/id/SigningException.java
+++ b/nostr-java-id/src/main/java/nostr/id/SigningException.java
@@ -1,0 +1,10 @@
+package nostr.id;
+
+import lombok.experimental.StandardException;
+
+/**
+ * Exception thrown when signing an {@link nostr.base.ISignable} fails.
+ */
+@StandardException
+public class SigningException extends RuntimeException {
+}

--- a/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
+++ b/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
@@ -112,6 +112,7 @@ public class IdentityTest {
     }
 
     @Test
+    // Ensures that signing with an invalid private key throws SigningException
     public void testSignWithInvalidKeyFails() {
         String invalidPriv = "0000000000000000000000000000000000000000000000000000000000000000";
         Identity identity = Identity.create(invalidPriv);
@@ -140,6 +141,6 @@ public class IdentityTest {
             }
         };
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> identity.sign(signable));
+        Assertions.assertThrows(SigningException.class, () -> identity.sign(signable));
     }
 }


### PR DESCRIPTION
## Summary
- wrap signing failures in custom `SigningException` and document behavior
- propagate new exception through API and tests

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed)*


------
https://chatgpt.com/codex/tasks/task_b_68a732b6ebec8331b89cf02365e975b0