### PR TITLE
ci: run CodeQL after CI workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,13 +4,13 @@ name: CodeQL
 # "advanced configuration" errors when using this workflow.
 
 on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 jobs:
   analyze:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Why now?
Restructures CodeQL analysis to execute only after the CI workflow completes successfully.
Related issue: #0

## What changed?
- Trigger CodeQL via `workflow_run` on CI completion
- Run analysis only when CI succeeds

## BREAKING
- n/a

## Review focus
- Ensure workflow condition and trigger match project expectations

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [x] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)

------
https://chatgpt.com/codex/tasks/task_b_68b0a1279db88331826fed2c9f1b113b