### PR TITLE
ci: trigger format after conventional commits

### DIFF
--- a/.github/workflows/google-java-format.yml
+++ b/.github/workflows/google-java-format.yml
@@ -1,12 +1,14 @@
 name: Format
 
 on:
-  push:
-    branches: [ main, develop  ]
+  workflow_run:
+    workflows: ["Conventional Commits"]
+    types: [completed]
 
 jobs:
 
   formatting:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4 # v2 minimum required


### PR DESCRIPTION
## Why now?
Trigger format workflow only after Conventional Commits to prevent duplicate runs and ensure commits meet style guidelines.
Related issue: #0

## What changed?
- run google-java-format workflow on workflow_run after Conventional Commits
- guard formatting job on successful Conventional Commits run

## BREAKING
- n/a

## Review focus
- ensure workflow triggers and job guard logic are correct

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [x] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)


------
https://chatgpt.com/codex/tasks/task_b_68b0a12290488331ba28f22107fdcdc8