### PR TITLE
ci: restrict codex workflow to CI-created issues

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   codex-job:
-    if: contains(github.event.label.name, 'codex')
+    if: contains(github.event.label.name, 'codex') && github.event.issue.user.login == 'github-actions[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Why now?
Codex should only act on issues created automatically by the CI workflow to avoid manual triggering.
Related issue: #0

## What changed?
- Restrict Codex workflow to codex-labeled issues opened by `github-actions[bot]`.

## BREAKING
- None.

## Review focus
- Ensure workflow condition is correct.

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object**
- [x] Description links the issue and answers “why now?”
- [x] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)

### Testing
```bash
mvn -q verify
# [ERROR] Tests run: 7, Failures: 0, Errors: 7, Skipped: 0
# java.lang.IllegalStateException: Could not find a valid Docker environment. Please see logs and check configuration
```


------
https://chatgpt.com/codex/tasks/task_b_68a8df8ba3a483318010f4688f82d47b