### PR TITLE
fix(ws): null-safe relay URI logging + 2.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is inspired by Keep a Changelog, and this project adheres to semantic
 - `BaseKey` now directly implements `Serializable` (previously implemented the now-deleted `IKey` interface).
 - `Nip05Validator` now creates `HttpClient` instances directly via a `Function<Duration, HttpClient>` factory (previously used deleted `HttpClientProvider`/`DefaultHttpClientProvider` interface).
 
+## [2.0.1] - 2026-05-06
+
+### Fixed
+- `NostrRelayClient` log statements were emitting `Sending request to relay null: ...` (and similar) once the WebSocket session had closed, because the relay URI was being read via `clientSession.getUri()` which returns `null` after close. Captured the URI in a `private final String relayUri` field set in each constructor and replaced 8 `clientSession.getUri()` log call-sites. Resolves 188 occurrences per 2-hour window observed in a downstream consumer's staging logs ([#523](https://github.com/tcheeric/nostr-java/pull/523)).
+
 ## [2.0.0] - 2026-02-24
 
 This is a major release that implements the full design simplification described in `docs/developer/SIMPLIFICATION_PROPOSAL.md`, reducing the library from 9 modules with ~180 classes to 4 modules with ~40 classes.

--- a/nostr-java-client/pom.xml
+++ b/nostr-java-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>nostr-java</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/nostr-java-client/src/main/java/nostr/client/springwebsocket/NostrRelayClient.java
+++ b/nostr-java-client/src/main/java/nostr/client/springwebsocket/NostrRelayClient.java
@@ -72,6 +72,13 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
   private int maxEventsPerRequest = DEFAULT_MAX_EVENTS_PER_REQUEST;
 
   private final WebSocketSession clientSession;
+  /**
+   * Relay URI captured at construction time. Used for logging so that
+   * messages remain meaningful even after the underlying WebSocket session
+   * has been closed (at which point {@link WebSocketSession#getUri()} may
+   * return {@code null} on some implementations).
+   */
+  private final String relayUri;
   private final ReentrantLock sendLock = new ReentrantLock();
   private PendingRequest pendingRequest;
   private final Map<String, ListenerRegistration> listeners = new ConcurrentHashMap<>();
@@ -119,6 +126,7 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
 
   public NostrRelayClient(@Value("${nostr.relay.uri}") String relayUri)
       throws java.util.concurrent.ExecutionException, InterruptedException {
+    this.relayUri = relayUri;
     this.clientSession = connectSession(relayUri);
     connectionState.set(ConnectionState.CONNECTED);
   }
@@ -129,6 +137,7 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
       throw new IllegalArgumentException("awaitTimeoutMs must be positive");
     }
     this.awaitTimeoutMs = awaitTimeoutMs;
+    this.relayUri = relayUri;
     log.info("NostrRelayClient created for {} with awaitTimeoutMs={}", relayUri, awaitTimeoutMs);
     this.clientSession = connectSession(relayUri);
     connectionState.set(ConnectionState.CONNECTED);
@@ -143,6 +152,14 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
     }
     this.clientSession = clientSession;
     this.awaitTimeoutMs = awaitTimeoutMs;
+    URI sessionUri = null;
+    try {
+      sessionUri = clientSession.getUri();
+    } catch (Exception ignored) {
+      // Some WebSocketSession implementations may throw before the session
+      // is fully initialised; fall through and store null.
+    }
+    this.relayUri = sessionUri == null ? null : sessionUri.toString();
     connectionState.set(ConnectionState.CONNECTED);
   }
 
@@ -253,7 +270,7 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
   public <T extends BaseMessage> List<String> send(T eventMessage) throws IOException {
     String json = eventMessage.encode();
     log.debug("Sending {} to relay {} (size={} bytes)",
-        eventMessage.getCommand(), clientSession.getUri(), json.length());
+        eventMessage.getCommand(), relayUri, json.length());
     return send(json);
   }
 
@@ -269,7 +286,7 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
       }
       request = new PendingRequest(maxEventsPerRequest);
       pendingRequest = request;
