### PR TITLE
refactor: use EventEncodingException for encoding

### DIFF
--- a/nostr-java-base/src/main/java/nostr/base/IDecoder.java
+++ b/nostr-java-base/src/main/java/nostr/base/IDecoder.java
@@ -1,7 +1,6 @@
 package nostr.base;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
@@ -14,6 +13,6 @@ import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 public interface IDecoder<T extends IElement> {
     ObjectMapper I_DECODER_MAPPER_BLACKBIRD
         = JsonMapper.builder().addModule(new BlackbirdModule()).build().configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
-    T decode(String str) throws JsonProcessingException;
+    T decode(String str);
 
 }

--- a/nostr-java-event/src/main/java/nostr/event/BaseMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/BaseMessage.java
@@ -1,8 +1,8 @@
 package nostr.event;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.Getter;
 import nostr.base.IElement;
+import nostr.event.json.codec.EventEncodingException;
 
 /**
  *
@@ -16,5 +16,5 @@ public abstract class BaseMessage implements IElement {
         this.command = command;
     }
 
-    public abstract String encode() throws JsonProcessingException;
+    public abstract String encode() throws EventEncodingException;
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/BaseEventEncoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/BaseEventEncoder.java
@@ -16,7 +16,7 @@ public class BaseEventEncoder<T extends BaseEvent> implements Encoder {
 
     @Override
 //    TODO: refactor all methods calling this to properly handle invalid json exception
-    public String encode() {
+    public String encode() throws EventEncodingException {
         try {
             return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(event);
         } catch (JsonProcessingException e) {

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/BaseTagDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/BaseTagDecoder.java
@@ -1,9 +1,10 @@
 package nostr.event.json.codec;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.Data;
 import nostr.base.IDecoder;
 import nostr.event.BaseTag;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import nostr.event.json.codec.EventEncodingException;
 
 import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
@@ -21,11 +22,11 @@ public class BaseTagDecoder<T extends BaseTag> implements IDecoder<T> {
     }
 
     @Override
-    public T decode(String jsonString) {
+    public T decode(String jsonString) throws EventEncodingException {
         try {
             return MAPPER_BLACKBIRD.readValue(jsonString, clazz);
         } catch (JsonProcessingException ex) {
-            throw new RuntimeException(ex);
+            throw new EventEncodingException("Failed to decode tag", ex);
         }
     }
 

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/BaseTagEncoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/BaseTagEncoder.java
@@ -1,11 +1,12 @@
 package nostr.event.json.codec;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import nostr.base.Encoder;
 import nostr.event.BaseTag;
 import nostr.event.json.serializer.BaseTagSerializer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import nostr.event.json.codec.EventEncodingException;
 
 public record BaseTagEncoder(BaseTag tag) implements Encoder {
     public static final ObjectMapper BASETAG_ENCODER_MAPPER_BLACKBIRD =
@@ -15,11 +16,11 @@ public record BaseTagEncoder(BaseTag tag) implements Encoder {
                     new BaseTagSerializer<>()));
 
     @Override
-    public String encode() {
+    public String encode() throws EventEncodingException {
         try {
             return BASETAG_ENCODER_MAPPER_BLACKBIRD.writeValueAsString(tag);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            throw new EventEncodingException("Failed to encode tag", e);
         }
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/FDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/FDecoder.java
@@ -1,6 +1,6 @@
 package nostr.event.json.codec;
 
 public interface FDecoder<T> {
-  
-  T decode(String str);
+
+  T decode(String str) throws EventEncodingException;
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/GenericEventDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/GenericEventDecoder.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.Data;
 import nostr.base.IDecoder;
 import nostr.event.impl.GenericEvent;
+import nostr.event.json.codec.EventEncodingException;
 
 /**
  *
@@ -24,8 +25,12 @@ public class GenericEventDecoder<T extends GenericEvent> implements IDecoder<T> 
   }
 
   @Override
-  public T decode(String jsonEvent) throws JsonProcessingException {
-    I_DECODER_MAPPER_BLACKBIRD.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
-    return I_DECODER_MAPPER_BLACKBIRD.readValue(jsonEvent, clazz);
+  public T decode(String jsonEvent) throws EventEncodingException {
+    try {
+      I_DECODER_MAPPER_BLACKBIRD.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+      return I_DECODER_MAPPER_BLACKBIRD.readValue(jsonEvent, clazz);
+    } catch (JsonProcessingException e) {
+      throw new EventEncodingException("Failed to decode generic event", e);
+    }
   }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/GenericTagDecoder.java
@@ -1,12 +1,13 @@
 package nostr.event.json.codec;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import nostr.base.ElementAttribute;
 import nostr.base.IDecoder;
 import nostr.event.tag.GenericTag;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import nostr.event.json.codec.EventEncodingException;
 
 import java.util.ArrayList;
 
@@ -25,7 +26,7 @@ public class GenericTagDecoder<T extends GenericTag> implements IDecoder<T> {
     }
 
     @Override
-    public T decode(@NonNull String json) {
+    public T decode(@NonNull String json) throws EventEncodingException {
         try {
             String[] jsonElements = I_DECODER_MAPPER_BLACKBIRD.readValue(json, String[].class);
             GenericTag genericTag = new GenericTag(
@@ -42,23 +43,12 @@ public class GenericTagDecoder<T extends GenericTag> implements IDecoder<T> {
                             }
                         }
                     });
-            /*
-            GenericTag genericTag = new GenericTag(
-                    jsonElements[0],
-                    IntStream.of(1, jsonElements.length - 1)
-                            .mapToObj(i ->
-                                    new ElementAttribute(
-                                            "param".concat(String.valueOf(i - 1)),
-                                            jsonElements[i]))
-                            .distinct()
-                            .toList());
-*/
 
             log.info("Decoded GenericTag: {}", genericTag);
 
             return (T) genericTag;
         } catch (JsonProcessingException ex) {
-            throw new RuntimeException(ex);
+            throw new EventEncodingException("Failed to decode generic tag", ex);
         }
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/codec/Nip05ContentDecoder.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/codec/Nip05ContentDecoder.java
@@ -1,9 +1,10 @@
 package nostr.event.json.codec;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.Data;
 import nostr.base.IDecoder;
 import nostr.event.Nip05Content;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import nostr.event.json.codec.EventEncodingException;
 
 import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
