### PR TITLE
refactor: remove unused Nip05Obj inner class

### DIFF
--- a/nostr-java-util/src/main/java/nostr/util/validator/Nip05Validator.java
+++ b/nostr-java-util/src/main/java/nostr/util/validator/Nip05Validator.java
@@ -153,9 +153,4 @@ public class Nip05Validator {
         return names.get(localPart);
     }
 
-    @Data
-    public static final class Nip05Obj {
-        private final String name;
-        private final String nip05;
-    }
 }


### PR DESCRIPTION
## Why now?
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Remove an unused inner class to simplify the validator implementation.
Related issue: #000

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
- drop Nip05Obj inner class from Nip05Validator

## BREAKING
<!-- If applicable, call it out explicitly. -->
<!-- ⚠️ BREAKING: Describe migration or impact. -->

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
- Ensure no lingering references to the removed class.

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)

## Testing
- `rg Nip05Obj -n`
- `mvn -q verify` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_b_68a812df6fb48331bc3f79c8a2ded338