### PR TITLE
test: add validation tests for event implementations

### DIFF
--- a/nostr-java-event/src/test/java/nostr/event/impl/AddressableEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/AddressableEventValidateTest.java
@@ -1,0 +1,39 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AddressableEventValidateTest {
+    private static final String HEX_64 = "a".repeat(64);
+    private static final String SIG_HEX = "b".repeat(128);
+
+    private AddressableEvent createEvent(int kind) {
+        AddressableEvent event = new AddressableEvent(new PublicKey(HEX_64), kind, new ArrayList<BaseTag>(), "");
+        event.setId(HEX_64);
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        event.setSignature(Signature.fromString(SIG_HEX));
+        return event;
+    }
+
+    // Valid kind within the 30000-39999 range passes validation
+    @Test
+    public void testValidateKindSuccess() {
+        AddressableEvent event = createEvent(30000);
+        assertDoesNotThrow(event::validate);
+    }
+
+    // Kind outside the allowed range triggers validation failure
+    @Test
+    public void testValidateKindFailure() {
+        AddressableEvent event = createEvent(1000);
+        assertThrows(AssertionError.class, event::validate);
+    }
+}

--- a/nostr-java-event/src/test/java/nostr/event/impl/ChannelMessageEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/ChannelMessageEventValidateTest.java
@@ -1,0 +1,61 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ChannelMessageEventValidateTest {
+    private static final String HEX_64_A = "a".repeat(64);
+    private static final String HEX_64_B = "b".repeat(64);
+    private static final String SIG_HEX = "c".repeat(128);
+    private static final String CHANNEL_JSON = "{\"name\":\"chan\",\"about\":\"desc\",\"picture\":\"http://example.com/img.png\"}";
+
+    private ChannelCreateEvent createRootEvent() {
+        ChannelCreateEvent root = new ChannelCreateEvent(new PublicKey(HEX_64_A), CHANNEL_JSON);
+        root.setId(HEX_64_B);
+        root.setCreatedAt(Instant.now().getEpochSecond());
+        root.setSignature(Signature.fromString(SIG_HEX));
+        return root;
+    }
+
+    private ChannelMessageEvent createValidEvent() {
+        ChannelCreateEvent root = createRootEvent();
+        ChannelMessageEvent event = new ChannelMessageEvent(new PublicKey(HEX_64_A), root, "hi", null);
+        event.setId(HEX_64_A);
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        event.setSignature(Signature.fromString(SIG_HEX));
+        return event;
+    }
+
+    // Channel message referencing its root event validates successfully
+    @Test
+    public void testValidateSuccess() {
+        ChannelMessageEvent event = createValidEvent();
+        assertDoesNotThrow(event::validate);
+    }
+
+    // Missing root event tag results in validation failure
+    @Test
+    public void testValidateMissingRootTag() {
+        ChannelMessageEvent event = new ChannelMessageEvent(new PublicKey(HEX_64_A), new ArrayList<BaseTag>(), "hi");
+        event.setId(HEX_64_A);
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        event.setSignature(Signature.fromString(SIG_HEX));
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    // Wrong kind value triggers validation error
+    @Test
+    public void testValidateWrongKind() {
+        ChannelMessageEvent event = createValidEvent();
+        event.setKind(-1);
+        assertThrows(AssertionError.class, event::validate);
+    }
+}

--- a/nostr-java-event/src/test/java/nostr/event/impl/DeletionEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/DeletionEventValidateTest.java
@@ -1,0 +1,67 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import nostr.event.tag.EventTag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DeletionEventValidateTest {
+    private static final String HEX_64_A = "a".repeat(64);
+    private static final String HEX_64_B = "b".repeat(64);
+    private static final String SIG_HEX = "c".repeat(128);
+
+    private DeletionEvent createValidEvent() {
+        PublicKey pubKey = new PublicKey(HEX_64_A);
+        List<BaseTag> tags = new ArrayList<>();
+        tags.add(new EventTag(HEX_64_B));
+        tags.add(BaseTag.create("k", "1"));
+        DeletionEvent event = new DeletionEvent(pubKey, tags);
+        event.setId(HEX_64_A);
+        event.setSignature(Signature.fromString(SIG_HEX));
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        return event;
+    }
+
+    // Valid deletion event with required tags passes validation
+    @Test
+    public void testValidateSuccess() {
+        DeletionEvent event = createValidEvent();
+        assertDoesNotThrow(event::validate);
+    }
+
+    // Validation fails when event or author tag is missing
+    @Test
+    public void testValidateMissingEventOrAuthorTag() {
+        DeletionEvent event = createValidEvent();
+        List<BaseTag> tags = new ArrayList<>();
+        tags.add(BaseTag.create("k", "1"));
+        event.setTags(tags);
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    // Validation fails when the kind tag is absent
+    @Test
+    public void testValidateMissingKindTag() {
+        DeletionEvent event = createValidEvent();
+        List<BaseTag> tags = new ArrayList<>();
+        tags.add(new EventTag(HEX_64_B));
+        event.setTags(tags);
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    // Validation fails if the event kind is incorrect
+    @Test
+    public void testValidateWrongKind() {
+        DeletionEvent event = createValidEvent();
+        event.setKind(-1);
+        assertThrows(AssertionError.class, event::validate);
+    }
+}

--- a/nostr-java-event/src/test/java/nostr/event/impl/DirectMessageEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/DirectMessageEventValidateTest.java
@@ -1,0 +1,56 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DirectMessageEventValidateTest {
+    private static final String HEX_64_A = "a".repeat(64);
+    private static final String HEX_64_B = "b".repeat(64);
+    private static final String SIG_HEX = "c".repeat(128);
+
+    private DirectMessageEvent createValidEvent() {
+        DirectMessageEvent event = new DirectMessageEvent(new PublicKey(HEX_64_A), new PublicKey(HEX_64_B), "hello");
+        event.setId(HEX_64_A);
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        event.setSignature(Signature.fromString(SIG_HEX));
+        return event;
+    }
+
+    private DirectMessageEvent createEventWithoutRecipient() {
+        DirectMessageEvent event = new DirectMessageEvent(new PublicKey(HEX_64_A), new ArrayList<BaseTag>(), "hello");
+        event.setId(HEX_64_A);
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        event.setSignature(Signature.fromString(SIG_HEX));
+        return event;
+    }
+
+    // Direct message with recipient tag validates successfully
+    @Test
+    public void testValidateSuccess() {
+        DirectMessageEvent event = createValidEvent();
+        assertDoesNotThrow(event::validate);
+    }
+
+    // Missing recipient public key tag causes validation failure
+    @Test
+    public void testValidateMissingRecipient() {
+        DirectMessageEvent event = createEventWithoutRecipient();
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    // Incorrect kind value is rejected during validation
+    @Test
+    public void testValidateWrongKind() {
+        DirectMessageEvent event = createValidEvent();
+        event.setKind(-1);
+        assertThrows(AssertionError.class, event::validate);
+    }
+}

--- a/nostr-java-event/src/test/java/nostr/event/impl/EphemeralEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/EphemeralEventValidateTest.java
@@ -1,0 +1,39 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class EphemeralEventValidateTest {
+    private static final String HEX_64 = "a".repeat(64);
+    private static final String SIG_HEX = "b".repeat(128);
+
+    private EphemeralEvent createEvent(int kind) {
+        EphemeralEvent event = new EphemeralEvent(new PublicKey(HEX_64), kind, new ArrayList<BaseTag>(), "");
+        event.setId(HEX_64);
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        event.setSignature(Signature.fromString(SIG_HEX));
+        return event;
+    }
+
+    // Kind within the 20000-29999 range validates successfully
+    @Test
+    public void testValidateKindSuccess() {
+        EphemeralEvent event = createEvent(20000);
+        assertDoesNotThrow(event::validate);
+    }
+
+    // Kind outside the 20000-29999 range fails validation
+    @Test
+    public void testValidateKindFailure() {
+        EphemeralEvent event = createEvent(1000);
+        assertThrows(AssertionError.class, event::validate);
+    }
+}

--- a/nostr-java-event/src/test/java/nostr/event/impl/HideMessageEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/HideMessageEventValidateTest.java
@@ -1,0 +1,53 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import nostr.event.tag.EventTag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HideMessageEventValidateTest {
+    private static final String HEX_64_A = "a".repeat(64);
+    private static final String HEX_64_B = "b".repeat(64);
+    private static final String SIG_HEX = "c".repeat(128);
+
+    private HideMessageEvent createValidEvent() {
+        List<BaseTag> tags = new ArrayList<>();
+        tags.add(new EventTag(HEX_64_B));
+        HideMessageEvent event = new HideMessageEvent(new PublicKey(HEX_64_A), tags, "");
+        event.setId(HEX_64_A);
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        event.setSignature(Signature.fromString(SIG_HEX));
+        return event;
+    }
+
+    // Hide message event with at least one event tag validates successfully
+    @Test
+    public void testValidateSuccess() {
+        HideMessageEvent event = createValidEvent();
+        assertDoesNotThrow(event::validate);
+    }
+
+    // Missing event tag causes validation to fail
+    @Test
+    public void testValidateMissingEventTag() {
+        HideMessageEvent event = createValidEvent();
+        event.setTags(new ArrayList<>());
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    // Wrong kind value triggers validation error
+    @Test
+    public void testValidateWrongKind() {
+        HideMessageEvent event = createValidEvent();
+        event.setKind(-1);
+        assertThrows(AssertionError.class, event::validate);
+    }
+}

--- a/nostr-java-event/src/test/java/nostr/event/impl/MuteUserEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/MuteUserEventValidateTest.java
@@ -1,0 +1,62 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import nostr.event.tag.PubKeyTag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MuteUserEventValidateTest {
+    private static final String HEX_64_A = "a".repeat(64);
+    private static final String HEX_64_B = "b".repeat(64);
+    private static final String SIG_HEX = "c".repeat(128);
+
+    private MuteUserEvent createValidEvent() {
+        PublicKey pubKey = new PublicKey(HEX_64_A);
+        List<BaseTag> tags = new ArrayList<>();
+        tags.add(new PubKeyTag(new PublicKey(HEX_64_B)));
+        MuteUserEvent event = new MuteUserEvent(pubKey, tags, "mute");
+        event.setId(HEX_64_A);
+        event.setSignature(Signature.fromString(SIG_HEX));
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        return event;
+    }
+
+    // Valid mute user event should pass validation
+    @Test
+    public void testValidateSuccess() {
+        MuteUserEvent event = createValidEvent();
+        assertDoesNotThrow(event::validate);
+    }
+
+    // Validation fails when the pubkey tag is missing
+    @Test
+    public void testValidateMissingPubKeyTag() {
+        MuteUserEvent event = createValidEvent();
+        event.setTags(new ArrayList<>());
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    // Validation fails if the event kind is incorrect
+    @Test
+    public void testValidateWrongKind() {
+        MuteUserEvent event = createValidEvent();
+        event.setKind(-1);
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    // Retrieves the muted user's public key from tags
+    @Test
+    public void testGetMutedUser() {
+        MuteUserEvent event = createValidEvent();
+        assertEquals(HEX_64_B, event.getMutedUser().toString());
+    }
+}

--- a/nostr-java-event/src/test/java/nostr/event/impl/ReactionEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/ReactionEventValidateTest.java
@@ -1,0 +1,62 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import nostr.event.tag.EventTag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ReactionEventValidateTest {
+    private static final String HEX_64_A = "a".repeat(64);
+    private static final String HEX_64_B = "b".repeat(64);
+    private static final String SIG_HEX = "c".repeat(128);
+
+    private ReactionEvent createValidEvent() {
+        PublicKey pubKey = new PublicKey(HEX_64_A);
+        List<BaseTag> tags = new ArrayList<>();
+        tags.add(new EventTag(HEX_64_B));
+        ReactionEvent event = new ReactionEvent(pubKey, tags, "+");
+        event.setId(HEX_64_A);
+        event.setSignature(Signature.fromString(SIG_HEX));
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        return event;
+    }
+
+    // Valid reaction event should pass validation
+    @Test
+    public void testValidateSuccess() {
+        ReactionEvent event = createValidEvent();
+        assertDoesNotThrow(event::validate);
+    }
+
+    // Validation fails when the required event tag is missing
+    @Test
+    public void testValidateMissingEventTag() {
+        ReactionEvent event = createValidEvent();
+        event.setTags(new ArrayList<>());
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    // Validation fails if the event kind is incorrect
+    @Test
+    public void testValidateWrongKind() {
+        ReactionEvent event = createValidEvent();
+        event.setKind(-1);
+        assertThrows(AssertionError.class, event::validate);
+    }
+
+    // Retrieves the ID of the reacted event from tags
+    @Test
+    public void testGetReactedEventId() {
+        ReactionEvent event = createValidEvent();
+        assertEquals(HEX_64_B, event.getReactedEventId());
+    }
+}

--- a/nostr-java-event/src/test/java/nostr/event/impl/ReplaceableEventValidateTest.java
+++ b/nostr-java-event/src/test/java/nostr/event/impl/ReplaceableEventValidateTest.java
@@ -1,0 +1,56 @@
+package nostr.event.impl;
+
+import nostr.base.PublicKey;
+import nostr.base.Signature;
+import nostr.event.BaseTag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ReplaceableEventValidateTest {
+    private static final String HEX_64_A = "a".repeat(64);
+    private static final String SIG_HEX = "c".repeat(128);
+
+    private ReplaceableEvent createEventWithKind(int kind) {
+        PublicKey pubKey = new PublicKey(HEX_64_A);
+        List<BaseTag> tags = new ArrayList<>();
+        ReplaceableEvent event = new ReplaceableEvent(pubKey, kind, tags, "");
+        event.setId(HEX_64_A);
+        event.setSignature(Signature.fromString(SIG_HEX));
+        event.setCreatedAt(Instant.now().getEpochSecond());
+        return event;
+    }
+
+    // Validation succeeds when kind falls within replaceable range
+    @Test
+    public void testValidateKindInRange() {
+        ReplaceableEvent event = createEventWithKind(10_000);
+        assertDoesNotThrow(event::validate);
+    }
+
+    // Kind zero is allowed for replaceable events
+    @Test
+    public void testValidateKindZero() {
+        ReplaceableEvent event = createEventWithKind(0);
+        assertDoesNotThrow(event::validate);
+    }
+
+    // Kind three is permitted under replaceable rules
+    @Test
+    public void testValidateKindThree() {
+        ReplaceableEvent event = createEventWithKind(3);
+        assertDoesNotThrow(event::validate);
+    }
+
+    // Validation fails when kind is outside the replaceable range
+    @Test
+    public void testValidateKindInvalid() {
+        ReplaceableEvent event = createEventWithKind(9_999);
+        assertThrows(AssertionError.class, event::validate);
+    }
+}


### PR DESCRIPTION
## Summary
- expand validation test coverage to addressable, ephemeral, direct message, hide message, and channel message events
- ensure range and tag rules are verified with plain-English comments for each test

## Testing
- ❌ `mvn -q verify` (fails: Could not find a valid Docker environment)

## Network Access
- No network access issues; failures due to missing Docker environment.

------
https://chatgpt.com/codex/tasks/task_b_68a747cfe1c88331931b320d049c1664