### PR TITLE
refactor: unify nostr exception hierarchy

### DIFF
--- a/nostr-java-api/src/main/java/nostr/api/NIP05.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP05.java
@@ -10,13 +10,13 @@ import static nostr.util.NostrUtil.escapeJsonString;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.ArrayList;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import nostr.api.factory.impl.GenericEventFactory;
 import nostr.config.Constants;
 import nostr.event.entities.UserProfile;
 import nostr.event.impl.GenericEvent;
 import nostr.id.Identity;
 import nostr.util.validator.Nip05Validator;
+import nostr.event.json.codec.EventEncodingException;
 
 /**
  * NIP-05 helpers (DNS-based verification). Create internet identifier metadata events.
@@ -34,7 +34,6 @@ public class NIP05 extends EventNostr {
    * @param profile the associate user profile
    * @return the IIM event
    */
-  @SneakyThrows
   @SuppressWarnings({"rawtypes","unchecked"})
   public NIP05 createInternetIdentifierMetadataEvent(@NonNull UserProfile profile) {
     String content = getContent(profile);
@@ -56,7 +55,7 @@ public class NIP05 extends EventNostr {
                   .build());
       return escapeJsonString(jsonString);
     } catch (JsonProcessingException ex) {
-      throw new RuntimeException(ex);
+      throw new EventEncodingException("Failed to encode NIP-05 profile content", ex);
     }
   }
 }

--- a/nostr-java-api/src/main/java/nostr/api/NIP25.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP25.java
@@ -4,10 +4,10 @@
  */
 package nostr.api;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import nostr.api.factory.impl.BaseTagFactory;
 import nostr.api.factory.impl.GenericEventFactory;
 import nostr.base.Relay;
@@ -126,9 +126,12 @@ public class NIP25 extends EventNostr {
     return new BaseTagFactory(Constants.Tag.EMOJI_CODE, shortcode, url.toString()).create();
   }
 
-  @SneakyThrows
   public static BaseTag createCustomEmojiTag(@NonNull String shortcode, @NonNull String url) {
-    return createCustomEmojiTag(shortcode, URI.create(url).toURL());
+    try {
+      return createCustomEmojiTag(shortcode, URI.create(url).toURL());
+    } catch (MalformedURLException ex) {
+      throw new IllegalArgumentException("Invalid custom emoji URL: " + url, ex);
+    }
   }
 
   /**

--- a/nostr-java-api/src/main/java/nostr/api/NIP60.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP60.java
@@ -2,6 +2,7 @@ package nostr.api;
 
 import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -9,7 +10,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import nostr.api.factory.impl.BaseTagFactory;
 import nostr.api.factory.impl.GenericEventFactory;
 import nostr.base.Relay;
@@ -23,6 +23,7 @@ import nostr.event.entities.CashuWallet;
 import nostr.event.entities.SpendingHistory;
 import nostr.event.impl.GenericEvent;
 import nostr.event.json.codec.BaseTagEncoder;
+import nostr.event.json.codec.EventEncodingException;
 import nostr.id.Identity;
 
 /**
@@ -176,7 +177,6 @@ public class NIP60 extends EventNostr {
     return new BaseTagFactory(Constants.Tag.EXPIRATION_CODE, expiration.toString()).create();
   }
 
-  @SneakyThrows
   private String getWalletEventContent(@NonNull CashuWallet wallet) {
     List<BaseTag> tags = new ArrayList<>();
     Map<String, Set<Relay>> relayMap = wallet.getRelays();
@@ -184,22 +184,27 @@ public class NIP60 extends EventNostr {
     unitSet.forEach(u -> tags.add(NIP60.createBalanceTag(wallet.getBalance(), u)));
     tags.add(NIP60.createPrivKeyTag(wallet.getPrivateKey()));
 
-    return NIP44.encrypt(
-        getSender(), MAPPER_BLACKBIRD.writeValueAsString(tags), getSender().getPublicKey());
+    try {
+      String serializedTags = MAPPER_BLACKBIRD.writeValueAsString(tags);
+      return NIP44.encrypt(getSender(), serializedTags, getSender().getPublicKey());
+    } catch (JsonProcessingException ex) {
+      throw new EventEncodingException("Failed to encode wallet content", ex);
+    }
   }
 
-  @SneakyThrows
   private String getTokenEventContent(@NonNull CashuToken token) {
-    return NIP44.encrypt(
-        getSender(), MAPPER_BLACKBIRD.writeValueAsString(token), getSender().getPublicKey());
+    try {
+      String serializedToken = MAPPER_BLACKBIRD.writeValueAsString(token);
+      return NIP44.encrypt(getSender(), serializedToken, getSender().getPublicKey());
+    } catch (JsonProcessingException ex) {
+      throw new EventEncodingException("Failed to encode token content", ex);
+    }
   }
 
-  @SneakyThrows
   private String getRedemptionQuoteEventContent(@NonNull CashuQuote quote) {
     return NIP44.encrypt(getSender(), quote.getId(), getSender().getPublicKey());
   }
 
-  @SneakyThrows
   private String getSpendingHistoryEventContent(@NonNull SpendingHistory spendingHistory) {
     List<BaseTag> tags = new ArrayList<>();
     tags.add(NIP60.createDirectionTag(spendingHistory.getDirection()));

--- a/nostr-java-api/src/main/java/nostr/api/NIP61.java
+++ b/nostr-java-api/src/main/java/nostr/api/NIP61.java
@@ -1,10 +1,10 @@
 package nostr.api;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import nostr.api.factory.impl.BaseTagFactory;
 import nostr.api.factory.impl.GenericEventFactory;
 import nostr.base.PublicKey;
@@ -75,15 +75,18 @@ public class NIP61 extends EventNostr {
    * @param content optional human-readable content
    * @return this instance for chaining
    */
