### PR TITLE
fix: remove default marker assignment in EventTag

### DIFF
--- a/nostr-java-event/src/main/java/nostr/event/tag/EventTag.java
+++ b/nostr-java-event/src/main/java/nostr/event/tag/EventTag.java
@@ -42,11 +42,7 @@ public class EventTag extends BaseTag {
     private Marker marker;
 
     public EventTag(String idEvent) {
-        this.recommendedRelayUrl = null;
         this.idEvent = idEvent;
-
-        // TODO: This is a bug. The marker should not be set, or at least not like this.
-        //this.marker = this.idEvent == null ? Marker.ROOT : Marker.REPLY;
     }
 
     public static <T extends BaseTag> T deserialize(@NonNull JsonNode node) {

--- a/nostr-java-event/src/test/java/nostr/event/unit/EventTagTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/EventTagTest.java
@@ -1,6 +1,8 @@
 package nostr.event.unit;
 
 import nostr.base.Marker;
+import nostr.event.BaseTag;
+import nostr.event.json.codec.BaseTagEncoder;
 import nostr.event.tag.EventTag;
 import org.junit.jupiter.api.Test;
 
@@ -9,12 +11,17 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Predicate;
 
+import static nostr.base.IEvent.MAPPER_BLACKBIRD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EventTagTest {
 
     @Test
+    // Verifies that getSupportedFields returns expected fields and values.
     void getSupportedFields() {
         String eventId = UUID.randomUUID().toString().concat(UUID.randomUUID().toString()).substring(0, 64);
         String recommendedRelayUrl = "ws://localhost:5555";
@@ -34,6 +41,42 @@ class EventTagTest {
 
         assertFalse(fields.stream().anyMatch(field -> field.getName().equals("idEventXXX")));
         assertFalse(fields.stream().flatMap(field -> eventTag.getFieldValue(field).stream()).anyMatch(fieldValue -> fieldValue.equals(eventId + "x")));
+    }
+
+    @Test
+    // Ensures that a newly created EventTag has a null marker and serializes without it.
+    void serializeWithoutMarker() throws Exception {
+        String eventId = "494001ac0c8af2a10f60f23538e5b35d3cdacb8e1cc956fe7a16dfa5cbfc4346";
+        EventTag eventTag = new EventTag(eventId);
+
+        assertNull(eventTag.getMarker());
+
+        String json = new BaseTagEncoder(eventTag).encode();
+        assertEquals("[\"e\",\"" + eventId + "\"]", json);
+
+        BaseTag decoded = MAPPER_BLACKBIRD.readValue(json, BaseTag.class);
+        assertInstanceOf(EventTag.class, decoded);
+        assertNull(((EventTag) decoded).getMarker());
+    }
+
+    @Test
+    // Checks that an explicit marker is serialized and restored on deserialization.
+    void serializeWithMarker() throws Exception {
+        String eventId = "494001ac0c8af2a10f60f23538e5b35d3cdacb8e1cc956fe7a16dfa5cbfc4346";
+        EventTag eventTag = EventTag.builder()
+                .idEvent(eventId)
+                .recommendedRelayUrl("wss://relay.example.com")
+                .marker(Marker.ROOT)
+                .build();
+
+        String json = new BaseTagEncoder(eventTag).encode();
+        assertEquals("[\"e\",\"" + eventId + "\",\"wss://relay.example.com\",\"ROOT\"]", json);
+
+        BaseTag decoded = MAPPER_BLACKBIRD.readValue(json, BaseTag.class);
+        assertInstanceOf(EventTag.class, decoded);
+        EventTag decodedEventTag = (EventTag) decoded;
+        assertEquals(Marker.ROOT, decodedEventTag.getMarker());
+        assertEquals("wss://relay.example.com", decodedEventTag.getRecommendedRelayUrl());
     }
 
     private static void anyFieldNameMatch(List<Field> fields, Predicate<Field> predicate) {

--- a/nostr-java-event/src/test/java/nostr/event/unit/TagDeserializerTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/unit/TagDeserializerTest.java
@@ -13,10 +13,12 @@ import java.math.BigDecimal;
 import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class TagDeserializerTest {
 
     @Test
+    // Parses an AddressTag from JSON and verifies its fields.
     void testAddressTagDeserialization() throws Exception {
         String pubKey = "bbbd79f81439ff794cf5ac5f7bff9121e257f399829e472c7a14d3e86fe76984";
         String json = "[\"a\",\"1:" + pubKey + ":test\",\"ws://localhost:8080\"]";
@@ -30,6 +32,7 @@ class TagDeserializerTest {
     }
 
     @Test
+    // Parses an EventTag with relay and marker and checks values.
     void testEventTagDeserialization() throws Exception {
         String id = "494001ac0c8af2a10f60f23538e5b35d3cdacb8e1cc956fe7a16dfa5cbfc4346";
         String json = "[\"e\",\"" + id + "\",\"wss://relay.example.com\",\"root\"]";
@@ -42,6 +45,20 @@ class TagDeserializerTest {
     }
 
     @Test
+    // Parses an EventTag without relay or marker and ensures marker is null.
+    void testEventTagDeserializationWithoutMarker() throws Exception {
+        String id = "494001ac0c8af2a10f60f23538e5b35d3cdacb8e1cc956fe7a16dfa5cbfc4346";
+        String json = "[\"e\",\"" + id + "\"]";
+        BaseTag tag = MAPPER_BLACKBIRD.readValue(json, BaseTag.class);
+        assertInstanceOf(EventTag.class, tag);
+        EventTag eTag = (EventTag) tag;
+        assertEquals(id, eTag.getIdEvent());
+        assertNull(eTag.getMarker());
+        assertNull(eTag.getRecommendedRelayUrl());
+    }
+
+    @Test
+    // Parses a PriceTag from JSON and validates number and currency.
     void testPriceTagDeserialization() throws Exception {
         String json = "[\"price\",\"10.99\",\"USD\"]";
         BaseTag tag = MAPPER_BLACKBIRD.readValue(json, BaseTag.class);
@@ -52,6 +69,7 @@ class TagDeserializerTest {
     }
 
     @Test
+    // Parses a UrlTag from JSON and checks the URL value.
     void testUrlTagDeserialization() throws Exception {
         String json = "[\"u\",\"http://example.com\"]";
         BaseTag tag = MAPPER_BLACKBIRD.readValue(json, BaseTag.class);
@@ -61,6 +79,7 @@ class TagDeserializerTest {
     }
 
     @Test
+    // Falls back to GenericTag for unknown tag codes.
     void testGenericFallback() throws Exception {
         String json = "[\"unknown\",\"value\"]";
         BaseTag tag = MAPPER_BLACKBIRD.readValue(json, BaseTag.class);


### PR DESCRIPTION
## Summary
- stop EventTag from pre-setting marker so it remains null unless explicitly provided
- add tests verifying default marker omission and explicit marker serialization/deserialization
- document event tag deserialization without marker

## Testing
- `mvn -q verify` *(fails: Could not find a valid Docker environment; see logs)*

------
https://chatgpt.com/codex/tasks/task_b_68a7329a2a7083318066373b0b8dab5d