### PR TITLE
docs: enforce PR template usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ The URL format for the NIPs is https://github.com/nostr-protocol/nips/blob/maste
 
 ## Pull Requests
 
-- Always follow the PR submission guidelines and use the pull request template at `.github/pull_request_template.md`, filling out all sections.
+- Always use the pull request template at `.github/pull_request_template.md` when crafting a PR, and fill out all sections.
 - Summarize the changes made and describe how they were tested.
 - Include any limitations or known issues in the description.
 - Add a "Network Access" section summarizing blocked domains if network requests were denied.


### PR DESCRIPTION
## Why now?
Ensures contributors always start from the PR template and complete all sections.
Related issue: #N/A

## What changed?
- Clarified AGENTS instructions to mandate PR template usage.

## BREAKING
None.

## Review focus
Confirm wording and placement in `AGENTS.md`.

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [x] Description links the issue and answers “why now?”
- [x] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)

## Network Access
No network access issues encountered.


------
https://chatgpt.com/codex/tasks/task_b_68a73982c4e883319d61dfb1474448bc