### PR TITLE
test: fix bolt11 whole btc fixture

### DIFF
--- a/nostr-java-api/src/test/java/nostr/api/unit/Bolt11UtilTest.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/Bolt11UtilTest.java
@@ -57,7 +57,7 @@ public class Bolt11UtilTest {
   @Test
   // Parses BTC with no unit. Example: 1 BTC → 100,000,000,000 msat.
   void parseWholeBtcNoUnit() {
-    long msat = Bolt11Util.parseMsat("lnbc11psome");
+    long msat = Bolt11Util.parseMsat("lnbc1p1some");
     assertEquals(100_000_000_000L, msat);
   }
 


### PR DESCRIPTION
## Summary
- update the whole-BTC parsing test to use a valid BOLT11 invoice format

## Testing
- mvn -q verify *(fails: missing xyz.tcheeric:nostr-java-bom:1.1.1 import POM in central)*

------
https://chatgpt.com/codex/tasks/task_b_68ead00a996c8331a07a0515d4e7f018