### PR TITLE
Update Maven configuration for central publishing

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -133,7 +133,12 @@ cmd_publish() {
   $no_docker && mvn_args=(-q -DnoDocker=true -P "$profile" deploy)
   $skip_tests && mvn_args=(-q -DskipTests -P "$profile" deploy)
   if $no_docker && $skip_tests; then mvn_args=(-q -DskipTests -DnoDocker=true -P "$profile" deploy); fi
-  run_cmd mvn $MVN_SETTINGS_OPTS "${mvn_args[@]}"
+  # For Central publishing, prefer the settings provided by actions/setup-java (no -s override)
+  if [[ "$profile" == "release-central" ]]; then
+    run_cmd mvn "${mvn_args[@]}"
+  else
+    run_cmd mvn $MVN_SETTINGS_OPTS "${mvn_args[@]}"
+  fi
 }
 
 cmd_next_snapshot() {


### PR DESCRIPTION
## Summary
<!-- Explain the problem, context, and why this change is needed. Link to the issue. -->

Prepared Maven configuration for publishing artifacts to Sonatype Central. Added environment-based credentials, adjusted commands for consistency, and ensured proper repository settings are utilized.

## What changed?
<!-- Brief summary; suggest where to start reviewing if many files. -->
- Updated Maven release scripts to avoid overriding default configurations (`-s` option removed).
- Introduced Sonatype Central server credentials (`CENTRAL_USERNAME`, `CENTRAL_PASSWORD`) for secure deployments via environment variables.
- CI updates to ensure custom Maven settings file is being used during builds.

## BREAKING
⚠️ BREAKING: Publishing to Sonatype Central requires `CENTRAL_USERNAME` and `CENTRAL_PASSWORD` environment variables to be set.

## Review focus
- Verify Maven command compatibility with CI updates.
- Confirm proper environment variable handling for credentials.

## Checklist
- [ ] Scope ≤ 300 lines (or split/stack)
- [ ] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [ ] Description links the issue and answers “why now?”
- [x] **BREAKING** flagged if needed
- [ ] Tests/docs updated (if relevant)