-  @SneakyThrows
   public NIP61 createNutzapEvent(@NonNull NutZap nutZap, @NonNull String content) {
-
-    return createNutzapEvent(
-        nutZap.getProofs(),
-        URI.create(nutZap.getMint().getUrl()).toURL(),
-        nutZap.getNutZappedEvent(),
-        nutZap.getRecipient(),
-        content);
+    try {
+      return createNutzapEvent(
+          nutZap.getProofs(),
+          URI.create(nutZap.getMint().getUrl()).toURL(),
+          nutZap.getNutZappedEvent(),
+          nutZap.getRecipient(),
+          content);
+    } catch (MalformedURLException ex) {
+      throw new IllegalArgumentException(
+          "Invalid mint URL for Nutzap event: " + nutZap.getMint().getUrl(), ex);
+    }
   }
 
   /**

--- a/nostr-java-api/src/main/java/nostr/api/NostrSpringWebSocketClient.java
+++ b/nostr-java-api/src/main/java/nostr/api/NostrSpringWebSocketClient.java
@@ -1,6 +1,7 @@
 package nostr.api;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -20,6 +21,7 @@ import nostr.base.IEvent;
 import nostr.base.ISignable;
 import nostr.client.springwebsocket.SpringWebSocketClient;
 import nostr.crypto.schnorr.Schnorr;
+import nostr.crypto.schnorr.SchnorrException;
 import nostr.event.filter.Filters;
 import nostr.event.impl.GenericEvent;
 import nostr.event.message.ReqMessage;
@@ -313,8 +315,10 @@ public class NostrSpringWebSocketClient implements NostrIF {
     try {
       var message = NostrUtil.sha256(event.get_serializedEvent());
       return Schnorr.verify(message, event.getPubKey().getRawData(), signature.getRawData());
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 algorithm not available", e);
+    } catch (SchnorrException e) {
+      throw new IllegalStateException("Failed to verify Schnorr signature", e);
     }
   }
 

--- a/nostr-java-api/src/main/java/nostr/api/factory/impl/BaseTagFactory.java
+++ b/nostr-java-api/src/main/java/nostr/api/factory/impl/BaseTagFactory.java
@@ -4,6 +4,7 @@
  */
 package nostr.api.factory.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,9 +12,9 @@ import java.util.stream.Stream;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import nostr.event.BaseTag;
 import nostr.event.tag.GenericTag;
