### PR TITLE
docs: rename relay alias to 398ja

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -159,7 +159,7 @@ The public API remains **100% compatible** between 0.4.0 and 0.5.1. All existing
 ```java
 // This code works in both 0.4.0 and 0.5.1
 Identity identity = Identity.generateRandomIdentity();
-Map<String, String> relays = Map.of("damus", "wss://relay.398ja.xyz");
+Map<String, String> relays = Map.of("398ja", "wss://relay.398ja.xyz");
 
 new NIP01(identity)
     .createTextNoteEvent("Hello nostr")

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -334,7 +334,7 @@ protected void validateTags() {
 **Examples:**
 ```java
 // RelayUri - validates WebSocket URIs
-RelayUri relay = new RelayUri("wss://relay.damus.io");
+RelayUri relay = new RelayUri("wss://relay.398ja.xyz");
 // Throws IllegalArgumentException if not ws:// or wss://
 
 // SubscriptionId - type-safe subscription identifiers
@@ -342,8 +342,8 @@ SubscriptionId subId = SubscriptionId.of("my-subscription");
 // Throws IllegalArgumentException if blank
 
 // Equality based on value, not object identity
-RelayUri r1 = new RelayUri("wss://relay.damus.io");
-RelayUri r2 = new RelayUri("wss://relay.damus.io");
+RelayUri r1 = new RelayUri("wss://relay.398ja.xyz");
+RelayUri r2 = new RelayUri("wss://relay.398ja.xyz");
 assert r1.equals(r2); // true - same value
 ```
 

--- a/docs/howto/api-examples.md
+++ b/docs/howto/api-examples.md
@@ -33,7 +33,7 @@ private static final Map<String, String> RELAYS = Map.of("local", "localhost:555
 
 **For testing**, you can:
 - Use a local relay (e.g., [nostr-rs-relay](https://github.com/scsibug/nostr-rs-relay))
-- Replace with public relays: `Map.of("damus", "wss://relay.398ja.xyz")`
+- Replace with public relays: `Map.of("398ja", "wss://relay.398ja.xyz")`
 
 ---
 
@@ -644,7 +644,7 @@ private static final Map<String, String> RELAYS =
 
 // Use public relays
 private static final Map<String, String> RELAYS = Map.of(
-    "damus", "wss://relay.398ja.xyz",
+    "398ja", "wss://relay.398ja.xyz",
     "nos", "wss://nos.lol"
 );
 ```

--- a/docs/howto/streaming-subscriptions.md
+++ b/docs/howto/streaming-subscriptions.md
@@ -24,7 +24,7 @@ import nostr.base.Kind;
 import nostr.event.filter.Filters;
 import nostr.event.filter.KindFilter;
 
-Map<String, String> relays = Map.of("damus", "wss://relay.398ja.xyz");
+Map<String, String> relays = Map.of("398ja", "wss://relay.398ja.xyz");
 
 NostrSpringWebSocketClient client = new NostrSpringWebSocketClient().setRelays(relays);
 

--- a/docs/howto/use-nostr-java-api.md
+++ b/docs/howto/use-nostr-java-api.md
@@ -42,7 +42,7 @@ import java.util.Map;
 public class QuickStart {
     public static void main(String[] args) {
         Identity identity = Identity.generateRandomIdentity();
-        Map<String, String> relays = Map.of("damus", "wss://relay.398ja.xyz");
+        Map<String, String> relays = Map.of("398ja", "wss://relay.398ja.xyz");
 
         new NIP01(identity)
             .createTextNoteEvent("Hello nostr")

--- a/docs/reference/nostr-java-api.md
+++ b/docs/reference/nostr-java-api.md
@@ -200,7 +200,7 @@ Base checked exception for utility methods.
 Identity id = Identity.generateRandomIdentity();
 NIP01 nip01 = new NIP01(id).createTextNoteEvent("Hello Nostr");
 NostrIF client = NostrSpringWebSocketClient.getInstance(id)
-        .setRelays(Map.of("damus","wss://relay.398ja.xyz"));
+        .setRelays(Map.of("398ja","wss://relay.398ja.xyz"));
 client.sendEvent(nip01.getEvent());
 ```
 


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Related issue: #____

## What changed?
- Renamed the relay alias from `damus` to `398ja` across the migration guide, API reference, and how-to guides to keep the documentation consistent.
- Updated the architecture explanation examples to reference the 398ja relay URI.

## BREAKING
None.

## Review focus
Please verify that the relay naming is now consistent across the updated documentation snippets.

## Testing
- `mvn -q verify`
```
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] Non-resolvable import POM: The following artifacts could not be resolved: xyz.tcheeric:nostr-java-bom:pom:1.1.1 (absent): Could not find artifact xyz.tcheeric:nostr-java-bom:pom:1.1.1 in central (https://repo.maven.apache.org/maven2) @ line 100, column 25
 @
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project xyz.tcheeric:nostr-java:1.0.1-SNAPSHOT (/workspace/nostr-java/pom.xml) has 1 error
[ERROR]     Non-resolvable import POM: The following artifacts could not be resolved: xyz.tcheeric:nostr-java-bom:pom:1.1.1 (absent): Could not find artifact xyz.tcheeric:nostr-java-bom:pom:1.1.1 in central (https://repo.maven.apache.org/maven2) @ line 100, column 25 -> [Help 2]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```

## Limitations
- `mvn -q verify` fails because `xyz.tcheeric:nostr-java-bom:pom:1.1.1` is not available from Maven Central.

## Network Access
- Maven Central (`https://repo.maven.apache.org/maven2`) responded but returned an artifact-not-found error. No domains were blocked.

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)


------
https://chatgpt.com/codex/tasks/task_b_68eb7c69dcec833195db38e7e65918f0