### PR TITLE
ci: add release-please configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,22 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          command: manifest
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,12 @@
+{
+  ".": "0.2.2",
+  "nostr-java-base": "0.2.2",
+  "nostr-java-crypto": "0.2.2",
+  "nostr-java-event": "0.2.2",
+  "nostr-java-examples": "0.2.2",
+  "nostr-java-id": "0.2.2",
+  "nostr-java-util": "0.2.2",
+  "nostr-java-client": "0.2.2",
+  "nostr-java-api": "0.2.2",
+  "nostr-java-encryption": "0.2.2"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,63 @@
+{
+  "packages": {
+    ".": {
+      "release-type": "maven",
+      "package-name": "nostr-java",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "nostr-java-base": {
+      "release-type": "maven",
+      "package-name": "nostr-java-base",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "nostr-java-crypto": {
+      "release-type": "maven",
+      "package-name": "nostr-java-crypto",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "nostr-java-event": {
+      "release-type": "maven",
+      "package-name": "nostr-java-event",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "nostr-java-examples": {
+      "release-type": "maven",
+      "package-name": "nostr-java-examples",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "nostr-java-id": {
+      "release-type": "maven",
+      "package-name": "nostr-java-id",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "nostr-java-util": {
+      "release-type": "maven",
+      "package-name": "nostr-java-util",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "nostr-java-client": {
+      "release-type": "maven",
+      "package-name": "nostr-java-client",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "nostr-java-api": {
+      "release-type": "maven",
+      "package-name": "nostr-java-api",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "nostr-java-encryption": {
+      "release-type": "maven",
+      "package-name": "nostr-java-encryption",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    }
+  }
+}


### PR DESCRIPTION
## Why now?
Automate releases across modules with Release Please.
Related issue: #000

## What changed?
- add Release Please configuration and manifest
- add release workflow for manifest command
- retag legacy releases with `v`-prefixed semver tags

## BREAKING
- none

## Review focus
- correctness of module mapping and workflow config

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)

## Testing
```bash
mvn -q verify
# ...
# [ERROR] nostr.api.integration.ApiNIP52EventIT -- Time elapsed: 0.003 s <<< ERROR!
# java.lang.IllegalStateException: Previous attempts to find a Docker environment failed. Will not retry. Please see logs and check configuration
```


------
https://chatgpt.com/codex/tasks/task_b_68af6fec74708331b9fca0f20dc63869