+import nostr.event.json.codec.EventEncodingException;
 
 /**
  * Utility to create {@link BaseTag} instances from code and parameters or from JSON.
@@ -52,10 +53,13 @@ public class BaseTagFactory {
     this.params = new ArrayList<>();
   }
 
-  @SneakyThrows
   public BaseTag create() {
     if (jsonString != null) {
-      return new ObjectMapper().readValue(jsonString, GenericTag.class);
+      try {
+        return new ObjectMapper().readValue(jsonString, GenericTag.class);
+      } catch (JsonProcessingException ex) {
+        throw new EventEncodingException("Failed to decode tag from JSON", ex);
+      }
     }
     return BaseTag.create(code, params);
   }

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP61Test.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP61Test.java
@@ -2,10 +2,10 @@ package nostr.api.unit;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
-import lombok.SneakyThrows;
 import nostr.api.NIP61;
 import nostr.base.Relay;
 import nostr.event.BaseTag;
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 public class NIP61Test {
 
   @Test
+  // Verifies that informational Nutzap events include the expected relay, mint, and pubkey tags.
   public void createNutzapInformationalEvent() {
     // Prepare
     Identity sender = Identity.generateRandomIdentity();
@@ -79,8 +80,8 @@ public class NIP61Test {
         "https://mint2.example.com", mintTags.get(1).getAttributes().get(0).value());
   }
 
-  @SneakyThrows
   @Test
+  // Validates that Nutzap events include URL, amount, and pubkey tags when provided with data.
   public void createNutzapEvent() {
     // Prepare
     Identity sender = Identity.generateRandomIdentity();
@@ -104,16 +105,22 @@ public class NIP61Test {
     List<EventTag> events = List.of(eventTag);
 
     // Create event
-    GenericEvent event =
-        nip61
-            .createNutzapEvent(
-                amount,
-                proofs,
-                URI.create(mint.getUrl()).toURL(),
-                events,
-                recipientId.getPublicKey(),
-                content)
-            .getEvent();
+    GenericEvent event;
+    try {
+      event =
+          nip61
+              .createNutzapEvent(
+                  amount,
+                  proofs,
+                  URI.create(mint.getUrl()).toURL(),
+                  events,
+                  recipientId.getPublicKey(),
+                  content)
+              .getEvent();
+    } catch (MalformedURLException ex) {
+      Assertions.fail("Mint URL should be valid in test data", ex);
+      return;
+    }
     List<BaseTag> tags = event.getTags();
 
     // Assert tags
@@ -150,6 +157,7 @@ public class NIP61Test {
   }
 
   @Test
+  // Ensures convenience tag factory methods create correctly coded tags.
   public void createTags() {
     // Test P2PK tag creation
     String pubkey = "test-pubkey";

--- a/nostr-java-base/src/main/java/nostr/base/BaseKey.java
+++ b/nostr-java-base/src/main/java/nostr/base/BaseKey.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import nostr.crypto.bech32.Bech32;
+import nostr.crypto.bech32.Bech32EncodingException;
 import nostr.crypto.bech32.Bech32Prefix;
 import nostr.util.NostrUtil;
 
@@ -29,9 +30,13 @@ public abstract class BaseKey implements IKey {
   public String toBech32String() {
     try {
       return Bech32.toBech32(prefix, rawData);
-    } catch (Exception ex) {
+    } catch (IllegalArgumentException ex) {
+      log.error(
+          "Invalid key data for Bech32 conversion for {} key with prefix {}", type, prefix, ex);
+      throw new KeyEncodingException("Invalid key data for Bech32 conversion", ex);
+    } catch (Bech32EncodingException ex) {
       log.error("Failed to convert {} key to Bech32 format with prefix {}", type, prefix, ex);
-      throw new RuntimeException("Failed to convert key to Bech32: " + ex.getMessage(), ex);
+      throw new KeyEncodingException("Failed to convert key to Bech32", ex);
     }
   }
 

--- a/nostr-java-base/src/main/java/nostr/base/KeyEncodingException.java
+++ b/nostr-java-base/src/main/java/nostr/base/KeyEncodingException.java
@@ -1,0 +1,8 @@
+package nostr.base;
+
+import lombok.experimental.StandardException;
+import nostr.util.exception.NostrEncodingException;
+
+/** Exception thrown when a key cannot be encoded to the requested format. */
+@StandardException
+public class KeyEncodingException extends NostrEncodingException {}

--- a/nostr-java-base/src/main/java/nostr/event/json/codec/EventEncodingException.java
+++ b/nostr-java-base/src/main/java/nostr/event/json/codec/EventEncodingException.java
@@ -1,6 +1,7 @@
 package nostr.event.json.codec;
 
 import lombok.experimental.StandardException;
+import nostr.util.exception.NostrEncodingException;
 
 /**
  * Exception thrown to indicate a problem occurred while encoding a Nostr event to JSON. This
@@ -8,4 +9,4 @@ import lombok.experimental.StandardException;
  * errors.
  */
 @StandardException
-public class EventEncodingException extends RuntimeException {}
+public class EventEncodingException extends NostrEncodingException {}

--- a/nostr-java-crypto/src/main/java/nostr/crypto/bech32/Bech32.java
+++ b/nostr-java-crypto/src/main/java/nostr/crypto/bech32/Bech32.java
@@ -50,13 +50,18 @@ public class Bech32 {
     }
   }
 
