### PR TITLE
fix: restore sender overrides in NIP-01 builder

### DIFF
--- a/nostr-java-api/src/main/java/nostr/api/nip01/NIP01EventBuilder.java
+++ b/nostr-java-api/src/main/java/nostr/api/nip01/NIP01EventBuilder.java
@@ -27,24 +27,39 @@ public final class NIP01EventBuilder {
   }
 
   public GenericEvent buildTextNote(String content) {
-    return new GenericEventFactory(resolveSender(null), Kind.TEXT_NOTE.getValue(), content)
+    return buildTextNote(null, content);
+  }
+
+  public GenericEvent buildTextNote(Identity sender, String content) {
+    return new GenericEventFactory(resolveSender(sender), Kind.TEXT_NOTE.getValue(), content)
         .create();
   }
 
-  // Removed deprecated Identity-accepting overloads; use instance-configured sender
-
   public GenericEvent buildRecipientTextNote(String content, List<PubKeyTag> tags) {
-    return new GenericEventFactory<PubKeyTag>(resolveSender(null), Kind.TEXT_NOTE.getValue(), tags, content)
+    return buildRecipientTextNote(null, content, tags);
+  }
+
+  public GenericEvent buildRecipientTextNote(
+      Identity sender, String content, List<PubKeyTag> tags) {
+    return new GenericEventFactory<PubKeyTag>(
+            resolveSender(sender), Kind.TEXT_NOTE.getValue(), tags, content)
         .create();
   }
 
   public GenericEvent buildTaggedTextNote(@NonNull List<BaseTag> tags, @NonNull String content) {
-    return new GenericEventFactory<BaseTag>(resolveSender(null), Kind.TEXT_NOTE.getValue(), tags, content)
+    return buildTaggedTextNote(null, tags, content);
+  }
+
+  public GenericEvent buildTaggedTextNote(
+      Identity sender, @NonNull List<BaseTag> tags, @NonNull String content) {
+    return new GenericEventFactory<BaseTag>(
+            resolveSender(sender), Kind.TEXT_NOTE.getValue(), tags, content)
         .create();
   }
 
   public GenericEvent buildMetadataEvent(@NonNull Identity sender, @NonNull String payload) {
-    return new GenericEventFactory(sender, Kind.SET_METADATA.getValue(), payload).create();
+    return new GenericEventFactory(resolveSender(sender), Kind.SET_METADATA.getValue(), payload)
+        .create();
   }
 
   public GenericEvent buildMetadataEvent(@NonNull String payload) {
@@ -56,28 +71,60 @@ public final class NIP01EventBuilder {
   }
 
   public GenericEvent buildReplaceableEvent(Integer kind, String content) {
-    return new GenericEventFactory(resolveSender(null), kind, content).create();
+    return buildReplaceableEvent(null, kind, content);
   }
 
-  public GenericEvent buildReplaceableEvent(List<BaseTag> tags, Integer kind, String content) {
-    return new GenericEventFactory<BaseTag>(resolveSender(null), kind, tags, content).create();
+  public GenericEvent buildReplaceableEvent(
+      Identity sender, Integer kind, String content) {
+    return new GenericEventFactory(resolveSender(sender), kind, content).create();
+  }
+
+  public GenericEvent buildReplaceableEvent(
+      List<BaseTag> tags, Integer kind, String content) {
+    return buildReplaceableEvent(null, tags, kind, content);
+  }
+
+  public GenericEvent buildReplaceableEvent(
+      Identity sender, List<BaseTag> tags, Integer kind, String content) {
+    return new GenericEventFactory<BaseTag>(resolveSender(sender), kind, tags, content).create();
   }
 
   public GenericEvent buildEphemeralEvent(List<BaseTag> tags, Integer kind, String content) {
-    return new GenericEventFactory<BaseTag>(resolveSender(null), kind, tags, content).create();
+    return buildEphemeralEvent(null, tags, kind, content);
+  }
+
+  public GenericEvent buildEphemeralEvent(
+      Identity sender, List<BaseTag> tags, Integer kind, String content) {
+    return new GenericEventFactory<BaseTag>(resolveSender(sender), kind, tags, content).create();
   }
 
   public GenericEvent buildEphemeralEvent(Integer kind, String content) {
-    return new GenericEventFactory(resolveSender(null), kind, content).create();
+    return buildEphemeralEvent(null, kind, content);
+  }
+
+  public GenericEvent buildEphemeralEvent(Identity sender, Integer kind, String content) {
+    return new GenericEventFactory(resolveSender(sender), kind, content).create();
   }
 
   public GenericEvent buildAddressableEvent(Integer kind, String content) {
-    return new GenericEventFactory(resolveSender(null), kind, content).create();
+    return buildAddressableEvent(null, kind, content);
+  }
+
+  public GenericEvent buildAddressableEvent(
+      Identity sender, Integer kind, String content) {
+    return new GenericEventFactory(resolveSender(sender), kind, content).create();
   }
 
   public GenericEvent buildAddressableEvent(
       @NonNull List<GenericTag> tags, @NonNull Integer kind, String content) {
-    return new GenericEventFactory<GenericTag>(resolveSender(null), kind, tags, content).create();
+    return buildAddressableEvent(null, tags, kind, content);
+  }
+
+  public GenericEvent buildAddressableEvent(
+      Identity sender, @NonNull List<GenericTag> tags, @NonNull Integer kind, String content) {
+    return new GenericEventFactory<GenericTag>(
+            resolveSender(sender), kind, tags, content)
+        .create();
   }
 
   private Identity resolveSender(Identity override) {

--- a/nostr-java-api/src/test/java/nostr/api/unit/NIP01EventBuilderTest.java
+++ b/nostr-java-api/src/test/java/nostr/api/unit/NIP01EventBuilderTest.java
@@ -1,0 +1,35 @@
+package nostr.api.unit;
+
+import nostr.api.nip01.NIP01EventBuilder;
+import nostr.base.PrivateKey;
+import nostr.event.impl.GenericEvent;
+import nostr.id.Identity;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NIP01EventBuilderTest {
+
+  // Ensures that an explicitly provided sender overrides the default identity.
+  @Test
+  void buildTextNoteUsesOverrideIdentity() {
+    Identity defaultSender = Identity.create(PrivateKey.generateRandomPrivKey());
+    Identity overrideSender = Identity.create(PrivateKey.generateRandomPrivKey());
+    NIP01EventBuilder builder = new NIP01EventBuilder(defaultSender);
+
+    GenericEvent event = builder.buildTextNote(overrideSender, "override");
+
+    assertEquals(overrideSender.getPublicKey(), event.getPubKey());
+  }
+
+  // Ensures that the builder falls back to the configured sender when no override is supplied.
+  @Test
+  void buildTextNoteUsesDefaultIdentityWhenOverrideMissing() {
+    Identity defaultSender = Identity.create(PrivateKey.generateRandomPrivKey());
+    NIP01EventBuilder builder = new NIP01EventBuilder(defaultSender);
+
+    GenericEvent event = builder.buildTextNote("fallback");
+
+    assertEquals(defaultSender.getPublicKey(), event.getPubKey());
+  }
+}


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->
Related issue: #____

Restored the ability for `NIP01EventBuilder` to accept per-call senders so the builder can satisfy callers that need to override the default identity, addressing the review feedback.

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
- Reintroduced sender-aware overloads for all event builder helpers while keeping the default-sender convenience methods.
- Added a focused unit test suite for `NIP01EventBuilder` covering override and fallback behavior.

### Testing
```
$ mvn -q verify
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] Non-resolvable import POM: The following artifacts could not be resolved: xyz.tcheeric:nostr-java-bom:pom:1.1.8 (absent): Could not find artifact xyz.tcheeric:nostr-java-bom:pom:1.1.8 in central (https://repo.maven.apache.org/maven2) @ line 99, column 25
 @
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project xyz.tcheeric:nostr-java:1.0.0 (/workspace/nostr-java/pom.xml) has 1 error
[ERROR]     Non-resolvable import POM: The following artifacts could not be resolved: xyz.tcheeric:nostr-java-bom:pom:1.1.8 (absent): Could not find artifact xyz.tcheeric:nostr-java-bom:pom:1.1.8 in central (https://repo.maven.apache.org/maven2) @ line 99, column 25 -> [Help 2]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```

## BREAKING
<!-- If applicable, call it out explicitly. -->
<!-- ⚠️ BREAKING: Describe migration or impact. -->
None.

## Review focus
<!-- Ask for specific feedback, e.g., "Concurrency strategy OK?" or "API shape acceptable?" -->
Please double-check that the overload placement and generics preserve backward compatibility and align with desired API surface.

## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)

## Network Access
No blocked domains encountered during this work.


------
https://chatgpt.com/codex/tasks/task_b_68ed9352511883319e4b975b168abe18