@@ -21,11 +22,11 @@ public class Nip05ContentDecoder<T extends Nip05Content> implements IDecoder<T> 
     }
 
     @Override
-    public T decode(String jsonContent) {
+    public T decode(String jsonContent) throws EventEncodingException {
         try {
             return MAPPER_BLACKBIRD.readValue(jsonContent, clazz);
         } catch (JsonProcessingException ex) {
-            throw new RuntimeException(ex);
+            throw new EventEncodingException("Failed to decode nip05 content", ex);
         }
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/message/CanonicalAuthenticationMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/CanonicalAuthenticationMessage.java
@@ -39,15 +39,15 @@ public class CanonicalAuthenticationMessage extends BaseAuthMessage {
     }
 
     @Override
-    public String encode() throws JsonProcessingException {
+    public String encode() throws EventEncodingException {
         try {
             return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(
                     JsonNodeFactory.instance.arrayNode()
                             .add(getCommand())
                             .add(ENCODER_MAPPER_BLACKBIRD.readTree(
                                     new BaseEventEncoder<>(getEvent()).encode())));
-        } catch (EventEncodingException e) {
-            throw new IllegalStateException("Failed to encode canonical authentication event", e);
+        } catch (JsonProcessingException e) {
+            throw new EventEncodingException("Failed to encode canonical authentication message", e);
         }
     }
 

--- a/nostr-java-event/src/main/java/nostr/event/message/CloseMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/CloseMessage.java
@@ -8,6 +8,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import nostr.base.Command;
 import nostr.event.BaseMessage;
+import nostr.event.json.codec.EventEncodingException;
 
 import static nostr.base.Encoder.ENCODER_MAPPER_BLACKBIRD;
 
@@ -32,11 +33,15 @@ public class CloseMessage extends BaseMessage {
     }
 
     @Override
-    public String encode() throws JsonProcessingException {
-        return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(
-            JsonNodeFactory.instance.arrayNode()
-                .add(getCommand())
-                .add(getSubscriptionId()));
+    public String encode() throws EventEncodingException {
+        try {
+            return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(
+                JsonNodeFactory.instance.arrayNode()
+                    .add(getCommand())
+                    .add(getSubscriptionId()));
+        } catch (JsonProcessingException e) {
+            throw new EventEncodingException("Failed to encode close message", e);
+        }
     }
 
     public static <T extends BaseMessage> T decode(@NonNull Object arg) {

--- a/nostr-java-event/src/main/java/nostr/event/message/EoseMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/EoseMessage.java
@@ -8,6 +8,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import nostr.base.Command;
 import nostr.event.BaseMessage;
+import nostr.event.json.codec.EventEncodingException;
 
 import static nostr.base.Encoder.ENCODER_MAPPER_BLACKBIRD;
 
@@ -31,11 +32,15 @@ public class EoseMessage extends BaseMessage {
     }
 
     @Override
-    public String encode() throws JsonProcessingException {
-        return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(
-            JsonNodeFactory.instance.arrayNode()
-                .add(getCommand())
-                .add(getSubscriptionId()));
+    public String encode() throws EventEncodingException {
+        try {
+            return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(
+                JsonNodeFactory.instance.arrayNode()
+                    .add(getCommand())
+                    .add(getSubscriptionId()));
+        } catch (JsonProcessingException e) {
+            throw new EventEncodingException("Failed to encode eose message", e);
+        }
     }
 
     public static <T extends BaseMessage> T decode(@NonNull Object arg) {

--- a/nostr-java-event/src/main/java/nostr/event/message/GenericMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/GenericMessage.java
@@ -10,6 +10,7 @@ import nostr.base.ElementAttribute;
 import nostr.base.IElement;
 import nostr.base.IGenericElement;
 import nostr.event.BaseMessage;
+import nostr.event.json.codec.EventEncodingException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,11 +48,15 @@ public class GenericMessage extends BaseMessage implements IGenericElement, IEle
     }
 
     @Override
-    public String encode() throws JsonProcessingException {
+    public String encode() throws EventEncodingException {
         var encoderArrayNode = JsonNodeFactory.instance.arrayNode();
         encoderArrayNode.add(getCommand());
         getAttributes().stream().map(ElementAttribute::value).forEach(v -> encoderArrayNode.add(v.toString()));
-        return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(encoderArrayNode);
+        try {
+            return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(encoderArrayNode);
+        } catch (JsonProcessingException e) {
+            throw new EventEncodingException("Failed to encode generic message", e);
+        }
     }
 
     public static <T extends BaseMessage> T decode(@NonNull Object[] msgArr) {

--- a/nostr-java-event/src/main/java/nostr/event/message/NoticeMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/NoticeMessage.java
@@ -8,6 +8,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import nostr.base.Command;
 import nostr.event.BaseMessage;
+import nostr.event.json.codec.EventEncodingException;
 
 import static nostr.base.Encoder.ENCODER_MAPPER_BLACKBIRD;
 
@@ -28,11 +29,15 @@ public class NoticeMessage extends BaseMessage {
     }
 
     @Override
-    public String encode() throws JsonProcessingException {
-        return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(
-            JsonNodeFactory.instance.arrayNode()
-                .add(getCommand())
-                .add(getMessage()));
+    public String encode() throws EventEncodingException {
+        try {
+            return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(
+                JsonNodeFactory.instance.arrayNode()
+                    .add(getCommand())
+                    .add(getMessage()));
+        } catch (JsonProcessingException e) {
+            throw new EventEncodingException("Failed to encode notice message", e);
+        }
     }
 
     public static <T extends BaseMessage> T decode(@NonNull Object arg) {

--- a/nostr-java-event/src/main/java/nostr/event/message/OkMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/OkMessage.java
@@ -8,6 +8,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import nostr.base.Command;
 import nostr.event.BaseMessage;
+import nostr.event.json.codec.EventEncodingException;
 
 import static nostr.base.Encoder.ENCODER_MAPPER_BLACKBIRD;
 import static nostr.base.IDecoder.I_DECODER_MAPPER_BLACKBIRD;
@@ -33,21 +34,25 @@ public class OkMessage extends BaseMessage {
     }
 
     @Override
-    public String encode() throws JsonProcessingException {
-        return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(
-            JsonNodeFactory.instance.arrayNode()
-                .add(getCommand())
-                .add(getEventId())
-                .add(getFlag())
-                .add(getMessage()));
+    public String encode() throws EventEncodingException {
+        try {
+            return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(
+                JsonNodeFactory.instance.arrayNode()
+                    .add(getCommand())
+                    .add(getEventId())
+                    .add(getFlag())
+                    .add(getMessage()));
+        } catch (JsonProcessingException e) {
+            throw new EventEncodingException("Failed to encode ok message", e);
+        }
     }
 
-    public static <T extends BaseMessage> T decode(@NonNull String jsonString) {
+    public static <T extends BaseMessage> T decode(@NonNull String jsonString) throws EventEncodingException {
         try {
             Object[] msgArr = I_DECODER_MAPPER_BLACKBIRD.readValue(jsonString, Object[].class);
             return (T) new OkMessage(msgArr[1].toString(), (Boolean) msgArr[2], msgArr[3].toString());
         } catch (JsonProcessingException e) {
-            throw new AssertionError(e);
+            throw new EventEncodingException("Failed to decode ok message", e);
         }
     }
 }

--- a/nostr-java-event/src/main/java/nostr/event/message/RelayAuthenticationMessage.java
+++ b/nostr-java-event/src/main/java/nostr/event/message/RelayAuthenticationMessage.java
@@ -8,6 +8,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import nostr.base.Command;
 import nostr.event.BaseMessage;
+import nostr.event.json.codec.EventEncodingException;
 
 import static nostr.base.Encoder.ENCODER_MAPPER_BLACKBIRD;
 
@@ -28,11 +29,15 @@ public class RelayAuthenticationMessage extends BaseAuthMessage {
     }
 
     @Override
-    public String encode() throws JsonProcessingException {
-        return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(
-            JsonNodeFactory.instance.arrayNode()
-                .add(getCommand())
-                .add(getChallenge()));
+    public String encode() throws EventEncodingException {
+        try {
+            return ENCODER_MAPPER_BLACKBIRD.writeValueAsString(
+                JsonNodeFactory.instance.arrayNode()
+                    .add(getCommand())
+                    .add(getChallenge()));
+        } catch (JsonProcessingException e) {
+            throw new EventEncodingException("Failed to encode relay authentication message", e);
+        }
     }
 
     public static <T extends BaseMessage> T decode(@NonNull Object arg) {


### PR DESCRIPTION
## Summary
- replace JsonProcessingException with EventEncodingException across message encoders and decoders
- surface EventEncodingException from message and tag codecs
- adjust integration tests for new exception handling

## Testing
- `mvn -q verify` *(fails: Previous attempts to find a Docker environment failed. Will not retry.)*


------
https://chatgpt.com/codex/tasks/task_b_68a812eddc248331a9df050b0ea234ad