### PR TITLE
ci: trigger publish on release workflow run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,13 @@
 name: Publish
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ["release-please"]
+    types: [completed]
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Why now?
Ensure publish workflow runs only after successful release process on `main`.
Related issue: #000

## What changed?
- Publish workflow now triggered by `release-please` workflow completion
- Guarded deployment to run only on successful `main` runs

## BREAKING
None

## Review focus
Confirm workflow syntax and conditional logic.

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [x] Description links the issue and answers “why now?”
- [x] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)


------
https://chatgpt.com/codex/tasks/task_b_68b0a12a85208331810f1da477947dc7