### PR TITLE
fix: nip-44 incompatibility with other clients

### DIFF
--- a/nostr-java-encryption/src/main/java/nostr/encryption/MessageCipher44.java
+++ b/nostr-java-encryption/src/main/java/nostr/encryption/MessageCipher44.java
@@ -6,6 +6,7 @@ import lombok.NonNull;
 import nostr.crypto.nip44.EncryptedPayloads;
 import nostr.util.NostrUtil;
 
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 
@@ -43,7 +44,7 @@ public class MessageCipher44 implements MessageCipher {
     try {
       return EncryptedPayloads.getConversationKey(
           NostrUtil.bytesToHex(senderPrivateKey), "02" + NostrUtil.bytesToHex(recipientPublicKey));
-    } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+    } catch (NoSuchAlgorithmException | InvalidKeySpecException | InvalidKeyException e) {
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
## Summary
Previous implementation doesn't work correctly. Tested e.g. with Amethyst and nak.
The kind 4 messages encrypted with nip44 could not be decrypted.

## What changed?
Replaced the current implementation with partially ported / refactored [reference kotlin](https://github.com/paulmillr/nip44/tree/main/kotlin) implementation.

## BREAKING
Messages with previous implementation cannot be decrypted.

## Review focus


## Checklist
- [x] Scope ≤ 300 lines (or split/stack)
- [x] Title is **verb + object** (e.g., “Refactor auth middleware to async”)
- [x] Description links the issue and answers “why now?”
- [x] **BREAKING** flagged if needed
- [x] Tests/docs updated (if relevant)
