### PR TITLE
ci: add workflow to publish artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Configure Maven
+        run: |
+          mkdir -p ~/.m2
+          cat <<EOF > ~/.m2/settings.xml
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <servers>
+              <server>
+                <id>reposilite-releases</id>
+                <username>${MAVEN_USERNAME}</username>
+                <password>${MAVEN_PASSWORD}</password>
+              </server>
+              <server>
+                <id>reposilite-snapshots</id>
+                <username>${MAVEN_USERNAME}</username>
+                <password>${MAVEN_PASSWORD}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      - name: Publish artifacts
+        run: ./mvnw -q deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}


### PR DESCRIPTION
## Why now?
Automate artifact publishing when changes land on `main` so the Maven repository stays up to date.
Related issue: #000

## What changed?
- add publish workflow to deploy artifacts to https://maven.398ja.xyz on pushes to `main`

## BREAKING
- none

## Review focus
- workflow setup and secret usage

## Checklist
- [x] Scope ≤ 300 lines
- [x] Title is **verb + object**
- [x] Description links the issue and answers “why now?”
- [x] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)

## Testing
- ❌ `./mvnw -q verify` *(network unreachable)*

## Network Access
- Maven Central downloads blocked: `java.net.SocketException: Network is unreachable`


------
https://chatgpt.com/codex/tasks/task_b_68af71c2b54c833193ad85f6a13cf572