### PR TITLE
Add Sonatype Central publishing credentials and refactor event handling

### DIFF
--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -29,6 +29,14 @@
       </repositories>
     </profile>
   </profiles>
+  <servers>
+    <!-- Sonatype Central Publishing credentials injected from env vars -->
+    <server>
+      <id>central</id>
+      <username>${env.CENTRAL_USERNAME}</username>
+      <password>${env.CENTRAL_PASSWORD}</password>
+    </server>
+  </servers>
   <activeProfiles>
     <activeProfile>nostr-java-repos</activeProfile>
   </activeProfiles>


### PR DESCRIPTION
## Summary
Introduce secure credentials for Sonatype Central publishing and perform cleanup on NIP01 event handling APIs. This includes improvements in default sender identity handling and a simplification of event builders.

Related issue: #____

## What changed?
- **Sonatype Central Credentials**: Added configuration for Sonatype Central server credentials using environment variables (`CENTRAL_USERNAME` and `CENTRAL_PASSWORD`).
- **CI Maven Update**: Updated CI configuration to use a custom Maven settings file for consistent builds.
- **Default Sender Handling**: Updated the NIP01 event builder to synchronize default sender identity when no override is provided.
- **API Simplification**: Removed `sender` parameter from event building methods to reduce redundancy and simplify usage.
- **Documentation Updates**: Adjusted documentation and made necessary changes for these updates.

## BREAKING
⚠️ BREAKING:
- `sender` parameter is removed from several event-building methods.
  - Migration: Remove `sender` argument from calls to `buildTextNote`, `buildReplaceableEvent`, `buildEphemeralEvent`, and `buildAddressableEvent`.
- Configuration required for publishing to Sonatype Central (Environment variables must be set).

## Review focus
- Confirm secure handling and setup of Sonatype Central credentials.
- Validate simplicity and intuitiveness of the updated event-building API.
- Check for overall consistency in the CI settings updates.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [ ] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)