-      log.info("Sending request to relay {}: {}", clientSession.getUri(), json);
+      log.info("Sending request to relay {}: {}", relayUri, json);
       clientSession.sendMessage(new TextMessage(json));
     } finally {
       sendLock.unlock();
@@ -280,7 +297,7 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
 
     try {
       List<String> result = request.getFuture().get(timeout, TimeUnit.MILLISECONDS);
-      log.info("Received {} relay events via {}", result.size(), clientSession.getUri());
+      log.info("Received {} relay events via {}", result.size(), relayUri);
       return result;
     } catch (TimeoutException e) {
       log.error("Timed out waiting for relay response after {}ms", timeout);
@@ -350,7 +367,7 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
       throws IOException {
     String json = requestMessage.encode();
     log.debug("Subscribing with {} on relay {} (size={} bytes)",
-        requestMessage.getCommand(), clientSession.getUri(), json.length());
+        requestMessage.getCommand(), relayUri, json.length());
     return subscribe(json, messageListener, errorListener, closeListener);
   }
 
@@ -425,7 +442,7 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
   @Recover
   public List<String> recover(IOException ex, String json) throws IOException {
     log.error("Failed to send message to relay {} after retries (size={} bytes)",
-        clientSession.getUri(), json.length(), ex);
+        relayUri, json.length(), ex);
     throw ex;
   }
 
@@ -433,7 +450,7 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
   public List<String> recover(IOException ex, BaseMessage eventMessage) throws IOException {
     String json = eventMessage.encode();
     log.error("Failed to send {} to relay {} after retries (size={} bytes)",
-        eventMessage.getCommand(), clientSession.getUri(), json.length(), ex);
+        eventMessage.getCommand(), relayUri, json.length(), ex);
     throw ex;
   }
 
@@ -446,7 +463,7 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
       Runnable closeListener)
       throws IOException {
     log.error("Failed to subscribe on relay {} after retries (size={} bytes)",
-        clientSession.getUri(), json.length(), ex);
+        relayUri, json.length(), ex);
     throw ex;
   }
 
@@ -460,7 +477,7 @@ public class NostrRelayClient extends TextWebSocketHandler implements AutoClosea
       throws IOException {
     String json = requestMessage.encode();
     log.error("Failed to subscribe with {} on relay {} after retries (size={} bytes)",
-        requestMessage.getCommand(), clientSession.getUri(), json.length(), ex);
+        requestMessage.getCommand(), relayUri, json.length(), ex);
     throw ex;
   }
 

--- a/nostr-java-core/pom.xml
+++ b/nostr-java-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>nostr-java</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nostr-java-event/pom.xml
+++ b/nostr-java-event/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>nostr-java</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nostr-java-identity/pom.xml
+++ b/nostr-java-identity/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>xyz.tcheeric</groupId>
         <artifactId>nostr-java</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>xyz.tcheeric</groupId>
     <artifactId>nostr-java</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>pom</packaging>
 
     <name>nostr-java</name>


### PR DESCRIPTION
## Summary
- `NostrRelayClient` was logging `Sending request to relay null: …` (188 occurrences in a 2-hour window of staging logs) because the log statement read `clientSession.getUri()`, which returns `null` once the WebSocket session has closed.
- Fix: capture the URI in a `private final String relayUri` set in each constructor; replace 8 `clientSession.getUri()` log call-sites.
- Bump version 2.0.0 → 2.0.1.

## Background
Surfaced during investigation of staging incident `as_1e9d265bf1c24d04` (2026-05-05). Full analysis lives in the consumer repo at `imani-apps/docs/analysis-gateway-core-relay-client-circuitbreaker-2026-05-06.md`. The original §2 recommendation (singleton-per-relay refactor) turned out to be a no-op — the multiplexing is already in place. The §4 fix in this PR stands on its own merits.

## Test plan
- [x] `./mvnw -pl nostr-java-client test` — 13 tests pass locally.
- [ ] CI passes on this PR.
- [ ] Verify no `to relay null` log lines in staging after `imani-bom` bumps to 2.0.1 and downstream services redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)