### PR TITLE
refactor: align event mapper and client lifecycle

### DIFF
--- a/nostr-java-api/src/main/java/nostr/api/NostrSpringWebSocketClient.java
+++ b/nostr-java-api/src/main/java/nostr/api/NostrSpringWebSocketClient.java
@@ -40,10 +40,6 @@ public class NostrSpringWebSocketClient implements NostrIF {
     this(null, new DefaultNoteService());
   }
 
-  public NostrSpringWebSocketClient() {
-    this(null, new DefaultNoteService());
-  }
-
   /**
    * Construct a client with a single relay configured.
    */
@@ -62,7 +58,7 @@ public class NostrSpringWebSocketClient implements NostrIF {
   /**
    * Construct a client with a sender identity and a custom note service.
    */
-  public NostrSpringWebSocketClient(@NonNull Identity sender, @NonNull NoteService noteService) {
+  public NostrSpringWebSocketClient(Identity sender, @NonNull NoteService noteService) {
     this.sender = sender;
     this.noteService = noteService;
     this.relayRegistry = new NostrRelayRegistry(buildFactory());
@@ -74,7 +70,7 @@ public class NostrSpringWebSocketClient implements NostrIF {
   /**
    * Construct a client with a sender identity.
    */
-  public NostrSpringWebSocketClient(@NonNull Identity sender) {
+  public NostrSpringWebSocketClient(Identity sender) {
     this(sender, new DefaultNoteService());
   }
 


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Related issue: #____

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
- Renamed the cached serialization buffer in `GenericEvent` and refreshed supporting helpers so signing and dispatch use the clearer `serializedEventCache` accessors.
- Introduced `EventJsonMapper` to own the shared Jackson configuration and swapped previous `IEvent` constants and call sites to the new utility for cleaner dependencies.
- Replaced the double-checked locking singleton in `NostrSpringWebSocketClient` with an initialization-on-demand holder to remove volatile state while keeping lazy initialization semantics.
- Restored optional sender support in `NostrSpringWebSocketClient` constructors so default and note-service instances no longer fail null checks when delegating.

## BREAKING
<!-- If applicable, call it out explicitly. -->
<!-- ⚠️ BREAKING: Describe migration or impact. -->
None.

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
- Verify the new `EventJsonMapper` wiring covers all former `IEvent.MAPPER_BLACKBIRD` usages without leaving stray imports.
- Confirm the singleton holder in `NostrSpringWebSocketClient` still satisfies existing entry points.
- Double-check the relaxed sender requirements keep Lombok null-safety in place for required collaborators.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [x] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)

## Testing
- `mvn -q verify` *(fails: xyz.tcheeric:nostr-java-bom:1.1.1 missing from Maven Central)*


------
https://chatgpt.com/codex/tasks/task_b_68e383c7988483319301f67a61c92ce6