-  public static String toBech32(Bech32Prefix hrp, byte[] hexKey) throws Exception {
-    byte[] data = convertBits(hexKey, 8, 5, true);
-
-    return Bech32.encode(Bech32.Encoding.BECH32, hrp.getCode(), data);
+  public static String toBech32(Bech32Prefix hrp, byte[] hexKey) {
+    try {
+      byte[] data = convertBits(hexKey, 8, 5, true);
+      return Bech32.encode(Bech32.Encoding.BECH32, hrp.getCode(), data);
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new Bech32EncodingException("Failed to encode key to Bech32", e);
+    }
   }
 
-  public static String toBech32(Bech32Prefix hrp, String hexKey) throws Exception {
+  public static String toBech32(Bech32Prefix hrp, String hexKey) {
     byte[] data = NostrUtil.hexToBytes(hexKey);
 
     return toBech32(hrp, data);

--- a/nostr-java-crypto/src/main/java/nostr/crypto/bech32/Bech32EncodingException.java
+++ b/nostr-java-crypto/src/main/java/nostr/crypto/bech32/Bech32EncodingException.java
@@ -1,0 +1,8 @@
+package nostr.crypto.bech32;
+
+import lombok.experimental.StandardException;
+import nostr.util.exception.NostrEncodingException;
+
+/** Exception thrown when Bech32 encoding or decoding fails. */
+@StandardException
+public class Bech32EncodingException extends NostrEncodingException {}

--- a/nostr-java-crypto/src/main/java/nostr/crypto/schnorr/Schnorr.java
+++ b/nostr-java-crypto/src/main/java/nostr/crypto/schnorr/Schnorr.java
@@ -26,15 +26,15 @@ public class Schnorr {
    * @return 64-byte signature (R || s)
    * @throws Exception if inputs are invalid or signing fails
    */
-  public static byte[] sign(byte[] msg, byte[] secKey, byte[] auxRand) throws Exception {
+  public static byte[] sign(byte[] msg, byte[] secKey, byte[] auxRand) throws SchnorrException {
     if (msg.length != 32) {
-      throw new Exception("The message must be a 32-byte array.");
+      throw new SchnorrException("The message must be a 32-byte array.");
     }
     BigInteger secKey0 = NostrUtil.bigIntFromBytes(secKey);
 
     if (!(BigInteger.ONE.compareTo(secKey0) <= 0
         && secKey0.compareTo(Point.getn().subtract(BigInteger.ONE)) <= 0)) {
-      throw new Exception("The secret key must be an integer in the range 1..n-1.");
+      throw new SchnorrException("The secret key must be an integer in the range 1..n-1.");
     }
     Point P = Point.mul(Point.getG(), secKey0);
     if (!P.hasEvenY()) {
@@ -56,7 +56,7 @@ public class Schnorr {
     BigInteger k0 =
         NostrUtil.bigIntFromBytes(Point.taggedHash("BIP0340/nonce", buf)).mod(Point.getn());
     if (k0.compareTo(BigInteger.ZERO) == 0) {
-      throw new Exception("Failure. This happens only with negligible probability.");
+      throw new SchnorrException("Failure. This happens only with negligible probability.");
     }
     Point R = Point.mul(Point.getG(), k0);
     BigInteger k;
@@ -83,7 +83,7 @@ public class Schnorr {
         R.toBytes().length,
         NostrUtil.bytesFromBigInteger(kes).length);
     if (!verify(msg, P.toBytes(), sig)) {
-      throw new Exception("The signature does not pass verification.");
+      throw new SchnorrException("The signature does not pass verification.");
     }
     return sig;
   }
@@ -97,17 +97,17 @@ public class Schnorr {
    * @return true if the signature is valid; false otherwise
    * @throws Exception if inputs are invalid
    */
-  public static boolean verify(byte[] msg, byte[] pubkey, byte[] sig) throws Exception {
+  public static boolean verify(byte[] msg, byte[] pubkey, byte[] sig) throws SchnorrException {
 
     if (msg.length != 32) {
-      throw new Exception("The message must be a 32-byte array.");
+      throw new SchnorrException("The message must be a 32-byte array.");
     }
 
     if (pubkey.length != 32) {
-      throw new Exception("The public key must be a 32-byte array.");
+      throw new SchnorrException("The public key must be a 32-byte array.");
     }
     if (sig.length != 64) {
-      throw new Exception("The signature must be a 64-byte array.");
+      throw new SchnorrException("The signature must be a 64-byte array.");
     }
 
     Point P = Point.liftX(pubkey);
@@ -151,11 +151,11 @@ public class Schnorr {
     }
   }
 
-  public static byte[] genPubKey(byte[] secKey) throws Exception {
+  public static byte[] genPubKey(byte[] secKey) throws SchnorrException {
     BigInteger x = NostrUtil.bigIntFromBytes(secKey);
     if (!(BigInteger.ONE.compareTo(x) <= 0
         && x.compareTo(Point.getn().subtract(BigInteger.ONE)) <= 0)) {
-      throw new Exception("The secret key must be an integer in the range 1..n-1.");
+      throw new SchnorrException("The secret key must be an integer in the range 1..n-1.");
     }
     Point ret = Point.mul(Point.G, x);
     return Point.bytesFromPoint(ret);

--- a/nostr-java-crypto/src/main/java/nostr/crypto/schnorr/SchnorrException.java
+++ b/nostr-java-crypto/src/main/java/nostr/crypto/schnorr/SchnorrException.java
@@ -1,0 +1,8 @@
+package nostr.crypto.schnorr;
+
+import lombok.experimental.StandardException;
+import nostr.util.exception.NostrCryptoException;
+
+/** Exception thrown when Schnorr signing or verification fails. */
+@StandardException
+public class SchnorrException extends NostrCryptoException {}

--- a/nostr-java-encryption/src/test/java/nostr/encryption/MessageCipherTest.java
+++ b/nostr-java-encryption/src/test/java/nostr/encryption/MessageCipherTest.java
@@ -3,12 +3,14 @@ package nostr.encryption;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import nostr.crypto.schnorr.Schnorr;
+import nostr.crypto.schnorr.SchnorrException;
 import org.junit.jupiter.api.Test;
 
 class MessageCipherTest {
 
   @Test
-  void testMessageCipher04EncryptDecrypt() throws Exception {
+  // Validates that MessageCipher04 encrypts and decrypts symmetrically
+  void testMessageCipher04EncryptDecrypt() throws SchnorrException {
     byte[] alicePriv = Schnorr.generatePrivateKey();
     byte[] alicePub = Schnorr.genPubKey(alicePriv);
     byte[] bobPriv = Schnorr.generatePrivateKey();
@@ -23,7 +25,8 @@ class MessageCipherTest {
   }
 
   @Test
-  void testMessageCipher44EncryptDecrypt() throws Exception {
+  // Validates that MessageCipher44 encrypts and decrypts symmetrically
+  void testMessageCipher44EncryptDecrypt() throws SchnorrException {
     byte[] alicePriv = Schnorr.generatePrivateKey();
     byte[] alicePub = Schnorr.genPubKey(alicePriv);
     byte[] bobPriv = Schnorr.generatePrivateKey();

--- a/nostr-java-event/src/main/java/nostr/event/entities/CashuProof.java
+++ b/nostr-java-event/src/main/java/nostr/event/entities/CashuProof.java
@@ -4,12 +4,13 @@ import static nostr.base.IEvent.MAPPER_BLACKBIRD;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
+import nostr.event.json.codec.EventEncodingException;
 
 @Data
 @NoArgsConstructor
@@ -31,9 +32,12 @@ public class CashuProof {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String witness;
 
-  @SneakyThrows
   @Override
   public String toString() {
-    return MAPPER_BLACKBIRD.writeValueAsString(this);
+    try {
+      return MAPPER_BLACKBIRD.writeValueAsString(this);
+    } catch (JsonProcessingException ex) {
+      throw new EventEncodingException("Failed to serialize Cashu proof", ex);
+    }
   }
 }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ChannelCreateEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ChannelCreateEvent.java
@@ -1,12 +1,13 @@
 package nostr.event.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.ArrayList;
 import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
 import nostr.base.Kind;
 import nostr.base.PublicKey;
 import nostr.base.annotation.Event;
 import nostr.event.entities.ChannelProfile;
+import nostr.event.json.codec.EventEncodingException;
 
 /**
  * @author guilhermegps
@@ -19,10 +20,13 @@ public class ChannelCreateEvent extends GenericEvent {
     super(pubKey, Kind.CHANNEL_CREATE, new ArrayList<>(), content);
   }
 
-  @SneakyThrows
   public ChannelProfile getChannelProfile() {
     String content = getContent();
-    return MAPPER_BLACKBIRD.readValue(content, ChannelProfile.class);
+    try {
+      return MAPPER_BLACKBIRD.readValue(content, ChannelProfile.class);
+    } catch (JsonProcessingException ex) {
+      throw new EventEncodingException("Failed to parse channel profile content", ex);
+    }
   }
 
   @Override
@@ -50,7 +54,7 @@ public class ChannelCreateEvent extends GenericEvent {
         throw new AssertionError("Invalid `content`: `picture` field is required.");
       }
 
-    } catch (Exception e) {
+    } catch (EventEncodingException e) {
       throw new AssertionError("Invalid `content`: Must be a valid ChannelProfile JSON object.", e);
     }
   }

--- a/nostr-java-event/src/main/java/nostr/event/impl/ChannelMetadataEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/ChannelMetadataEvent.java
@@ -1,8 +1,8 @@
 package nostr.event.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
 import nostr.base.Kind;
 import nostr.base.Marker;
 import nostr.base.PublicKey;
@@ -11,6 +11,7 @@ import nostr.event.BaseTag;
 import nostr.event.entities.ChannelProfile;
 import nostr.event.tag.EventTag;
 import nostr.event.tag.HashtagTag;
+import nostr.event.json.codec.EventEncodingException;
 
 /**
  * @author guilhermegps
@@ -23,10 +24,13 @@ public class ChannelMetadataEvent extends GenericEvent {
     super(pubKey, Kind.CHANNEL_METADATA, baseTagList, content);
   }
 
-  @SneakyThrows
   public ChannelProfile getChannelProfile() {
     String content = getContent();
-    return MAPPER_BLACKBIRD.readValue(content, ChannelProfile.class);
+    try {
+      return MAPPER_BLACKBIRD.readValue(content, ChannelProfile.class);
+    } catch (JsonProcessingException ex) {
+      throw new EventEncodingException("Failed to parse channel profile content", ex);
+    }
   }
 
   @Override
@@ -47,7 +51,7 @@ public class ChannelMetadataEvent extends GenericEvent {
       if (profile.getPicture() == null) {
         throw new AssertionError("Invalid `content`: `picture` field is required.");
       }
-    } catch (Exception e) {
+    } catch (EventEncodingException e) {
       throw new AssertionError("Invalid `content`: Must be a valid ChannelProfile JSON object.", e);
     }
   }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateProductEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateProductEvent.java
@@ -1,15 +1,16 @@
 package nostr.event.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import nostr.base.IEvent;
 import nostr.base.Kind;
 import nostr.base.PublicKey;
 import nostr.base.annotation.Event;
 import nostr.event.BaseTag;
 import nostr.event.entities.Product;
+import nostr.event.json.codec.EventEncodingException;
 
 /**
  * @author eric
@@ -22,9 +23,12 @@ public class CreateOrUpdateProductEvent extends MerchantEvent<Product> {
     super(sender, 30_018, tags, content);
   }
 
-  @SneakyThrows
   public Product getProduct() {
-    return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), Product.class);
+    try {
+      return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), Product.class);
+    } catch (JsonProcessingException ex) {
+      throw new EventEncodingException("Failed to parse product content", ex);
+    }
   }
 
   protected Product getEntity() {
@@ -56,7 +60,7 @@ public class CreateOrUpdateProductEvent extends MerchantEvent<Product> {
       if (product.getPrice() == null) {
         throw new AssertionError("Invalid `content`: `price` field is required.");
       }
-    } catch (Exception e) {
+    } catch (EventEncodingException e) {
       throw new AssertionError("Invalid `content`: Must be a valid Product JSON object.", e);
     }
   }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateStallEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CreateOrUpdateStallEvent.java
@@ -1,17 +1,18 @@
 package nostr.event.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import nostr.base.IEvent;
 import nostr.base.Kind;
 import nostr.base.PublicKey;
 import nostr.base.annotation.Event;
 import nostr.event.BaseTag;
 import nostr.event.entities.Stall;
+import nostr.event.json.codec.EventEncodingException;
 
 /**
  * @author eric
@@ -27,9 +28,12 @@ public class CreateOrUpdateStallEvent extends MerchantEvent<Stall> {
     super(sender, Kind.STALL_CREATE_OR_UPDATE.getValue(), tags, content);
   }
 
-  @SneakyThrows
   public Stall getStall() {
-    return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), Stall.class);
+    try {
+      return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), Stall.class);
+    } catch (JsonProcessingException ex) {
+      throw new EventEncodingException("Failed to parse stall content", ex);
+    }
   }
 
   @Override
@@ -57,7 +61,7 @@ public class CreateOrUpdateStallEvent extends MerchantEvent<Stall> {
       if (stall.getCurrency() == null || stall.getCurrency().isEmpty()) {
         throw new AssertionError("Invalid `content`: `currency` field is required.");
       }
-    } catch (Exception e) {
+    } catch (EventEncodingException e) {
       throw new AssertionError("Invalid `content`: Must be a valid Stall JSON object.", e);
     }
   }

--- a/nostr-java-event/src/main/java/nostr/event/impl/CustomerOrderEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/CustomerOrderEvent.java
@@ -1,17 +1,18 @@
 package nostr.event.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import nostr.base.IEvent;
 import nostr.base.Kind;
 import nostr.base.PublicKey;
 import nostr.base.annotation.Event;
 import nostr.event.BaseTag;
 import nostr.event.entities.CustomerOrder;
+import nostr.event.json.codec.EventEncodingException;
 
 /**
  * @author eric
@@ -27,9 +28,12 @@ public class CustomerOrderEvent extends CheckoutEvent<CustomerOrder> {
     super(sender, tags, content, MessageType.NEW_ORDER);
   }
 
-  @SneakyThrows
   public CustomerOrder getCustomerOrder() {
-    return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), CustomerOrder.class);
+    try {
+      return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), CustomerOrder.class);
+    } catch (JsonProcessingException ex) {
+      throw new EventEncodingException("Failed to parse customer order content", ex);
+    }
   }
 
   protected CustomerOrder getEntity() {

--- a/nostr-java-event/src/main/java/nostr/event/impl/InternetIdentifierMetadataEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/InternetIdentifierMetadataEvent.java
@@ -1,14 +1,15 @@
 package nostr.event.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
 import nostr.base.Kind;
 import nostr.base.PublicKey;
 import nostr.base.annotation.Event;
 import nostr.event.NIP05Event;
 import nostr.event.entities.UserProfile;
+import nostr.event.json.codec.EventEncodingException;
 
 /**
  * @author squirrel
@@ -26,10 +27,13 @@ public final class InternetIdentifierMetadataEvent extends NIP05Event {
     this.setContent(content);
   }
 
-  @SneakyThrows
   public UserProfile getProfile() {
     String content = getContent();
-    return MAPPER_BLACKBIRD.readValue(content, UserProfile.class);
+    try {
+      return MAPPER_BLACKBIRD.readValue(content, UserProfile.class);
+    } catch (JsonProcessingException ex) {
+      throw new EventEncodingException("Failed to parse user profile content", ex);
+    }
   }
 
   @Override

--- a/nostr-java-event/src/main/java/nostr/event/impl/NostrMarketplaceEvent.java
+++ b/nostr-java-event/src/main/java/nostr/event/impl/NostrMarketplaceEvent.java
@@ -1,15 +1,16 @@
 package nostr.event.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
 import nostr.base.IEvent;
 import nostr.base.PublicKey;
 import nostr.base.annotation.Event;
 import nostr.event.BaseTag;
 import nostr.event.entities.Product;
+import nostr.event.json.codec.EventEncodingException;
 
 /**
  * @author eric
@@ -25,8 +26,11 @@ public abstract class NostrMarketplaceEvent extends AddressableEvent {
     super(sender, kind, tags, content);
   }
 
-  @SneakyThrows
   public Product getProduct() {
-    return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), Product.class);
+    try {
+      return IEvent.MAPPER_BLACKBIRD.readValue(getContent(), Product.class);
+    } catch (JsonProcessingException ex) {
+      throw new EventEncodingException("Failed to parse marketplace product content", ex);
+    }
   }
 }

--- a/nostr-java-event/src/main/java/nostr/event/json/serializer/RelaysTagSerializer.java
+++ b/nostr-java-event/src/main/java/nostr/event/json/serializer/RelaysTagSerializer.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import nostr.event.tag.RelaysTag;
 
 public class RelaysTagSerializer extends JsonSerializer<RelaysTag> {
@@ -22,8 +21,7 @@ public class RelaysTagSerializer extends JsonSerializer<RelaysTag> {
     jsonGenerator.writeEndArray();
   }
 
-  @SneakyThrows
-  private static void writeString(JsonGenerator jsonGenerator, String json) {
+  private static void writeString(JsonGenerator jsonGenerator, String json) throws IOException {
     jsonGenerator.writeString(json);
   }
 }

--- a/nostr-java-id/src/main/java/nostr/id/Identity.java
+++ b/nostr-java-id/src/main/java/nostr/id/Identity.java
@@ -11,6 +11,7 @@ import nostr.base.PrivateKey;
 import nostr.base.PublicKey;
 import nostr.base.Signature;
 import nostr.crypto.schnorr.Schnorr;
+import nostr.crypto.schnorr.SchnorrException;
 import nostr.util.NostrUtil;
 
 /**
@@ -75,7 +76,10 @@ public class Identity {
     if (cachedPublicKey == null) {
       try {
         cachedPublicKey = new PublicKey(Schnorr.genPubKey(this.getPrivateKey().getRawData()));
-      } catch (Exception ex) {
+      } catch (IllegalArgumentException ex) {
+        log.error("Invalid private key while deriving public key", ex);
+        throw new IllegalStateException("Invalid private key", ex);
+      } catch (SchnorrException ex) {
         log.error("Failed to derive public key", ex);
         throw new IllegalStateException("Failed to derive public key", ex);
       }
@@ -110,7 +114,10 @@ public class Identity {
     } catch (NoSuchAlgorithmException ex) {
       log.error("SHA-256 algorithm not available for signing", ex);
       throw new IllegalStateException("SHA-256 algorithm not available", ex);
-    } catch (Exception ex) {
+    } catch (IllegalArgumentException ex) {
+      log.error("Invalid signing input", ex);
+      throw new SigningException("Failed to sign because of invalid input", ex);
+    } catch (SchnorrException ex) {
       log.error("Signing failed", ex);
       throw new SigningException("Failed to sign with provided key", ex);
     }

--- a/nostr-java-id/src/main/java/nostr/id/SigningException.java
+++ b/nostr-java-id/src/main/java/nostr/id/SigningException.java
@@ -1,7 +1,8 @@
 package nostr.id;
 
 import lombok.experimental.StandardException;
+import nostr.util.exception.NostrCryptoException;
 
 /** Exception thrown when signing an {@link nostr.base.ISignable} fails. */
 @StandardException
-public class SigningException extends RuntimeException {}
+public class SigningException extends NostrCryptoException {}

--- a/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
+++ b/nostr-java-id/src/test/java/nostr/id/IdentityTest.java
@@ -2,12 +2,14 @@ package nostr.id;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import nostr.base.ISignable;
 import nostr.base.PublicKey;
 import nostr.base.Signature;
 import nostr.crypto.schnorr.Schnorr;
+import nostr.crypto.schnorr.SchnorrException;
 import nostr.event.impl.GenericEvent;
 import nostr.event.tag.DelegationTag;
 import nostr.util.NostrUtil;
@@ -22,6 +24,7 @@ public class IdentityTest {
   public IdentityTest() {}
 
   @Test
+  // Ensures signing a text note event attaches a signature
   public void testSignEvent() {
     System.out.println("testSignEvent");
     Identity identity = Identity.generateRandomIdentity();
@@ -32,6 +35,7 @@ public class IdentityTest {
   }
 
   @Test
+  // Ensures signing a delegation tag populates its signature
   public void testSignDelegationTag() {
     System.out.println("testSignDelegationTag");
     Identity identity = Identity.generateRandomIdentity();
@@ -42,6 +46,7 @@ public class IdentityTest {
   }
 
   @Test
+  // Verifies that generating random identities yields unique private keys
   public void testGenerateRandomIdentityProducesUniqueKeys() {
     Identity id1 = Identity.generateRandomIdentity();
     Identity id2 = Identity.generateRandomIdentity();
@@ -49,6 +54,7 @@ public class IdentityTest {
   }
 
   @Test
+  // Confirms that deriving the public key from a known private key matches expectations
   public void testGetPublicKeyDerivation() {
     String privHex = "0000000000000000000000000000000000000000000000000000000000000001";
     Identity identity = Identity.create(privHex);
@@ -58,7 +64,9 @@ public class IdentityTest {
   }
 
   @Test
-  public void testSignProducesValidSignature() throws Exception {
+  // Verifies that signing produces a Schnorr signature that validates successfully
+  public void testSignProducesValidSignature()
+      throws NoSuchAlgorithmException, SchnorrException {
     String privHex = "0000000000000000000000000000000000000000000000000000000000000001";
     Identity identity = Identity.create(privHex);
     final byte[] message = "hello".getBytes(StandardCharsets.UTF_8);
@@ -98,6 +106,7 @@ public class IdentityTest {
   }
 
   @Test
+  // Confirms public key derivation is cached for subsequent calls
   public void testPublicKeyCaching() {
     Identity identity = Identity.generateRandomIdentity();
     PublicKey first = identity.getPublicKey();
@@ -106,6 +115,7 @@ public class IdentityTest {
   }
 
   @Test
+  // Ensures that invalid private keys trigger a derivation failure
   public void testGetPublicKeyFailure() {
     String invalidPriv = "0000000000000000000000000000000000000000000000000000000000000000";
     Identity identity = Identity.create(invalidPriv);

--- a/nostr-java-util/src/main/java/nostr/util/NostrException.java
+++ b/nostr-java-util/src/main/java/nostr/util/NostrException.java
@@ -1,12 +1,14 @@
 package nostr.util;
 
 import lombok.experimental.StandardException;
+import nostr.util.exception.NostrProtocolException;
 
 /**
- * @author squirrel
+ * Legacy exception maintained for backward compatibility. Prefer using specific subclasses of
+ * {@link nostr.util.exception.NostrRuntimeException}.
  */
 @StandardException
-public class NostrException extends Exception {
+public class NostrException extends NostrProtocolException {
   public NostrException(String message) {
     super(message);
   }

--- a/nostr-java-util/src/main/java/nostr/util/exception/NostrCryptoException.java
+++ b/nostr-java-util/src/main/java/nostr/util/exception/NostrCryptoException.java
@@ -1,0 +1,9 @@
+package nostr.util.exception;
+
+import lombok.experimental.StandardException;
+
+/**
+ * Indicates failures in cryptographic operations such as signing, verification, or key generation.
+ */
+@StandardException
+public class NostrCryptoException extends NostrRuntimeException {}

--- a/nostr-java-util/src/main/java/nostr/util/exception/NostrEncodingException.java
+++ b/nostr-java-util/src/main/java/nostr/util/exception/NostrEncodingException.java
@@ -1,0 +1,9 @@
+package nostr.util.exception;
+
+import lombok.experimental.StandardException;
+
+/**
+ * Thrown when serialization or deserialization of Nostr data fails.
+ */
+@StandardException
+public class NostrEncodingException extends NostrRuntimeException {}

--- a/nostr-java-util/src/main/java/nostr/util/exception/NostrNetworkException.java
+++ b/nostr-java-util/src/main/java/nostr/util/exception/NostrNetworkException.java
@@ -1,0 +1,9 @@
+package nostr.util.exception;
+
+import lombok.experimental.StandardException;
+
+/**
+ * Represents failures when communicating with relays or external services.
+ */
+@StandardException
+public class NostrNetworkException extends NostrRuntimeException {}

--- a/nostr-java-util/src/main/java/nostr/util/exception/NostrProtocolException.java
+++ b/nostr-java-util/src/main/java/nostr/util/exception/NostrProtocolException.java
@@ -1,0 +1,9 @@
+package nostr.util.exception;
+
+import lombok.experimental.StandardException;
+
+/**
+ * Signals violations or inconsistencies with the Nostr protocol or specific NIP specifications.
+ */
+@StandardException
+public class NostrProtocolException extends NostrRuntimeException {}

--- a/nostr-java-util/src/main/java/nostr/util/exception/NostrRuntimeException.java
+++ b/nostr-java-util/src/main/java/nostr/util/exception/NostrRuntimeException.java
@@ -1,0 +1,10 @@
+package nostr.util.exception;
+
+import lombok.experimental.StandardException;
+
+/**
+ * Base unchecked exception for all Nostr domain errors surfaced by the SDK. Subclasses provide
+ * additional context for protocol, cryptography, encoding, and networking failures.
+ */
+@StandardException
+public class NostrRuntimeException extends RuntimeException {}


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Related issue: #____ (code review Finding 1.3)

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
- Introduced a shared unchecked exception hierarchy (`NostrRuntimeException` and specializations) to align with the error-handling policy from Finding 1.3.
- Updated existing encoding and crypto exception types to extend the new hierarchy so callers observe consistent runtime behaviour.
- Retained `NostrException` for compatibility while delegating to the protocol-specific base class.

## BREAKING
<!-- If applicable, call it out explicitly. -->
<!-- ⚠️ BREAKING: Describe migration or impact. -->
None.

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
- Confirm the new base exceptions cover the previously mixed checked/unchecked cases without missing usage sites.

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [x] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)

## Testing
- `mvn -q verify` *(fails: xyz.tcheeric:nostr-java-bom:1.1.1 missing from Maven Central)*

## Network Access
- Blocked: https://repo.maven.apache.org/maven2/xyz/tcheeric/nostr-java-bom/1.1.1/nostr-java-bom-1.1.1.pom (artifact not found)


------
https://chatgpt.com/codex/tasks/task_b_68e337e2acfc83319e62250f0db94bc8